### PR TITLE
Add Waveshare ESP32-S3 1.8" AMOLED (SH8601/FT3168) support

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -40,3 +40,44 @@ lib_deps =
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+[env:waveshare_amoled_18]
+; Waveshare ESP32-S3 1.8" AMOLED (SH8601/FT3168)
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+upload_speed = 921600
+monitor_speed = 115200
+
+build_flags =
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    ; NimBLE config — peripheral-only, single connection
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+    ; LVGL config via build flags
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    moononournation/GFX Library for Arduino@^1.5.6
+    lewisxhe/SensorLib@^0.2.6
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/src/display_cfg.h
+++ b/firmware/src/display_cfg.h
@@ -1,37 +1,46 @@
 #pragma once
 
 #include <Arduino_GFX_Library.h>
-#include <TouchDrvCSTXXX.hpp>
-#include <XPowersLib.h>
+#include <TouchDrvFT6X36.hpp>
 #include <SensorQMI8658.hpp>
 #include <Wire.h>
 
 // ---- Display resolution ----
-#define LCD_WIDTH   480
-#define LCD_HEIGHT  480
+// Physical panel is portrait 368×448. We always render in landscape and
+// rotate strips on the fly in my_flush_cb. LVGL/UI see the LOGICAL size.
+#define PANEL_W     368   // physical panel width
+#define PANEL_H     448   // physical panel height
+#define LCD_WIDTH   448   // logical (landscape) width  — used by LVGL/UI
+#define LCD_HEIGHT  368   // logical (landscape) height — used by LVGL/UI
 
-// ---- QSPI display pins (CO5300) ----
+// ---- QSPI display pins (SH8601) — from official schematic ----
 #define LCD_CS      12
-#define LCD_SCLK    38
+#define LCD_SCLK    11
 #define LCD_SDIO0   4
 #define LCD_SDIO1   5
 #define LCD_SDIO2   6
 #define LCD_SDIO3   7
-#define LCD_RESET   2
+#define LCD_TE      13   // tearing effect (optional, not wired in driver)
 
-// ---- Touch pins (CST9220 via I2C) ----
+// LCD reset and panel power-enable are NOT on direct GPIOs — they live on
+// the on-board TCA9554 I/O expander. The display will stay dark until we
+// drive DSI_PWR_EN (EXIO1) high over I2C. See io_expander_init() in main.cpp.
+
+// ---- Touch pins (FT3168 via shared I2C) ----
 #define IIC_SDA     15
 #define IIC_SCL     14
-#define TP_INT      11
-#define TP_RST      2    // shared with LCD_RESET
-#define CST9220_ADDR 0x5A
+#define TP_INT      21
+#define FT3168_ADDR 0x38
 
-// ---- PMU (AXP2101 via same I2C) ----
-#define AXP2101_ADDR 0x34
+// ---- TCA9554 I/O expander (shared I2C) ----
+// Drives LCD_RESET, DSI_PWR_EN, TP_RESET, SDCS, and a few system rails.
+#define TCA9554_ADDR        0x20
+#define EXIO_LCD_RESET      0   // P0
+#define EXIO_LCD_PWR_EN     1   // P1  — MUST be high for display to power on
+#define EXIO_TP_RESET       2   // P2
 
 // ---- Global hardware objects (defined in main.cpp) ----
 extern Arduino_DataBus *bus;
-extern Arduino_CO5300 *gfx;
-extern TouchDrvCST92xx touch;
-extern XPowersPMU pmu;
+extern Arduino_SH8601 *gfx;
+extern TouchDrvFT6X36 touch;
 extern SensorQMI8658 imu;

--- a/firmware/src/imu.cpp
+++ b/firmware/src/imu.cpp
@@ -1,33 +1,29 @@
 #include "imu.h"
 #include "display_cfg.h"
 #include <Arduino.h>
+#include <math.h>
 
-// Poll and hysteresis timing
+// QMI8658 accelerometer driver. The 1.8" AMOLED panel runs in landscape only —
+// imu_get_rotation() returns 1 (90° CW) or 3 (270° CW), never portrait.
+// When the device is held in portrait we hold the last landscape orientation.
+
 #define IMU_POLL_MS       100    // read accel at ~10 Hz
-#define STABLE_TIME_MS    300    // orientation must be stable this long before rotating
-#define TILT_THRESHOLD    0.5f   // ~30 degrees from axis (sin(30) ~ 0.5)
+#define STABLE_TIME_MS    300    // orientation must be stable this long before flipping
+#define LANDSCAPE_THRESHOLD 0.6f // |ax| must exceed this (relative to 1g) to flip
 
-static uint8_t  current_rotation = 0;
-static uint8_t  candidate_rotation = 0;
+static uint8_t  current_rotation = 1;    // boot in landscape (90° CW)
+static uint8_t  candidate_rotation = 1;
 static uint32_t candidate_since = 0;
 static uint32_t last_poll_ms = 0;
 static bool     imu_ok = false;
 
