### PR TITLE
Add dockerized BLE daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ Check status: `systemctl --user status claude-usage-daemon`
 
 View logs: `journalctl --user -u claude-usage-daemon -f`
 
+### Run the daemon in Docker (alternative)
+
+Skip the systemd unit and run the daemon in a container instead. The compose file mounts the host's system D-Bus so `bleak` reaches BlueZ, plus your credentials file and the cached MAC dir.
+
+```bash
+docker compose -f daemon/docker-compose.yml up -d --build
+docker compose -f daemon/docker-compose.yml logs -f
+```
+
+Only one BLE client can hold the GATT connection — stop the systemd unit (`systemctl --user stop claude-usage-daemon`) before starting the container. Docker Desktop on macOS can't reach host Bluetooth, so this path is Linux only.
+
 ## How it works
 
 1. The daemon reads your Claude Code OAuth token from `~/.claude/.credentials.json`.

--- a/daemon/.dockerignore
+++ b/daemon/.dockerignore
@@ -1,0 +1,9 @@
+.venv
+__pycache__
+*.pyc
+docker-compose.yml
+Dockerfile
+.dockerignore
+claude-usage-daemon.service
+com.user.claude-usage-daemon.plist
+claude-usage-daemon.sh

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+# ca-certificates: outbound HTTPS to api.anthropic.com.
+# bleak talks to BlueZ over D-Bus via the pure-Python dbus-fast wheel,
+# so no system dbus-dev / bluez packages are needed inside the container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir "bleak>=0.22" "httpx>=0.27"
+
+WORKDIR /app
+COPY claude_usage_daemon.py /app/
+
+ENTRYPOINT ["python3", "-u", "/app/claude_usage_daemon.py"]

--- a/daemon/docker-compose.yml
+++ b/daemon/docker-compose.yml
@@ -1,0 +1,27 @@
+# Run the Clawdmeter BLE usage daemon in Docker. Linux only — Docker
+# Desktop on macOS cannot reach the host's Bluetooth stack, so use the
+# launchd install (install-mac.sh) there instead.
+#
+# Quick start:
+#   docker compose -f daemon/docker-compose.yml up -d --build
+#   docker compose -f daemon/docker-compose.yml logs -f
+#
+# Note: only one host process can hold the GATT connection at a time —
+# stop any systemd unit or foreground daemon before starting this.
+
+services:
+  claude-usage-daemon:
+    build: .
+    image: clawdmeter-daemon:latest
+    container_name: claude-usage-daemon
+    # bleak/dbus-fast talks to the host's BlueZ over the system D-Bus
+    # socket; mounting it is enough, no host networking needed.
+    # AppArmor's default container profile blocks D-Bus AddMatch on
+    # Ubuntu/Debian hosts — unconfine so BlueZ method calls go through.
+    security_opt:
+      - apparmor=unconfined
+    volumes:
+      - /var/run/dbus:/var/run/dbus
+      - ${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json:ro
+      - ${HOME}/.config/claude-usage-monitor:/root/.config/claude-usage-monitor
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Drop-in container for running `daemon/claude_usage_daemon.py` without installing Python deps on the host.
- Compose file mounts the host's system D-Bus so bleak reaches BlueZ, plus `~/.claude/.credentials.json` (ro) and `~/.config/claude-usage-monitor/` (rw, for the cached MAC).
- AppArmor's default container profile blocks D-Bus `AddMatch` on Ubuntu/Debian, so the compose file sets `apparmor=unconfined`.

Linux only — Docker Desktop on macOS can't reach host Bluetooth; Mac users keep using `install-mac.sh` / launchd.

## Quick start
```
docker compose -f daemon/docker-compose.yml up -d --build
docker compose -f daemon/docker-compose.yml logs -f
```

NOTE: Only one BLE client can hold the GATT connection — stop any systemd unit or foreground daemon before starting the container.


Also, I discovered the python-based daemon after I opened the other docker PR. Sorry for the bonus related PR.