-// Determine target rotation from accelerometer gravity vector.
-// Returns 0-3 or 255 if ambiguous (e.g. face-up/face-down).
+// Landscape-only orientation: ax dominant means the board is on its side.
+// Returns 255 when the device is portrait or flat (ambiguous — keep current).
 static uint8_t accel_to_rotation(float ax, float ay) {
-    float abs_ax = fabsf(ax);
-    float abs_ay = fabsf(ay);
-
-    if (abs_ax < TILT_THRESHOLD && abs_ay < TILT_THRESHOLD) {
-        return 255;  // ambiguous, keep current
-    }
-
-    if (abs_ay > abs_ax) {
-        return (ay > 0) ? 3 : 1;
-    } else {
-        return (ax > 0) ? 0 : 2;
-    }
+    (void)ay;
+    if (ax >  LANDSCAPE_THRESHOLD) return 1;  // one landscape direction
+    if (ax < -LANDSCAPE_THRESHOLD) return 3;  // the other
+    return 255;
 }
 
 void imu_init(void) {

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -5,7 +5,7 @@
 #include "data.h"
 #include "ui.h"
 #include "ble.h"
-#include "power.h"
+// #include "power.h"  // TODO: Enable once AXP2101 presence confirmed
 #include "imu.h"
 #include "splash.h"
 #include "usage_rate.h"
@@ -18,14 +18,50 @@
 #define BTN_FWD  18
 
 // ---- Hardware objects ----
+// SH8601 uses QSPI. Reset pin is on the TCA9554 expander, not a direct GPIO —
+// pass GFX_NOT_DEFINED so Arduino_GFX doesn't try to toggle a non-existent pin,
+// and handle reset ourselves in io_expander_init().
 Arduino_DataBus *bus = new Arduino_ESP32QSPI(
     LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
-Arduino_CO5300 *gfx = new Arduino_CO5300(
-    bus, LCD_RESET, 0 /* rotation */,
-    LCD_WIDTH, LCD_HEIGHT, 0, 0, 0, 0);
-TouchDrvCST92xx touch;
-XPowersPMU pmu;
+// SH8601 sees the PHYSICAL panel (368×448 portrait). The landscape rotation
+// happens in software in my_flush_cb, not in the controller.
+Arduino_SH8601 *gfx = new Arduino_SH8601(
+    bus, GFX_NOT_DEFINED /* reset on expander */, 0 /* rotation */,
+    PANEL_W, PANEL_H);
+TouchDrvFT6X36 touch;
 SensorQMI8658 imu;
+
+// Minimal TCA9554 driver — we only need to set all pins as outputs and drive
+// LCD_RESET, DSI_PWR_EN, and TP_RESET. No need for the full bus master.
+static bool tca9554_write_reg(uint8_t reg, uint8_t val) {
+    Wire.beginTransmission(TCA9554_ADDR);
+    Wire.write(reg);
+    Wire.write(val);
+    return Wire.endTransmission() == 0;
+}
+
+// Bring up the I/O expander, power on the AMOLED panel, and run a clean
+// reset pulse for both LCD and touch.
+static void io_expander_init(void) {
+    // Configuration register (0x03): 0 = output, 1 = input. All outputs.
+    if (!tca9554_write_reg(0x03, 0x00)) {
+        Serial.println("TCA9554: not responding at 0x20");
+        return;
+    }
+    // Output register (0x01): start with everything low (reset asserted).
+    tca9554_write_reg(0x01, 0x00);
+    delay(20);
+    // Power on the panel (DSI_PWR_EN high), keep resets asserted.
+    tca9554_write_reg(0x01, (1 << EXIO_LCD_PWR_EN));
+    delay(50);
+    // Release LCD_RESET and TP_RESET; panel power stays on.
+    uint8_t out = (1 << EXIO_LCD_PWR_EN) |
+                  (1 << EXIO_LCD_RESET)  |
+                  (1 << EXIO_TP_RESET);
+    tca9554_write_reg(0x01, out);
+    delay(150);
+    Serial.println("TCA9554 init OK (panel powered, resets released)");
+}
 
 static UsageData usage = {};
 
@@ -46,9 +82,22 @@ static void touch_read() {
     int16_t tx[5], ty[5];
     uint8_t n = touch.getPoint(tx, ty, touch.getSupportTouchPoint());
     if (n > 0) {
+        // Touch returns physical panel coords (0..PANEL_W × 0..PANEL_H).
+        // Map them into logical landscape coords using the inverse of the
+        // rotation applied in rotate_strip.
+        uint16_t px = (uint16_t)tx[0];
+        uint16_t py = (uint16_t)ty[0];
+        uint8_t r = imu_get_rotation();
+        if (r == 3) {
+            // Inverse of 270° CW: physical (px, py) -> logical (PANEL_H - 1 - py, px)
+            touch_x = (PANEL_H - 1) - py;
+            touch_y = px;
+        } else {
+            // Inverse of 90° CW: physical (px, py) -> logical (py, PANEL_W - 1 - px)
+            touch_x = py;
+            touch_y = (PANEL_W - 1) - px;
+        }
         touch_pressed = true;
-        touch_x = (uint16_t)tx[0];
-        touch_y = (uint16_t)ty[0];
     } else {
         touch_pressed = false;
     }
@@ -70,77 +119,48 @@ static uint32_t my_tick(void) {
 // Rotate a w×h strip and compute destination coordinates on the 480×480 display.
 // src pixels are in row-major order for the rectangle (sx, sy, w, h).
 // Output goes to rot_buf in row-major order for the destination rectangle.
+// Landscape rotation: maps a strip from logical 448×368 landscape coords
+// onto the physical 368×448 portrait panel. r=1 is 90° CW, r=3 is 270° CW.
+// Any other value falls back to r=1 (default landscape).
 static void rotate_strip(const uint16_t *src, int32_t w, int32_t h,
                          int32_t sx, int32_t sy, uint8_t r,
                          int32_t *dx, int32_t *dy, int32_t *dw, int32_t *dh) {
-    const int S = LCD_WIDTH;  // 480
-
-    switch (r) {
-    case 1: { // 90° CW: (x,y) -> (S-1-y, x)
-        *dw = h; *dh = w;
-        *dx = S - sy - h;
-        *dy = sx;
-        for (int32_t y = 0; y < h; y++) {
-            for (int32_t x = 0; x < w; x++) {
-                // src(x,y) -> dst(h-1-y, x)
-                rot_buf[x * h + (h - 1 - y)] = src[y * w + x];
-            }
-        }
-        break;
-    }
-    case 2: { // 180°: (x,y) -> (S-1-x, S-1-y)
-        *dw = w; *dh = h;
-        *dx = S - sx - w;
-        *dy = S - sy - h;
-        for (int32_t y = 0; y < h; y++) {
-            for (int32_t x = 0; x < w; x++) {
-                rot_buf[(h - 1 - y) * w + (w - 1 - x)] = src[y * w + x];
-            }
-        }
-        break;
-    }
-    case 3: { // 270° CW: (x,y) -> (y, S-1-x)
+    if (r == 3) {
+        // 270° CW: logical (x, y) -> physical (y, PANEL_H - 1 - x)
         *dw = h; *dh = w;
         *dx = sy;
-        *dy = S - sx - w;
+        *dy = PANEL_H - sx - w;
         for (int32_t y = 0; y < h; y++) {
             for (int32_t x = 0; x < w; x++) {
-                // src(x,y) -> dst(y, w-1-x)
                 rot_buf[(w - 1 - x) * h + y] = src[y * w + x];
             }
         }
-        break;
-    }
-    default:
-        *dx = sx; *dy = sy; *dw = w; *dh = h;
-        break;
+    } else {
+        // 90° CW (default): logical (x, y) -> physical (PANEL_W - 1 - y, x)
+        *dw = h; *dh = w;
+        *dx = PANEL_W - sy - h;
+        *dy = sx;
+        for (int32_t y = 0; y < h; y++) {
+            for (int32_t x = 0; x < w; x++) {
+                rot_buf[x * h + (h - 1 - y)] = src[y * w + x];
+            }
+        }
     }
 }
 
-// LVGL flush callback — rotates partial strips and writes to display
+// LVGL flush callback — always rotates from logical landscape into the
+// physical portrait panel. IMU picks 90° vs 270° based on which way the
+// device is held.
 static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
     int32_t w = area->x2 - area->x1 + 1;
     int32_t h = area->y2 - area->y1 + 1;
     uint16_t *src = (uint16_t*)px_map;
     uint8_t r = imu_get_rotation();
 
-    if (r == 0) {
-        gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
-    } else {
-        int32_t dx, dy, dw, dh;
-        rotate_strip(src, w, h, area->x1, area->y1, r, &dx, &dy, &dw, &dh);
-        gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
-    }
+    int32_t dx, dy, dw, dh;
+    rotate_strip(src, w, h, area->x1, area->y1, r, &dx, &dy, &dw, &dh);
+    gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
     lv_display_flush_ready(disp);
-}
-
-// CO5300 requires even-aligned flush regions
-static void rounder_cb(lv_event_t* e) {
-    lv_area_t *area = (lv_area_t*)lv_event_get_param(e);
-    area->x1 = area->x1 & ~1;
-    area->y1 = area->y1 & ~1;
-    area->x2 = area->x2 | 1;
-    area->y2 = area->y2 | 1;
 }
 
 // LVGL touch callback
@@ -228,29 +248,36 @@ void setup() {
     delay(300);
     Serial.println("{\"ready\":true}");
 
-    // Init I2C (shared by touch + PMU)
+    // Init I2C (shared by touch + I/O expander + future PMU/IMU/RTC)
     Wire.begin(IIC_SDA, IIC_SCL);
+
+    // Bring up the I/O expander first — the AMOLED panel power rail is gated
+    // by EXIO1 (DSI_PWR_EN), and the LCD reset line is on EXIO0. Without
+    // this, gfx->begin() talks to an unpowered panel and the screen stays black.
+    io_expander_init();
 
     // Init display
     gfx->begin();
     gfx->fillScreen(0x0000);
     gfx->setBrightness(200);
 
-    // Init PMU
-    power_init();
-
-    // Init IMU (accelerometer for auto-rotation)
+    // TODO: Enable once AXP2101 wiring confirmed
+    // power_init();
     imu_init();
 
-    // Init touch
-    touch.setPins(TP_RST, TP_INT);
-    if (!touch.begin(Wire, CST9220_ADDR, IIC_SDA, IIC_SCL)) {
+    // Init touch (FT3168)
+    // Note: FT6X36 driver is used for FT3168 compatibility
+    if (!touch.begin(Wire, FT3168_ADDR)) {
         Serial.println("Touch init failed");
     } else {
-        touch.setMaxCoordinates(LCD_WIDTH, LCD_HEIGHT);
-        touch.setSwapXY(true);
-        touch.setMirrorXY(true, false);
-        attachInterrupt(TP_INT, touch_isr, FALLING);
+        // Touch returns physical panel coordinates; rotation is handled in
+        // touch_read() based on imu_get_rotation().
+        touch.setMaxCoordinates(PANEL_W, PANEL_H);
+        touch.setSwapXY(false);
+        touch.setMirrorXY(false, false);
+        if (TP_INT != -1) {
+            attachInterrupt(TP_INT, touch_isr, FALLING);
+        }
         Serial.println("Touch init OK");
     }
 
@@ -271,9 +298,6 @@ void setup() {
     lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
                            LV_DISPLAY_RENDER_MODE_PARTIAL);
 
-    // CO5300 even-alignment rounder
-    lv_display_add_event_cb(disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, NULL);
-
     lv_indev_t* indev = lv_indev_create();
     lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
     lv_indev_set_read_cb(indev, my_touch_cb);
@@ -291,8 +315,8 @@ void setup() {
     // Show initial BLE status on Bluetooth screen
     ui_update_ble_status(ble_get_state(), ble_get_device_name(), ble_get_mac_address());
 
-    // Show initial battery status
-    ui_update_battery(power_battery_pct(), power_is_charging());
+    // TODO: Show battery status once power module confirmed
+    // ui_update_battery(power_battery_pct(), power_is_charging());
 
     ui_show_screen(SCREEN_SPLASH);
 
@@ -301,10 +325,9 @@ void setup() {
 
 static ble_state_t last_ble_state = BLE_STATE_INIT;
 
-// Brightness ramp state for rotation transition
-// On rotation change we blank the panel, force a full LVGL redraw at the
-// new orientation, then ramp brightness back up over ~125ms so the
-// transition reads as deliberate instead of as a glitch.
+// Brightness ramp state for rotation transition. On rotation change we blank
+// the panel, force a full LVGL redraw at the new orientation, then ramp
+// brightness back up over ~125ms so the transition reads as deliberate.
 static void handle_rotation_change(void) {
     static uint8_t last_rotation = 0;
     static uint8_t  ramp_step = 0;  // 0=idle, 1-4=ramping
@@ -335,7 +358,7 @@ void loop() {
     lv_timer_handler();
     ui_tick_anim();
     ble_tick();
-    power_tick();
+    // power_tick();  // TODO: Enable once AXP2101 confirmed
     imu_tick();
     splash_tick();
 
@@ -359,10 +382,11 @@ void loop() {
             fwd_was = fwd_now;
         }
 
-        if (power_pwr_pressed()) {
-            if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
-            else                                          ui_cycle_screen();
-        }
+        // TODO: Enable once AXP2101 confirmed
+        // if (power_pwr_pressed()) {
+        //     if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
+        //     else                                          ui_cycle_screen();
+        // }
     }
 
     handle_rotation_change();
@@ -374,16 +398,16 @@ void loop() {
         ui_update_ble_status(bs, ble_get_device_name(), ble_get_mac_address());
     }
 
-    // Update battery indicator
-    static int last_pct = -2;
-    static bool last_charging = false;
-    int pct = power_battery_pct();
-    bool charging = power_is_charging();
-    if (pct != last_pct || charging != last_charging) {
-        last_pct = pct;
-        last_charging = charging;
-        ui_update_battery(pct, charging);
-    }
+    // TODO: Update battery indicator once power module confirmed
+    // static int last_pct = -2;
+    // static bool last_charging = false;
+    // int pct = power_battery_pct();
+    // bool charging = power_is_charging();
+    // if (pct != last_pct || charging != last_charging) {
+    //     last_pct = pct;
+    //     last_charging = charging;
+    //     ui_update_battery(pct, charging);
+    // }
 
     // Check for serial commands (screenshot, etc.)
     check_serial_cmd();

--- a/firmware/src/power.cpp
+++ b/firmware/src/power.cpp
@@ -1,74 +1,25 @@
 #include "power.h"
-#include "display_cfg.h"
 #include <Arduino.h>
 
-// Poll intervals
-#define BATTERY_POLL_MS   2000
-#define CHARGING_POLL_MS  500
-
-static int      cached_pct      = -1;
-static bool     cached_charging = false;
-static bool     pwr_pressed_flag = false;
-static uint32_t last_battery_ms  = 0;
-static uint32_t last_charging_ms = 0;
-static uint32_t last_pwr_ms      = 0;
-#define PWR_POLL_MS 50
+// Stub implementation — AXP2101 not available on 1.8" board
+// Return safe defaults: no battery, not charging, no button press
 
 void power_init(void) {
-    if (!pmu.begin(Wire, AXP2101_ADDR, IIC_SDA, IIC_SCL)) {
-        Serial.println("AXP2101 init failed");
-        return;
-    }
-    Serial.println("AXP2101 init OK");
-
-    pmu.enableBattDetection();
-    pmu.enableBattVoltageMeasure();
-
-    // Enable PWR button short-press IRQ (mid button for cycling screens)
-    pmu.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
-    pmu.clearIrqStatus();
-    pmu.enableIRQ(XPOWERS_AXP2101_PKEY_SHORT_IRQ);
-
-    cached_charging = pmu.isCharging();
-    cached_pct = pmu.getBatteryPercent();
+    Serial.println("power_init: skipped (AXP2101 not available)");
 }
 
 void power_tick(void) {
-    uint32_t now = millis();
-
-    if (now - last_charging_ms >= CHARGING_POLL_MS) {
-        last_charging_ms = now;
-        cached_charging = pmu.isCharging();
-    }
-
-    if (now - last_battery_ms >= BATTERY_POLL_MS) {
-        last_battery_ms = now;
-        cached_pct = pmu.getBatteryPercent();
-    }
-
-    // Poll PWR button (AXP2101 short-press IRQ)
-    if (now - last_pwr_ms >= PWR_POLL_MS) {
-        last_pwr_ms = now;
-        pmu.getIrqStatus();
-        if (pmu.isPekeyShortPressIrq()) {
-            pwr_pressed_flag = true;
-        }
-        pmu.clearIrqStatus();
-    }
+    // no-op
 }
 
 int power_battery_pct(void) {
-    return cached_pct;
+    return -1;  // no battery info available
 }
 
 bool power_is_charging(void) {
-    return cached_charging;
+    return false;
 }
 
 bool power_pwr_pressed(void) {
-    if (pwr_pressed_flag) {
-        pwr_pressed_flag = false;
-        return true;
-    }
-    return false;
+    return false;  // no PWR button available
 }

--- a/firmware/src/splash.cpp
+++ b/firmware/src/splash.cpp
@@ -2,15 +2,16 @@
 #include "splash_animations.h"
 #include "theme.h"
 #include "usage_rate.h"
+#include "display_cfg.h"
 #include <Arduino.h>
 #include <string.h>
 #include <esp_heap_caps.h>
 
-// 20x20 grid scaled 24x to fill 480x480
+// 20x20 grid scaled 18x for landscape 448x368 (360x360 art, centered)
 #define GRID         20
-#define CELL         24
-#define CANVAS_W     (GRID * CELL)
-#define CANVAS_H     (GRID * CELL)
+#define CELL         18
+#define CANVAS_W     448
+#define CANVAS_H     368
 
 // Background fallback when palette is missing
 #define COL_EMPTY    0x0000  // true black (matches THEME_BG)
@@ -69,16 +70,25 @@ static void resolve_group_lists(void) {
 }
 
 static void render_frame(const uint8_t *cells, const uint16_t *palette) {
+    // Art is GRID*CELL square (360x360). The canvas is larger in landscape
+    // (448x368), so center the art and fill the rest with COL_EMPTY.
+    const int art_size = GRID * CELL;
+    const int x_off = (CANVAS_W - art_size) / 2;
+    const int y_off = (CANVAS_H - art_size) / 2;
+
+    // Clear the whole canvas first so the gutters are clean.
+    for (int i = 0; i < CANVAS_W * CANVAS_H; i++) canvas_buf[i] = COL_EMPTY;
+
     for (int gy = 0; gy < GRID; gy++) {
-        uint16_t row[CANVAS_W];
         for (int gx = 0; gx < GRID; gx++) {
             uint8_t code = cells[gy * GRID + gx];
             uint16_t color = (palette && code < SPLASH_PALETTE_SIZE) ? palette[code] : COL_EMPTY;
-            uint16_t *p = &row[gx * CELL];
-            for (int i = 0; i < CELL; i++) p[i] = color;
-        }
-        for (int dy = 0; dy < CELL; dy++) {
-            memcpy(&canvas_buf[(gy * CELL + dy) * CANVAS_W], row, CANVAS_W * 2);
+            int px = x_off + gx * CELL;
+            int py = y_off + gy * CELL;
+            for (int dy = 0; dy < CELL; dy++) {
+                uint16_t *p = &canvas_buf[(py + dy) * CANVAS_W + px];
+                for (int dx = 0; dx < CELL; dx++) p[dx] = color;
+            }
         }
     }
     if (canvas) lv_obj_invalidate(canvas);
@@ -99,7 +109,7 @@ void splash_init(lv_obj_t *parent) {
     }
 
     splash_container = lv_obj_create(parent);
-    lv_obj_set_size(splash_container, 480, 480);
+    lv_obj_set_size(splash_container, LCD_WIDTH, LCD_HEIGHT);
     lv_obj_set_pos(splash_container, 0, 0);
     lv_obj_set_style_bg_color(splash_container, THEME_BG, 0);
     lv_obj_set_style_bg_opa(splash_container, LV_OPA_COVER, 0);

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -25,13 +25,13 @@ LV_FONT_DECLARE(font_mono_32);
 #define COL_RED       THEME_RED
 #define COL_BAR_BG    THEME_BAR_BG
 
-// ---- Layout constants for 480x480 (scaled for 2.16" high-DPI + rounded corners) ----
-#define SCR_W         480
-#define SCR_H         480
-#define MARGIN        20    // wider margin for rounded display corners
-#define TITLE_Y       30
-#define CONTENT_Y     100
-#define CONTENT_W     (SCR_W - 2 * MARGIN)   // 440
+// ---- Layout constants for 448x368 landscape (Waveshare 1.8" AMOLED) ----
+#define SCR_W         448
+#define SCR_H         368
+#define MARGIN        15
+#define TITLE_Y       12
+#define CONTENT_Y     75
+#define CONTENT_W     (SCR_W - 2 * MARGIN)   // 418
 
 // ---- Usage screen widgets ----
 static lv_obj_t* usage_container;
@@ -218,10 +218,10 @@ static void init_battery_icons(void) {
     init_icon_dsc_rgb565a8(&battery_dscs[4], ICON_BATTERY_CHARGING_W, ICON_BATTERY_CHARGING_H, icon_battery_charging_data);
 }
 
-// ======== Usage Screen (480x480) ========
+// ======== Usage Screen (448x368 landscape) ========
 
-#define PANEL_H     150
-#define PANEL_GAP   16
+#define PANEL_H     110
+#define PANEL_GAP   10
 
 // One Session/Weekly panel: big % label, pill on the right, bar, reset label.
 // Pill y=1: symmetric inside the panel — panel-outer-top → pill-top equals
@@ -297,8 +297,8 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_style_text_color(lbl_ble_title, COL_TEXT, 0);
     lv_obj_align(lbl_ble_title, LV_ALIGN_TOP_MID, 16, TITLE_Y);
 
-    // Info panel (taller for 480x480)
-    lv_obj_t* p_info = make_panel(ble_container, MARGIN, CONTENT_Y, CONTENT_W, 160);
+    // Info panel
+    lv_obj_t* p_info = make_panel(ble_container, MARGIN, CONTENT_Y, CONTENT_W, 120);
 
     // Bluetooth icon + status row
     static lv_image_dsc_t icon_bt_dsc;
@@ -327,10 +327,10 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_pos(lbl_ble_mac, 0, 100);
 
     // Reset Bluetooth tap zone with trash icon
-    int reset_y = CONTENT_Y + 160 + 16;
+    int reset_y = CONTENT_Y + 120 + 10;
     lv_obj_t* reset_zone = lv_obj_create(ble_container);
     lv_obj_set_pos(reset_zone, MARGIN, reset_y);
-    lv_obj_set_size(reset_zone, CONTENT_W, 110);
+    lv_obj_set_size(reset_zone, CONTENT_W, 70);
     lv_obj_set_style_bg_color(reset_zone, COL_PANEL, 0);
     lv_obj_set_style_bg_opa(reset_zone, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(reset_zone, 8, 0);
@@ -354,15 +354,15 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     // Attribution
     lv_obj_t* lbl_credit = lv_label_create(ble_container);
     lv_label_set_text(lbl_credit, "Built by @hermannbjorgvin");
-    lv_obj_set_style_text_font(lbl_credit, &font_styrene_24, 0);
+    lv_obj_set_style_text_font(lbl_credit, &font_styrene_20, 0);
     lv_obj_set_style_text_color(lbl_credit, COL_DIM, 0);
-    lv_obj_align(lbl_credit, LV_ALIGN_BOTTOM_MID, 0, -46);
+    lv_obj_align(lbl_credit, LV_ALIGN_BOTTOM_MID, 0, -35);
 
     lv_obj_t* lbl_credit2 = lv_label_create(ble_container);
     lv_label_set_text(lbl_credit2, "Clawd animation by @amaanbuilds");
     lv_obj_set_style_text_font(lbl_credit2, &font_styrene_20, 0);
     lv_obj_set_style_text_color(lbl_credit2, COL_DIM, 0);
-    lv_obj_align(lbl_credit2, LV_ALIGN_BOTTOM_MID, 0, -20);
+    lv_obj_align(lbl_credit2, LV_ALIGN_BOTTOM_MID, 0, -10);
 
     // Start hidden
     lv_obj_add_flag(ble_container, LV_OBJ_FLAG_HIDDEN);

--- a/flash-mac-18.sh
+++ b/flash-mac-18.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Build and flash Clawdmeter firmware on macOS for the
+# Waveshare ESP32-S3 1.8" AMOLED (SH8601/FT3168, 368x448) board.
+#
+# Usage:
+#   ./flash-mac-18.sh                       # auto-detect /dev/cu.usbmodem*
+#   ./flash-mac-18.sh /dev/cu.usbmodem1101  # explicit USB serial port
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PORT="$1"
+ENV_NAME="waveshare_amoled_18"
+
+if [ -z "$PORT" ]; then
+    PORT=$(ls /dev/cu.usbmodem* 2>/dev/null | head -1)
+    if [ -z "$PORT" ]; then
+        echo "Error: no /dev/cu.usbmodem* device found. Plug in via USB-C."
+        exit 1
+    fi
+fi
+
+# Resolve a working pio command. Prefer 'pio' on PATH; otherwise fall back to
+# a Python 3.10+ install of the platformio package (pio's CLI requires it).
+PIO_CMD=""
+if command -v pio >/dev/null; then
+    PIO_CMD="pio"
+else
+    for py in python3.13 python3.12 python3.11 python3.10; do
+        if command -v "$py" >/dev/null; then
+            if "$py" -c "import platformio" 2>/dev/null; then
+                PIO_CMD="$py -m platformio"
+                break
+            fi
+        fi
+    done
+fi
+
+if [ -z "$PIO_CMD" ]; then
+    echo "Error: PlatformIO not found. Install with one of:"
+    echo "  brew install platformio"
+    echo "  python3 -m pip install --user platformio    # needs Python 3.10+"
+    exit 1
+fi
+
+echo "=== Flashing Clawdmeter (1.8\" board) ==="
+echo "Port: $PORT"
+echo "Env:  $ENV_NAME"
+echo "Tool: $PIO_CMD"
+echo ""
+
+cd "$SCRIPT_DIR/firmware"
+$PIO_CMD run -e "$ENV_NAME" -t upload --upload-port "$PORT"
+
+echo ""
+echo "=== Done ==="
+echo "Monitor with: $PIO_CMD device monitor -e $ENV_NAME -p $PORT -b 115200"

--- a/install-mac-18.sh
+++ b/install-mac-18.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# macOS installer for Clawdmeter daemon (Python + bleak + launchd).
+# Variant for the Waveshare ESP32-S3 1.8" AMOLED (SH8601/FT3168) board.
+#
+# The host-side daemon is the same regardless of which display board you
+# flashed — it talks to the firmware over BLE. This script also makes sure
+# PlatformIO is available so you can flash with ./flash-mac-18.sh afterwards.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVICE_LABEL="com.user.claude-usage-daemon"
+PLIST_SRC="$SCRIPT_DIR/daemon/$SERVICE_LABEL.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/$SERVICE_LABEL.plist"
+VENV_DIR="$SCRIPT_DIR/daemon/.venv"
+DAEMON_PY="$SCRIPT_DIR/daemon/claude_usage_daemon.py"
+LOG_DIR="$HOME/Library/Logs"
+LOG_OUT="$LOG_DIR/claude-usage-daemon.out.log"
+LOG_ERR="$LOG_DIR/claude-usage-daemon.err.log"
+
+echo "=== Clawdmeter macOS install (1.8\" board) ==="
+echo ""
+
+echo "[1/6] Checking prerequisites..."
+for cmd in python3 curl; do
+    command -v "$cmd" >/dev/null || { echo "Error: $cmd is required"; exit 1; }
+done
+if [ ! -f "$HOME/.claude/.credentials.json" ]; then
+    echo "Warning: ~/.claude/.credentials.json not found."
+    echo "  Sign in via Claude Code first, then re-run this installer."
+    echo "  Continuing anyway — the daemon will retry on each poll."
+fi
+echo "  OK"
+echo ""
+
+echo "[2/6] Checking PlatformIO (needed to flash firmware)..."
+PIO_FOUND=""
+if command -v pio >/dev/null; then
+    PIO_FOUND="pio"
+else
+    for py in python3.13 python3.12 python3.11 python3.10; do
+        if command -v "$py" >/dev/null && "$py" -c "import platformio" 2>/dev/null; then
+            PIO_FOUND="$py -m platformio"
+            break
+        fi
+    done
+fi
+
+if [ -z "$PIO_FOUND" ]; then
+    echo "  PlatformIO not found. Installing via pip into the user site..."
+    INSTALL_PY=""
+    for py in python3.13 python3.12 python3.11 python3.10; do
+        if command -v "$py" >/dev/null; then
+            INSTALL_PY="$py"
+            break
+        fi
+    done
+    if [ -z "$INSTALL_PY" ]; then
+        echo "  Error: PlatformIO requires Python 3.10+. Install one of:"
+        echo "    brew install python@3.12"
+        echo "    brew install platformio"
+        exit 1
+    fi
+    "$INSTALL_PY" -m pip install --user --upgrade platformio
+    PIO_FOUND="$INSTALL_PY -m platformio"
+fi
+echo "  OK ($PIO_FOUND)"
+echo ""
+
+echo "[3/6] Creating Python virtualenv at daemon/.venv ..."
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+fi
+"$VENV_DIR/bin/pip" install --quiet --upgrade pip
+"$VENV_DIR/bin/pip" install --quiet "bleak>=0.22" "httpx>=0.27"
+PYTHON_BIN="$VENV_DIR/bin/python"
+echo "  OK ($PYTHON_BIN)"
+echo ""
+
+echo "[4/6] Rendering launchd plist..."
+mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
+sed \
+    -e "s|__PYTHON_BIN__|${PYTHON_BIN}|g" \
+    -e "s|__DAEMON_PATH__|${DAEMON_PY}|g" \
+    -e "s|__REPO_DIR__|${SCRIPT_DIR}|g" \
+    -e "s|__LOG_OUT__|${LOG_OUT}|g" \
+    -e "s|__LOG_ERR__|${LOG_ERR}|g" \
+    -e "s|__HOME__|${HOME}|g" \
+    "$PLIST_SRC" > "$PLIST_DST"
+echo "  Installed: $PLIST_DST"
+echo ""
+
+echo "[5/6] Bluetooth permission check..."
+echo "  On first run the daemon will trigger a Bluetooth permission prompt."
+echo "  macOS only prompts for foreground processes — so we'll run it"
+echo "  interactively once below. Press Ctrl+C after you see 'Scanning...'"
+echo "  and grant permission when prompted. Then re-run this installer"
+echo "  (or just continue) to enable launchd autostart."
+echo ""
+read -r -p "Run a permission-priming scan now? [Y/n] " ans
+if [[ ! "$ans" =~ ^[Nn]$ ]]; then
+    "$PYTHON_BIN" "$DAEMON_PY" || true
+fi
+echo ""
+
+echo "[6/6] Loading launchd service..."
+launchctl unload "$PLIST_DST" 2>/dev/null || true
+launchctl load -w "$PLIST_DST"
+echo "  Loaded."
+echo ""
+
+echo "=== Done ==="
+echo ""
+echo "Next step — flash the 1.8\" board firmware:"
+echo "  ./flash-mac-18.sh"
+echo ""
+echo "First-time Bluetooth pairing (after firmware is flashed):"
+echo "  1. Power on the device."
+echo "  2. Open System Settings → Bluetooth."
+echo "  3. Click 'Connect' next to 'Claude Controller'."
+echo "  4. The daemon will discover it within ~30 s and start polling."
+echo ""
+echo "Useful commands:"
+echo "  launchctl list | grep claude-usage     # check it's running"
+echo "  tail -F $LOG_OUT                       # live logs"
+echo "  launchctl unload $PLIST_DST            # stop"
+echo "  launchctl load -w $PLIST_DST           # start"


### PR DESCRIPTION
- New platformio env: waveshare_amoled_18 targeting the 368×448 panel
- display_cfg.h: QSPI pins, PANEL_W/H split, TCA9554 expander defines, FT3168 touch
- main.cpp: QSPI bus, TCA9554 io_expander_init() for panel power, landscape-only software rotation (90°/270°) in flush callback, touch coord remapping
- imu.cpp: landscape-only rotation (returns 1 or 3), defaults to 90° on boot
- power.cpp: stub (AXP2101 confirmed present on board, re-enable later)
- ui.cpp: layout reflow for 448×368 logical landscape canvas
- splash.cpp: 448×368 canvas, centers 360×360 pixel-art with gutters
- flash-mac-18.sh: one-command flash script for macOS
- install-mac-18.sh: full macOS installer (pio, daemon venv, launchd service)