### PR TITLE
Add LILYGO and Waveshare Touch-LCD-2 board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,27 @@ Each board is selected at build time via a PlatformIO environment
 behind `BOARD_*` macros so neither target's behaviour bleeds into the
 other.
 
-| Board                                                                                                                | PlatformIO env          | Display                  | Touch | PMU      | IMU     | Buttons          |
-| -------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------------ | :---: | :------: | :-----: | ---------------- |
-| [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786)      | `waveshare_amoled_216`  | 480×480 AMOLED (CO5300)  | CST9220 | AXP2101 | QMI8658 | 3 (incl. PMU PKEY) |
-| [LILYGO T-Display S3](https://www.lilygo.cc/products/t-display-s3) (Basic, no touch)                                 | `lilygo_t_display_s3`   | 170×320 ST7789 (parallel)| —     | ADC sense | —       | 2 (BOOT + IO14)  |
+| Board                                                                                                                | PlatformIO env                   | Display                   | Touch   | PMU       | IMU      | Buttons             |
+| -------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------- | :-----: | :-------: | :------: | ------------------- |
+| [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786)      | `waveshare_amoled_216`           | 480×480 AMOLED (CO5300)   | CST9220 | AXP2101   | QMI8658  | 3 (incl. PMU PKEY)  |
+| [LILYGO T-Display S3](https://www.lilygo.cc/products/t-display-s3) (Basic, no touch)                                 | `lilygo_t_display_s3`            | 170×320 ST7789 (parallel) | —       | ADC sense | —        | 2 (BOOT + IO14)     |
+| [Waveshare ESP32-S3-Touch-LCD-2](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-2)                                | `waveshare_esp32_s3_touch_lcd_2` | 240×320 ST7789T3 (SPI)    | CST816D | ADC sense | QMI8658† | 0 (touch-only nav)  |
 
-Common to both targets: ESP32-S3 (R8 / 16 MB flash, 8 MB PSRAM), USB-C
+Common to all targets: ESP32-S3 (R8 / 16 MB flash, 8 MB PSRAM), USB-C
 for flashing, optional 3.7 V Li-Po battery, and the BLE HID + custom
 GATT service used by the host daemon.
 
+† On the Touch-LCD-2 the IMU is wired but `BOARD_HAS_IMU` is left at 0
+in the initial port — rotation is fixed via `BOARD_FIXED_ROTATION`. Flip
+that pair in `boards/board_waveshare_esp32_s3_touch_lcd_2.h` to enable
+auto-rotation once the orientation mapping has been tuned for the
+non-square panel.
+
 ### Planned boards
 
-I've started scouting a few more panels for future targets. They all
-need additional driver work and aren't in the tree yet — open to PRs.
+A few more panels I'd like to land next. None of these are in the tree
+yet — open to PRs.
 
-- **Waveshare ESP32-S3 Touch LCD 2.0"** — 240×320 IPS, capacitive touch, optional camera. Similar driver story to the LILYGO, plus touch.
 - **Waveshare ESP32-P4 Smart 86 Box** — 4" 720×720 touchscreen, RS485, relay, camera, RJ45 ETH. ESP32-P4 has no native BLE, so the BLE path needs to go over ESP-Hosted to a coprocessor — bigger lift than the S3 ports.
 - **Waveshare ESP32-P4-WIFI6 dev board (3.5" LCD)** — same ESP32-P4 / ESP-Hosted constraint as the Smart 86 Box, smaller form factor.
 
@@ -86,12 +92,13 @@ board, the script suffices:
 ./flash-mac.sh /dev/cu.usbmodem1101  # or pass an explicit USB serial port
 ```
 
-For the **LILYGO T-Display S3**, drive `pio` directly so you can pick the
-env:
+For the **LILYGO T-Display S3** or **Waveshare ESP32-S3-Touch-LCD-2**,
+drive `pio` directly so you can pick the env:
 
 ```bash
 cd firmware
-pio run -e lilygo_t_display_s3 -t upload --upload-port /dev/cu.usbmodem1101
+pio run -e lilygo_t_display_s3            -t upload --upload-port /dev/cu.usbmodem1101
+pio run -e waveshare_esp32_s3_touch_lcd_2 -t upload --upload-port /dev/cu.usbmodem1101
 ```
 
 (See the LILYGO download-mode note in the Linux section if the chip
@@ -136,6 +143,9 @@ pio run -e waveshare_amoled_216 -t upload --upload-port /dev/ttyACM0
 
 # LILYGO T-Display S3 (Basic, no touch)
 pio run -e lilygo_t_display_s3 -t upload --upload-port /dev/ttyACM0
+
+# Waveshare ESP32-S3-Touch-LCD-2 (240x320 + CST816D touch)
+pio run -e waveshare_esp32_s3_touch_lcd_2 -t upload --upload-port /dev/ttyACM0
 ```
 
 > **LILYGO note:** if `esptool` reports `Failed to connect to ESP32-S3:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A small ESP32 dashboard I made for my desk to keep an eye on Claude Code usage.
 
-It runs on a [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) and pairs with my laptop over Bluetooth, the splash screen plays pixel-art Clawd animations that get
+It runs on a [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) (the original target) or a [LILYGO T-Display S3](https://www.lilygo.cc/products/t-display-s3), pairs with my laptop over Bluetooth, the splash screen plays pixel-art Clawd animations that get
 busier when your usage rate climbs. The two side buttons send Space and
 Shift+Tab over BLE HID for Claude Code's voice mode and mode-toggle shortcuts.
 
@@ -25,7 +25,41 @@ While the splash is up, the middle button cycles animations instead of screens. 
 
 ## Hardware
 
-- [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) - ESP32-S3R8, 2.16" 480×480 AMOLED (CO5300 QSPI), CST9220 cap touch, AXP2101 PMU + Li-Po battery, QMI8658 IMU
+### Supported boards
+
+The firmware now compiles for two boards out of the same source tree.
+Each board is selected at build time via a PlatformIO environment
+(`pio run -e <env>`) — pinout, capability flags, and UI layout live
+behind `BOARD_*` macros so neither target's behaviour bleeds into the
+other.
+
+| Board                                                                                                                | PlatformIO env          | Display                  | Touch | PMU      | IMU     | Buttons          |
+| -------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------------ | :---: | :------: | :-----: | ---------------- |
+| [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786)      | `waveshare_amoled_216`  | 480×480 AMOLED (CO5300)  | CST9220 | AXP2101 | QMI8658 | 3 (incl. PMU PKEY) |
+| [LILYGO T-Display S3](https://www.lilygo.cc/products/t-display-s3) (Basic, no touch)                                 | `lilygo_t_display_s3`   | 170×320 ST7789 (parallel)| —     | ADC sense | —       | 2 (BOOT + IO14)  |
+
+Common to both targets: ESP32-S3 (R8 / 16 MB flash, 8 MB PSRAM), USB-C
+for flashing, optional 3.7 V Li-Po battery, and the BLE HID + custom
+GATT service used by the host daemon.
+
+### Planned boards
+
+I've started scouting a few more panels for future targets. They all
+need additional driver work and aren't in the tree yet — open to PRs.
+
+- **Waveshare ESP32-S3 Touch LCD 2.0"** — 240×320 IPS, capacitive touch, optional camera. Similar driver story to the LILYGO, plus touch.
+- **Waveshare ESP32-P4 Smart 86 Box** — 4" 720×720 touchscreen, RS485, relay, camera, RJ45 ETH. ESP32-P4 has no native BLE, so the BLE path needs to go over ESP-Hosted to a coprocessor — bigger lift than the S3 ports.
+- **Waveshare ESP32-P4-WIFI6 dev board (3.5" LCD)** — same ESP32-P4 / ESP-Hosted constraint as the Smart 86 Box, smaller form factor.
+
+If you want to port Clawdmeter to a different panel, the structure is:
+
+1. Add `firmware/src/boards/board_<name>.h` with pinout + capability flags (`BOARD_HAS_TOUCH` / `BOARD_HAS_PMU` / `BOARD_HAS_IMU` / `BOARD_HAS_BATTERY_ADC`).
+2. Wire the new `BOARD_*` macro into `firmware/src/display_cfg.h` and instantiate the GFX driver in the matching `#if` block of `firmware/src/main.cpp`.
+3. Add a `[env:<name>]` section to `firmware/platformio.ini`.
+4. Tune `firmware/src/ui_layout.h` for the panel's dimensions and fonts.
+
+### Accessories
+
 - USB-C cable for flashing firmware and charging
 - 3.7V Li-Po battery (MX1.25 2-pin connector, optional)
 
@@ -43,10 +77,25 @@ The macOS host pieces — Python daemon, LaunchAgent, and flash helper — were 
 
 ### Flash the firmware
 
+`flash-mac.sh` invokes `pio run -t upload` with the default
+PlatformIO env, which is set to `waveshare_amoled_216`. For the Waveshare
+board, the script suffices:
+
 ```bash
 ./flash-mac.sh                       # auto-detects /dev/cu.usbmodem*
 ./flash-mac.sh /dev/cu.usbmodem1101  # or pass an explicit USB serial port
 ```
+
+For the **LILYGO T-Display S3**, drive `pio` directly so you can pick the
+env:
+
+```bash
+cd firmware
+pio run -e lilygo_t_display_s3 -t upload --upload-port /dev/cu.usbmodem1101
+```
+
+(See the LILYGO download-mode note in the Linux section if the chip
+doesn't auto-reset into the ROM bootloader.)
 
 ### Pair the device
 
@@ -75,10 +124,25 @@ launchctl load -w ~/Library/LaunchAgents/com.user.claude-usage-daemon.plist # st
 
 ### Flash the firmware
 
+Pick the env that matches your board. The two currently-supported targets
+both flash over USB-C to `/dev/ttyACM0` on Linux (no boot-mode gymnastics
+needed for either):
+
 ```bash
 cd firmware
-pio run -t upload --upload-port /dev/ttyACM0
+
+# Waveshare ESP32-S3-Touch-AMOLED-2.16 (default — the original target)
+pio run -e waveshare_amoled_216 -t upload --upload-port /dev/ttyACM0
+
+# LILYGO T-Display S3 (Basic, no touch)
+pio run -e lilygo_t_display_s3 -t upload --upload-port /dev/ttyACM0
 ```
+
+> **LILYGO note:** if `esptool` reports `Failed to connect to ESP32-S3:
+> Invalid head of packet`, the existing firmware is holding the native
+> USB and the chip isn't dropping into the ROM bootloader on its own.
+> Put it in download mode manually: hold **BOOT** (GPIO 0), tap **RST**,
+> release BOOT — then retry the upload.
 
 ### Pair the device
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,4 +1,18 @@
-[env:waveshare_amoled_216]
+; ============================================================
+; Clawdmeter — Claude Code usage monitor firmware
+;
+; Shared LVGL + NimBLE configuration lives in [common]; each board
+; selects itself with a BOARD_<NAME> build flag and adds only the
+; libraries it actually drives. Add a new board by:
+;   1. Dropping a header in src/boards/board_<name>.h
+;   2. Wiring it up in src/display_cfg.h
+;   3. Adding a new [env:<name>] section below
+; ============================================================
+
+[platformio]
+default_envs = waveshare_amoled_216
+
+[common]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
 board = esp32-s3-devkitc-1
 framework = arduino
@@ -9,8 +23,6 @@ monitor_speed = 115200
 build_flags =
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DBOARD_HAS_PSRAM
-    ; AXP2101 PMU
-    -DXPOWERS_CHIP_AXP2101
     ; NimBLE config — peripheral-only, single connection
     -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
     -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
@@ -35,8 +47,37 @@ build_flags =
 
 lib_deps =
     moononournation/GFX Library for Arduino@^1.5.6
-    lewisxhe/SensorLib@^0.2.6
-    lewisxhe/XPowersLib@^0.2.7
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+; ------------------------------------------------------------
+; Original target: Waveshare ESP32-S3-Touch-AMOLED-2.16
+; CO5300 QSPI 480x480, CST9220 touch, AXP2101 PMU, QMI8658 IMU.
+; ------------------------------------------------------------
+[env:waveshare_amoled_216]
+extends = common
+build_flags =
+    ${common.build_flags}
+    -DBOARD_WAVESHARE_AMOLED_216
+    -DXPOWERS_CHIP_AXP2101
+lib_deps =
+    ${common.lib_deps}
+    lewisxhe/SensorLib@^0.2.6
+    lewisxhe/XPowersLib@^0.2.7
+
+; ------------------------------------------------------------
+; LILYGO T-Display S3 (Basic, no touch)
+; ST7789 170x320 8-bit parallel, two front buttons, ADC battery.
+; No PMU, no IMU, no touch — so SensorLib / XPowersLib are omitted.
+; ------------------------------------------------------------
+[env:lilygo_t_display_s3]
+extends = common
+board_build.flash_size = 16MB
+board_upload.flash_size = 16MB
+build_flags =
+    ${common.build_flags}
+    -DBOARD_LILYGO_T_DISPLAY_S3
+    -DARDUINO_USB_MODE=1
+lib_deps =
+    ${common.lib_deps}

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -81,3 +81,21 @@ build_flags =
     -DARDUINO_USB_MODE=1
 lib_deps =
     ${common.lib_deps}
+
+; ------------------------------------------------------------
+; Waveshare ESP32-S3-Touch-LCD-2
+; ST7789T3 240x320 SPI, CST816D capacitive touch (I2C), QMI8658C IMU,
+; ADC battery (GPIO5, 1:3 divider). No PMU — linear charger only, so
+; XPowersLib is omitted. SensorLib is included for the touch driver.
+; ------------------------------------------------------------
+[env:waveshare_esp32_s3_touch_lcd_2]
+extends = common
+board_build.flash_size = 16MB
+board_upload.flash_size = 16MB
+build_flags =
+    ${common.build_flags}
+    -DBOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_2
+    -DARDUINO_USB_MODE=1
+lib_deps =
+    ${common.lib_deps}
+    lewisxhe/SensorLib@^0.2.6

--- a/firmware/src/boards/board_lilygo_t_display_s3.h
+++ b/firmware/src/boards/board_lilygo_t_display_s3.h
@@ -1,0 +1,82 @@
+#pragma once
+//
+// Board: LILYGO T-Display S3 (Basic, no touch)
+// 170x320 ST7789 IPS LCD via 8-bit i80 parallel, two front buttons (BOOT
+// on GPIO0, user button on GPIO14), battery voltage on GPIO4 ADC. No PMU,
+// no IMU, no touch.
+//
+// ESP32-S3R8, 16 MB flash, 8 MB PSRAM.
+//
+
+// ---- Display ----
+#define BOARD_NAME              "LILYGO T-Display S3"
+#define BOARD_LCD_W             170
+#define BOARD_LCD_H             320
+// ST7789 parallel, not AMOLED — no DCS brightness command, backlight is GPIO.
+#define BOARD_LCD_IS_AMOLED     0
+#define BOARD_LCD_IS_ROUND      0
+// Portrait by default. If you prefer landscape, set to 1 or 3 and re-flash —
+// LVGL and the GFX driver pick it up at boot. There is no IMU on this board
+// so rotation is fixed.
+#ifndef BOARD_FIXED_ROTATION
+#define BOARD_FIXED_ROTATION    0
+#endif
+
+// ST7789 control pins
+#define LCD_DC                  7
+#define LCD_CS                  6
+#define LCD_WR                  8
+#define LCD_RD                  9
+#define LCD_RESET               5
+#define LCD_BL                  38     // backlight
+#define LCD_POWER_ON            15     // panel power rail enable
+
+// 8-bit parallel data pins
+#define LCD_D0                  39
+#define LCD_D1                  40
+#define LCD_D2                  41
+#define LCD_D3                  42
+#define LCD_D4                  45
+#define LCD_D5                  46
+#define LCD_D6                  47
+#define LCD_D7                  48
+
+// ST7789 internal RAM is 240x320 but the visible panel is 170 columns —
+// the column window starts at x=35.
+#define LCD_COL_OFFSET          35
+#define LCD_ROW_OFFSET          0
+
+// ---- I2C ----
+// Not used by the Basic variant — leave the symbols defined so files that
+// reference them don't break, but nothing initializes the bus.
+#define IIC_SDA                 -1
+#define IIC_SCL                 -1
+
+// ---- Touch ----
+#define BOARD_HAS_TOUCH         0     // Basic variant has no touch controller
+
+// ---- PMU ----
+#define BOARD_HAS_PMU           0     // no AXP2101 on this board
+#define BOARD_HAS_PWR_BUTTON    0
+#define BOARD_HAS_BATTERY_ADC   1     // approximate battery voltage from ADC
+
+// Battery ADC (un-calibrated; logs the raw value at boot so the divider can
+// be derived empirically). Holding-stock cells like a 3.7 V LiPo go through
+// a 2:1 voltage divider on this board.
+#define BAT_ADC_GPIO            4
+#define BAT_ADC_MAX             4095        // 12-bit
+#define BAT_ADC_REF_VOLTAGE     3.3f        // ESP32-S3 VDDA reference
+#define BAT_ADC_DIVIDER_RATIO   2.0f        // empirical: 100k/100k
+#define BAT_ADC_CORRECTION_FACTOR 1.0f      // tweak after calibration
+
+// ---- IMU ----
+#define BOARD_HAS_IMU           0
+
+// ---- Physical buttons ----
+// BOOT/IO0 is a strap pin — DO NOT hold it during power-up or the chip
+// enters download mode. After boot it can be used as a normal input.
+// IO14 is a plain GPIO. Both are wired to GND with internal pull-ups.
+#define BOARD_BTN_COUNT         2
+#define BOARD_BTN0_GPIO         0     // BOOT — short=back/splash, long=Space hold
+#define BOARD_BTN1_GPIO         14    // IO14 — short=cycle screen, long=Shift+Tab
+#define BOARD_BTN_ACTIVE_LOW    1

--- a/firmware/src/boards/board_waveshare_amoled_216.h
+++ b/firmware/src/boards/board_waveshare_amoled_216.h
@@ -30,9 +30,13 @@
 
 // ---- Touch (CST9220) ----
 #define BOARD_HAS_TOUCH         1
+// Unified SensorLib CST driver — auto-detects the actual chip at the
+// configured address, so the same type works for CST92xx (Waveshare
+// AMOLED) and CST816 (Touch-LCD-2).
+#define BOARD_TOUCH_CLASS       TouchDrvCSTXXX
+#define BOARD_TOUCH_ADDR        0x5A
 #define TP_INT                  11
 #define TP_RST                  2     // shared with LCD_RESET
-#define CST9220_ADDR            0x5A
 
 // ---- PMU (AXP2101) ----
 #define BOARD_HAS_PMU           1

--- a/firmware/src/boards/board_waveshare_amoled_216.h
+++ b/firmware/src/boards/board_waveshare_amoled_216.h
@@ -1,0 +1,53 @@
+#pragma once
+//
+// Board: Waveshare ESP32-S3-Touch-AMOLED-2.16
+// 480x480 round-square AMOLED (CO5300, QSPI), CST9220 touch, AXP2101 PMU,
+// QMI8658 accelerometer. All peripherals share one I2C bus.
+//
+// This is the original Clawdmeter board.
+//
+
+// ---- Display ----
+#define BOARD_NAME              "Waveshare AMOLED 2.16\""
+#define BOARD_LCD_W             480
+#define BOARD_LCD_H             480
+#define BOARD_LCD_IS_AMOLED     1     // QSPI CO5300; brightness control via DCS
+#define BOARD_LCD_IS_ROUND      1     // visible window has rounded corners
+#define BOARD_FIXED_ROTATION    0     // auto-rotation overrides at runtime
+
+// QSPI CO5300 pins
+#define LCD_CS                  12
+#define LCD_SCLK                38
+#define LCD_SDIO0               4
+#define LCD_SDIO1               5
+#define LCD_SDIO2               6
+#define LCD_SDIO3               7
+#define LCD_RESET               2
+
+// ---- I2C (shared by touch, PMU, IMU) ----
+#define IIC_SDA                 15
+#define IIC_SCL                 14
+
+// ---- Touch (CST9220) ----
+#define BOARD_HAS_TOUCH         1
+#define TP_INT                  11
+#define TP_RST                  2     // shared with LCD_RESET
+#define CST9220_ADDR            0x5A
+
+// ---- PMU (AXP2101) ----
+#define BOARD_HAS_PMU           1
+#define BOARD_HAS_BATTERY_ADC   0     // ADC path not used when PMU present
+#define BOARD_HAS_PWR_BUTTON    1     // AXP2101 PKEY drives the mid button
+#define AXP2101_ADDR            0x34
+
+// ---- IMU (QMI8658, auto-rotation) ----
+#define BOARD_HAS_IMU           1
+
+// ---- Physical buttons ----
+// Two on-board side buttons + one PMU PKEY make the 3-button scheme. The
+// PMU button is wired through power.cpp (HAS_PWR_BUTTON above) — only the
+// two GPIO buttons are described here.
+#define BOARD_BTN_COUNT         2
+#define BOARD_BTN0_GPIO         0     // left — Space (voice-mode push-to-talk)
+#define BOARD_BTN1_GPIO         18    // right — Shift+Tab (mode toggle)
+#define BOARD_BTN_ACTIVE_LOW    1

--- a/firmware/src/boards/board_waveshare_esp32_s3_touch_lcd_2.h
+++ b/firmware/src/boards/board_waveshare_esp32_s3_touch_lcd_2.h
@@ -1,0 +1,97 @@
+#pragma once
+//
+// Board: Waveshare ESP32-S3-Touch-LCD-2
+// https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-2
+//
+// 240x320 ST7789T3 IPS LCD via SPI, CST816D capacitive touch (I2C),
+// QMI8658C accelerometer (same I2C bus as touch), ADC battery sense on
+// GPIO5, ETA-class linear charger (no AXP2101 / PMU). SD card and OV3660
+// camera are wired but unused for the dashboard build.
+//
+// ESP32-S3R8, 16 MB flash, 8 MB PSRAM.
+//
+
+// ---- Display ----
+#define BOARD_NAME              "Waveshare ESP32-S3-Touch-LCD-2"
+#define BOARD_LCD_W             240
+#define BOARD_LCD_H             320
+#define BOARD_LCD_IS_AMOLED     0     // backlit IPS, no DCS brightness
+#define BOARD_LCD_IS_ROUND      0
+#ifndef BOARD_FIXED_ROTATION
+#define BOARD_FIXED_ROTATION    0
+#endif
+
+// ST7789T3 SPI pins. LCD_RESET shares GPIO0 with the BOOT/STRAP signal
+// — gfx->begin() pulses it low to reset the panel, which also briefly
+// pulls GPIO0 low. After init GPIO0 is held high, so the BOOT button is
+// usable as an emergency reset only; do not map it as a normal nav
+// button or you'll reset the LCD on every press.
+#define LCD_MOSI                38
+#define LCD_SCLK                39
+#define LCD_DC                  42
+#define LCD_CS                  45
+#define LCD_RESET               0
+#define LCD_BL                  1
+#define LCD_MISO                -1     // not connected
+#define LCD_COL_OFFSET          0      // standard 240x320 ST7789
+#define LCD_ROW_OFFSET          0
+
+// ---- I2C (shared by touch + IMU) ----
+#define IIC_SDA                 48
+#define IIC_SCL                 47
+
+// ---- Touch (CST816D) ----
+#define BOARD_HAS_TOUCH         1
+// Unified SensorLib CST driver. It auto-detects the actual chip — the
+// CST816D in our case — based on the I2C address, so the same type
+// is reused on the Waveshare AMOLED (CST9220 @ 0x5A).
+#define BOARD_TOUCH_CLASS       TouchDrvCSTXXX
+#define BOARD_TOUCH_ADDR        0x15      // factory default for CST816 family
+#define TP_INT                  46
+#define TP_RST                  -1        // not wired; chip self-resets at POR
+
+// ---- PMU ----
+// ETA6098-class linear charger, no PMU IC. Battery state read from ADC.
+#define BOARD_HAS_PMU           0
+#define BOARD_HAS_PWR_BUTTON    0
+#define BOARD_HAS_BATTERY_ADC   1
+
+// Battery ADC. Schematic shows R19=200K / R20=100K, so V_bat is divided
+// by 3 before reaching GPIO5. Correction factor is left at 1.0 until
+// the boot-time raw log is used to calibrate.
+#define BAT_ADC_GPIO            5
+#define BAT_ADC_MAX             4095
+#define BAT_ADC_REF_VOLTAGE     3.3f
+#define BAT_ADC_DIVIDER_RATIO   3.0f
+#define BAT_ADC_CORRECTION_FACTOR 1.0f
+#define BAT_CHARGE_DETECT_USB_CDC 1  // Charger status pin is not exposed.
+
+// ---- IMU (QMI8658C, optional auto-rotation) ----
+// Hooked to the same I2C bus as the touch. Default rotation tracking is
+// disabled until the firmware is observed to work fine on this board —
+// flip BOARD_FIXED_ROTATION above and set this flag to 1 to opt in.
+#define BOARD_HAS_IMU           0
+#define IMU_INT1                3
+
+// ---- Physical buttons ----
+// KEY1 is wired to ESP_EN (hardware reset, not an application input).
+// KEY2 is BOOT/GPIO0 which doubles as LCD_RESET — unsafe to map as a
+// nav button. Navigation on this board is done entirely through touch.
+#define BOARD_BTN_COUNT         0
+#define BOARD_BTN_ACTIVE_LOW    1
+
+// ---- Storage / camera ----
+// Documented for reference; the dashboard build does not initialize
+// either subsystem.
+#define SD_MOSI                 38
+#define SD_SCLK                 39
+#define SD_MISO                 40
+#define SD_CS                   41
+
+#define CAM_PWDN                17
+#define CAM_XCLK                8
+#define CAM_PCLK                9
+#define CAM_VSYNC               6
+#define CAM_HREF                4
+#define CAM_SDA                 21
+#define CAM_SCL                 16

--- a/firmware/src/buttons.cpp
+++ b/firmware/src/buttons.cpp
@@ -1,0 +1,158 @@
+#include "buttons.h"
+#include "display_cfg.h"
+#include "ble.h"
+#include "ui.h"
+#include "splash.h"
+#include "power.h"
+#include <Arduino.h>
+
+// HID usage codes (USB HID 1.11, Keyboard/Keypad page).
+#define HID_KEY_TAB    0x2B
+#define HID_KEY_SPACE  0x2C
+#define HID_MOD_SHIFT  0x02
+
+static inline bool btn_is_pressed(int gpio) {
+#if BOARD_BTN_ACTIVE_LOW
+    return digitalRead(gpio) == LOW;
+#else
+    return digitalRead(gpio) == HIGH;
+#endif
+}
+
+#if defined(BOARD_WAVESHARE_AMOLED_216)
+
+// Waveshare keeps the original 3-button scheme:
+//   - BOARD_BTN0 (GPIO 0)  edge -> Space press / release (voice mode)
+//   - BOARD_BTN1 (GPIO 18) edge -> Shift+Tab press / release (mode toggle)
+//   - PMU PKEY  short      -> cycle screens; on splash, cycle animations
+// The Space/Shift-Tab keys mirror the button state directly so users can
+// hold them — matches how Claude Code's voice mode wants push-to-talk.
+
+void buttons_init(void) {
+    pinMode(BOARD_BTN0_GPIO, INPUT_PULLUP);
+    pinMode(BOARD_BTN1_GPIO, INPUT_PULLUP);
+}
+
+void buttons_tick(void) {
+    static bool b0_was = false, b1_was = false;
+    bool b0_now = btn_is_pressed(BOARD_BTN0_GPIO);
+    bool b1_now = btn_is_pressed(BOARD_BTN1_GPIO);
+
+    if (b0_now != b0_was) {
+        if (b0_now) ble_keyboard_press(HID_KEY_SPACE, 0);
+        else        ble_keyboard_release();
+        b0_was = b0_now;
+    }
+    if (b1_now != b1_was) {
+        if (b1_now) ble_keyboard_press(HID_KEY_TAB, HID_MOD_SHIFT);
+        else        ble_keyboard_release();
+        b1_was = b1_now;
+    }
+
+#if BOARD_HAS_PWR_BUTTON
+    if (power_pwr_pressed()) {
+        if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
+        else                                          ui_cycle_screen();
+    }
+#endif
+}
+
+#elif defined(BOARD_LILYGO_T_DISPLAY_S3)
+
+// LILYGO only has two physical buttons, so each one carries a short and a
+// long action:
+//   BTN0 (BOOT / GPIO 0)
+//     - short press      -> toggle to/from the splash screen
+//     - long press hold  -> Space held (voice push-to-talk)
+//   BTN1 (IO14)
+//     - short press      -> cycle screens (or, on splash, next animation)
+//     - long press edge  -> Shift+Tab once
+//
+// BOOT is also a strap pin — holding it during reset puts the chip into
+// download mode. After boot it behaves like a normal input.
+
+#define BTN_DEBOUNCE_MS    25
+#define BTN_LONG_PRESS_MS  600
+
+struct ButtonState {
+    int      gpio;
+    bool     stable;          // debounced pressed state
+    bool     raw_last;        // last raw sample
+    uint32_t raw_since;       // when raw_last started
+    uint32_t press_started;   // when stable went from up -> down
+    bool     long_fired;      // long-press action already taken this hold
+    bool     space_active;    // true while we're holding Space for this button
+};
+
+static ButtonState btn0 = { BOARD_BTN0_GPIO, false, false, 0, 0, false, false };
+static ButtonState btn1 = { BOARD_BTN1_GPIO, false, false, 0, 0, false, false };
+
+static void btn_update(ButtonState* b) {
+    uint32_t now = millis();
+    bool raw = btn_is_pressed(b->gpio);
+    if (raw != b->raw_last) {
+        b->raw_last = raw;
+        b->raw_since = now;
+        return;
+    }
+    if (now - b->raw_since < BTN_DEBOUNCE_MS) return;
+    if (raw == b->stable) return;
+
+    b->stable = raw;
+    if (raw) {
+        b->press_started = now;
+        b->long_fired = false;
+    }
+}
+
+static bool btn_held_long(const ButtonState* b) {
+    return b->stable && !b->long_fired &&
+           (millis() - b->press_started >= BTN_LONG_PRESS_MS);
+}
+
+void buttons_init(void) {
+    pinMode(BOARD_BTN0_GPIO, INPUT_PULLUP);
+    pinMode(BOARD_BTN1_GPIO, INPUT_PULLUP);
+}
+
+void buttons_tick(void) {
+    bool b0_prev = btn0.stable;
+    bool b1_prev = btn1.stable;
+    btn_update(&btn0);
+    btn_update(&btn1);
+
+    // BTN0: long-press begins -> hold Space; release -> release Space; a
+    // short press (release before threshold and no Space sent) toggles
+    // the splash screen.
+    if (btn0.stable && !btn0.space_active && btn_held_long(&btn0)) {
+        ble_keyboard_press(HID_KEY_SPACE, 0);
+        btn0.space_active = true;
+        btn0.long_fired = true;
+    }
+    if (!btn0.stable && b0_prev) {
+        if (btn0.space_active) {
+            ble_keyboard_release();
+            btn0.space_active = false;
+        } else {
+            ui_toggle_splash();
+        }
+    }
+
+    // BTN1: long-press fires Shift+Tab once and releases; short press
+    // cycles screens (or next animation on splash).
+    if (btn_held_long(&btn1)) {
+        ble_keyboard_press(HID_KEY_TAB, HID_MOD_SHIFT);
+        ble_keyboard_release();
+        btn1.long_fired = true;
+    }
+    if (!btn1.stable && b1_prev) {
+        if (!btn1.long_fired) {
+            if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
+            else                                          ui_cycle_screen();
+        }
+    }
+}
+
+#else
+#  error "buttons.cpp: no board-specific implementation for the selected board"
+#endif

--- a/firmware/src/buttons.cpp
+++ b/firmware/src/buttons.cpp
@@ -153,6 +153,16 @@ void buttons_tick(void) {
     }
 }
 
+#elif defined(BOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_2)
+
+// Touch-only navigation on this board. KEY1 is wired to ESP_EN (a pure
+// hardware reset, not exposed as a GPIO), and KEY2 (BOOT/GPIO0) doubles
+// as LCD_RESET — pressing it briefly while the firmware runs would
+// reset the panel, which is too noisy to use for navigation. Touch
+// gestures driven through LVGL cover the same ground.
+void buttons_init(void) {}
+void buttons_tick(void) {}
+
 #else
 #  error "buttons.cpp: no board-specific implementation for the selected board"
 #endif

--- a/firmware/src/buttons.h
+++ b/firmware/src/buttons.h
@@ -1,0 +1,19 @@
+#pragma once
+//
+// Physical button input layer.
+//
+// Each board owns its own mapping of buttons to actions; this header
+// declares the small generic API that main.cpp calls. Implementations
+// live in buttons.cpp behind BOARD_* guards.
+//
+// Action vocabulary (chosen so both boards converge on the same UI
+// behavior):
+//   - voice push-to-talk    — Space held while a button is held
+//   - mode toggle           — Shift+Tab edge-triggered
+//   - cycle screen          — Usage <-> Bluetooth (or, on splash, cycle
+//                             through the pixel-art animations)
+//   - back / splash toggle  — toggle to/from the splash screen
+//
+
+void buttons_init(void);
+void buttons_tick(void);

--- a/firmware/src/display_cfg.h
+++ b/firmware/src/display_cfg.h
@@ -20,8 +20,10 @@
 #  include "boards/board_waveshare_amoled_216.h"
 #elif defined(BOARD_LILYGO_T_DISPLAY_S3)
 #  include "boards/board_lilygo_t_display_s3.h"
+#elif defined(BOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_2)
+#  include "boards/board_waveshare_esp32_s3_touch_lcd_2.h"
 #else
-#  error "No board selected. Define one of: BOARD_WAVESHARE_AMOLED_216, BOARD_LILYGO_T_DISPLAY_S3."
+#  error "No board selected. Define one of: BOARD_WAVESHARE_AMOLED_216, BOARD_LILYGO_T_DISPLAY_S3, BOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_2."
 #endif
 
 // ---- Legacy aliases ----
@@ -55,11 +57,10 @@
 // ---- Global hardware objects (defined in main.cpp) ----
 // `gfx` is the base GFX pointer so callsites stay board-agnostic. The
 // concrete driver type (Arduino_CO5300 vs Arduino_ST7789) is picked in
-// main.cpp behind the BOARD_* macro.
+// main.cpp behind the BOARD_* macro. The touch driver type also varies
+// per board (CST92xx vs CST816) — it stays main.cpp-local since no
+// other compilation unit needs it.
 extern Arduino_GFX *gfx;
-#if BOARD_HAS_TOUCH
-extern TouchDrvCST92xx touch;
-#endif
 #if BOARD_HAS_PMU
 extern XPowersPMU pmu;
 #endif

--- a/firmware/src/display_cfg.h
+++ b/firmware/src/display_cfg.h
@@ -1,37 +1,75 @@
 #pragma once
+//
+// Central board dispatcher.
+//
+// Each supported board defines BOARD_<NAME> via a build flag in
+// platformio.ini, e.g.:
+//      build_flags = -DBOARD_WAVESHARE_AMOLED_216
+//
+// This file selects the matching board header (pinout, dimensions,
+// capability flags), pulls in the third-party driver headers that the
+// selected hardware needs, and declares the shared `gfx` graphics object.
+// Capability flags (BOARD_HAS_TOUCH / BOARD_HAS_PMU / BOARD_HAS_IMU /
+// BOARD_HAS_BATTERY_ADC) gate the optional subsystems in main.cpp,
+// power.cpp, imu.cpp, touch handling, etc.
+//
 
 #include <Arduino_GFX_Library.h>
-#include <TouchDrvCSTXXX.hpp>
-#include <XPowersLib.h>
-#include <SensorQMI8658.hpp>
-#include <Wire.h>
 
-// ---- Display resolution ----
-#define LCD_WIDTH   480
-#define LCD_HEIGHT  480
+#if defined(BOARD_WAVESHARE_AMOLED_216)
+#  include "boards/board_waveshare_amoled_216.h"
+#elif defined(BOARD_LILYGO_T_DISPLAY_S3)
+#  include "boards/board_lilygo_t_display_s3.h"
+#else
+#  error "No board selected. Define one of: BOARD_WAVESHARE_AMOLED_216, BOARD_LILYGO_T_DISPLAY_S3."
+#endif
 
-// ---- QSPI display pins (CO5300) ----
-#define LCD_CS      12
-#define LCD_SCLK    38
-#define LCD_SDIO0   4
-#define LCD_SDIO1   5
-#define LCD_SDIO2   6
-#define LCD_SDIO3   7
-#define LCD_RESET   2
+// ---- Legacy aliases ----
+// The original code referenced LCD_WIDTH / LCD_HEIGHT; keep them as
+// synonyms for the new BOARD_LCD_W / BOARD_LCD_H so we don't churn every
+// callsite when adding boards.
+#define LCD_WIDTH   BOARD_LCD_W
+#define LCD_HEIGHT  BOARD_LCD_H
 
-// ---- Touch pins (CST9220 via I2C) ----
-#define IIC_SDA     15
-#define IIC_SCL     14
-#define TP_INT      11
-#define TP_RST      2    // shared with LCD_RESET
-#define CST9220_ADDR 0x5A
+// ---- I2C bus presence ----
+// Touch, PMU, and IMU all live on the same I2C bus on Waveshare; on
+// LILYGO none of them are present. Reduce to a single capability flag so
+// main.cpp can skip Wire.begin() entirely on boards that don't need it.
+#define BOARD_HAS_I2C \
+    (BOARD_HAS_TOUCH || BOARD_HAS_PMU || BOARD_HAS_IMU)
 
-// ---- PMU (AXP2101 via same I2C) ----
-#define AXP2101_ADDR 0x34
+// ---- Driver headers (only what the selected board needs) ----
+#if BOARD_HAS_I2C
+#  include <Wire.h>
+#endif
+#if BOARD_HAS_TOUCH
+#  include <TouchDrvCSTXXX.hpp>
+#endif
+#if BOARD_HAS_PMU
+#  include <XPowersLib.h>
+#endif
+#if BOARD_HAS_IMU
+#  include <SensorQMI8658.hpp>
+#endif
 
 // ---- Global hardware objects (defined in main.cpp) ----
-extern Arduino_DataBus *bus;
-extern Arduino_CO5300 *gfx;
+// `gfx` is the base GFX pointer so callsites stay board-agnostic. The
+// concrete driver type (Arduino_CO5300 vs Arduino_ST7789) is picked in
+// main.cpp behind the BOARD_* macro.
+extern Arduino_GFX *gfx;
+#if BOARD_HAS_TOUCH
 extern TouchDrvCST92xx touch;
+#endif
+#if BOARD_HAS_PMU
 extern XPowersPMU pmu;
+#endif
+#if BOARD_HAS_IMU
 extern SensorQMI8658 imu;
+#endif
+
+// ---- Board-level helpers (implemented in main.cpp / power.cpp) ----
+// Set panel brightness 0..255. On AMOLED boards this drives the CO5300
+// DCS brightness command; on backlit LCDs it maps to the backlight PWM
+// (or simply ON/OFF if PWM isn't wired up). No-op on boards without
+// brightness control.
+void board_set_brightness(uint8_t level);

--- a/firmware/src/imu.cpp
+++ b/firmware/src/imu.cpp
@@ -2,32 +2,32 @@
 #include "display_cfg.h"
 #include <Arduino.h>
 
-// Poll and hysteresis timing
-#define IMU_POLL_MS       100    // read accel at ~10 Hz
-#define STABLE_TIME_MS    300    // orientation must be stable this long before rotating
-#define TILT_THRESHOLD    0.5f   // ~30 degrees from axis (sin(30) ~ 0.5)
+#if BOARD_HAS_IMU
 
-static uint8_t  current_rotation = 0;
-static uint8_t  candidate_rotation = 0;
+// Auto-rotation from the QMI8658 accelerometer's gravity vector. Active
+// only on boards that physically have an IMU; everywhere else the
+// rotation is fixed at BOARD_FIXED_ROTATION and we don't even compile
+// the polling code.
+
+#define IMU_POLL_MS       100    // ~10 Hz accel polling
+#define STABLE_TIME_MS    300    // hold the new orientation for this long
+#define TILT_THRESHOLD    0.5f   // ~30 deg from axis (sin(30) ≈ 0.5)
+
+static uint8_t  current_rotation = BOARD_FIXED_ROTATION;
+static uint8_t  candidate_rotation = BOARD_FIXED_ROTATION;
 static uint32_t candidate_since = 0;
 static uint32_t last_poll_ms = 0;
 static bool     imu_ok = false;
 
-// Determine target rotation from accelerometer gravity vector.
-// Returns 0-3 or 255 if ambiguous (e.g. face-up/face-down).
 static uint8_t accel_to_rotation(float ax, float ay) {
     float abs_ax = fabsf(ax);
     float abs_ay = fabsf(ay);
 
-    if (abs_ax < TILT_THRESHOLD && abs_ay < TILT_THRESHOLD) {
-        return 255;  // ambiguous, keep current
-    }
+    // Ambiguous when laid flat — keep the current orientation.
+    if (abs_ax < TILT_THRESHOLD && abs_ay < TILT_THRESHOLD) return 255;
 
-    if (abs_ay > abs_ax) {
-        return (ay > 0) ? 3 : 1;
-    } else {
-        return (ax > 0) ? 0 : 2;
-    }
+    if (abs_ay > abs_ax) return (ay > 0) ? 3 : 1;
+    else                 return (ax > 0) ? 0 : 2;
 }
 
 void imu_init(void) {
@@ -71,6 +71,14 @@ void imu_tick(void) {
     }
 }
 
-uint8_t imu_get_rotation(void) {
-    return current_rotation;
-}
+uint8_t imu_get_rotation(void) { return current_rotation; }
+
+#else
+
+// No IMU on this board — rotation is a compile-time constant pulled from
+// the board header, and the tick is a no-op.
+void    imu_init(void)         { Serial.println("imu: not present on this board"); }
+void    imu_tick(void)         {}
+uint8_t imu_get_rotation(void) { return BOARD_FIXED_ROTATION; }
+
+#endif

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -30,7 +30,6 @@ Arduino_GFX *gfx = amoled;
 
 void board_set_brightness(uint8_t level) { amoled->setBrightness(level); }
 
-TouchDrvCST92xx touch;
 XPowersPMU      pmu;
 SensorQMI8658   imu;
 
@@ -55,6 +54,24 @@ void board_set_brightness(uint8_t level) {
     digitalWrite(LCD_BL, level > 0 ? HIGH : LOW);
 }
 
+#elif defined(BOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_2)
+
+// ST7789T3 over standard 4-wire SPI. Standard 240x320 panel, no column
+// offset. LCD_RESET is shared with GPIO0/BOOT/STRAP — gfx->begin()
+// briefly drives it low (panel reset), which is fine because the reset
+// pulse happens before anything else uses the pin.
+static Arduino_DataBus *bus = new Arduino_ESP32SPI(
+    LCD_DC, LCD_CS, LCD_SCLK, LCD_MOSI, LCD_MISO);
+static Arduino_ST7789 *st7789 = new Arduino_ST7789(
+    bus, LCD_RESET, BOARD_FIXED_ROTATION,
+    true /* IPS */, BOARD_LCD_W, BOARD_LCD_H,
+    LCD_COL_OFFSET, LCD_ROW_OFFSET, LCD_COL_OFFSET, LCD_ROW_OFFSET);
+Arduino_GFX *gfx = st7789;
+
+void board_set_brightness(uint8_t level) {
+    digitalWrite(LCD_BL, level > 0 ? HIGH : LOW);
+}
+
 #endif
 
 // ============================================================
@@ -63,8 +80,12 @@ void board_set_brightness(uint8_t level) {
 
 static UsageData usage = {};
 
-// ---- Touch (Waveshare only) ----
+// ---- Touch ----
+// The concrete driver class differs per board (CST92xx vs CST816), so
+// each board header defines BOARD_TOUCH_CLASS and we instantiate it
+// here as a file-local object. No other compilation unit needs it.
 #if BOARD_HAS_TOUCH
+static BOARD_TOUCH_CLASS touch;
 static volatile bool     touch_pressed = false;
 static volatile uint16_t touch_x = 0;
 static volatile uint16_t touch_y = 0;
@@ -275,6 +296,11 @@ void setup(void) {
     digitalWrite(LCD_BL, HIGH);
     pinMode(LCD_RD, OUTPUT);
     digitalWrite(LCD_RD, HIGH);
+#elif defined(BOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_2)
+    // Drive the backlight high before the panel comes up so the first
+    // frame isn't a black flash. Reset is handled inside gfx->begin().
+    pinMode(LCD_BL, OUTPUT);
+    digitalWrite(LCD_BL, HIGH);
 #endif
 
 #if BOARD_HAS_I2C
@@ -291,12 +317,18 @@ void setup(void) {
 
 #if BOARD_HAS_TOUCH
     touch.setPins(TP_RST, TP_INT);
-    if (!touch.begin(Wire, CST9220_ADDR, IIC_SDA, IIC_SCL)) {
+    if (!touch.begin(Wire, BOARD_TOUCH_ADDR, IIC_SDA, IIC_SCL)) {
         Serial.println("Touch init failed");
     } else {
         touch.setMaxCoordinates(BOARD_LCD_W, BOARD_LCD_H);
+        // The CST9220 on the Waveshare AMOLED needs its axes swapped +
+        // mirrored to match the panel; the CST816D on the Touch-LCD-2
+        // already reports coordinates aligned to the ST7789, so leave
+        // those transforms off there.
+#  if defined(BOARD_WAVESHARE_AMOLED_216)
         touch.setSwapXY(true);
         touch.setMirrorXY(true, false);
+#  endif
         attachInterrupt(TP_INT, touch_isr, FALLING);
         Serial.println("Touch init OK");
     }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -9,27 +9,62 @@
 #include "imu.h"
 #include "splash.h"
 #include "usage_rate.h"
+#include "buttons.h"
 
-// Physical buttons (global, screen-independent):
-//   BTN_BACK   (GPIO 0)  — left,  send Space (Claude Code voice mode push-to-talk)
-//   BTN_FWD    (GPIO 18) — right, send Shift+Tab (Claude Code mode toggle)
-//   AXP PWR    (PMU)     — middle, cycle screens; on splash, cycle animations
-#define BTN_BACK 0
-#define BTN_FWD  18
+// ============================================================
+// Board-specific display driver instantiation
+// ============================================================
+//
+// Each board wires up `gfx` (Arduino_GFX base pointer) and provides a
+// `board_set_brightness(level)` helper used during the rotation flash.
+// Everything below this section is board-agnostic.
 
-// ---- Hardware objects ----
-Arduino_DataBus *bus = new Arduino_ESP32QSPI(
+#if defined(BOARD_WAVESHARE_AMOLED_216)
+
+static Arduino_DataBus  *bus      = new Arduino_ESP32QSPI(
     LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
-Arduino_CO5300 *gfx = new Arduino_CO5300(
-    bus, LCD_RESET, 0 /* rotation */,
-    LCD_WIDTH, LCD_HEIGHT, 0, 0, 0, 0);
+static Arduino_CO5300   *amoled   = new Arduino_CO5300(
+    bus, LCD_RESET, 0 /* rotation; we rotate in software */,
+    BOARD_LCD_W, BOARD_LCD_H, 0, 0, 0, 0);
+Arduino_GFX *gfx = amoled;
+
+void board_set_brightness(uint8_t level) { amoled->setBrightness(level); }
+
 TouchDrvCST92xx touch;
-XPowersPMU pmu;
-SensorQMI8658 imu;
+XPowersPMU      pmu;
+SensorQMI8658   imu;
+
+#elif defined(BOARD_LILYGO_T_DISPLAY_S3)
+
+// 8-bit i80 parallel bus + ST7789. The ST7789 panel internally is 240x320
+// but only 170 columns are wired out, so the column window starts at
+// x=LCD_COL_OFFSET.
+static Arduino_DataBus *bus = new Arduino_ESP32LCD8(
+    LCD_DC, LCD_CS, LCD_WR, LCD_RD,
+    LCD_D0, LCD_D1, LCD_D2, LCD_D3,
+    LCD_D4, LCD_D5, LCD_D6, LCD_D7);
+static Arduino_ST7789 *st7789 = new Arduino_ST7789(
+    bus, LCD_RESET, BOARD_FIXED_ROTATION,
+    true /* IPS */, BOARD_LCD_W, BOARD_LCD_H,
+    LCD_COL_OFFSET, LCD_ROW_OFFSET, LCD_COL_OFFSET, LCD_ROW_OFFSET);
+Arduino_GFX *gfx = st7789;
+
+// Backlight is a plain GPIO on this board. Map [0..0] to OFF, anything
+// else to ON. A future change could put the pin on LEDC for true PWM.
+void board_set_brightness(uint8_t level) {
+    digitalWrite(LCD_BL, level > 0 ? HIGH : LOW);
+}
+
+#endif
+
+// ============================================================
+// LVGL plumbing
+// ============================================================
 
 static UsageData usage = {};
 
-// ---- Touch interrupt + shared state ----
+// ---- Touch (Waveshare only) ----
+#if BOARD_HAS_TOUCH
 static volatile bool     touch_pressed = false;
 static volatile uint16_t touch_x = 0;
 static volatile uint16_t touch_y = 0;
@@ -39,7 +74,7 @@ static void IRAM_ATTR touch_isr(void) {
     touch_data_ready = true;
 }
 
-static void touch_read() {
+static void touch_read(void) {
     if (!touch_data_ready) return;
     touch_data_ready = false;
 
@@ -54,96 +89,6 @@ static void touch_read() {
     }
 }
 
-// ---- LVGL draw buffers (PSRAM-backed, partial render) ----
-#define BUF_LINES 40
-static uint16_t *buf1 = nullptr;
-static uint16_t *buf2 = nullptr;
-// rot_buf for strip rotation — max size is 480×480 (full invalidation case)
-// but typical partial strips are much smaller
-static uint16_t *rot_buf = nullptr;
-
-// LVGL tick callback
-static uint32_t my_tick(void) {
-    return millis();
-}
-
-// Rotate a w×h strip and compute destination coordinates on the 480×480 display.
-// src pixels are in row-major order for the rectangle (sx, sy, w, h).
-// Output goes to rot_buf in row-major order for the destination rectangle.
-static void rotate_strip(const uint16_t *src, int32_t w, int32_t h,
-                         int32_t sx, int32_t sy, uint8_t r,
-                         int32_t *dx, int32_t *dy, int32_t *dw, int32_t *dh) {
-    const int S = LCD_WIDTH;  // 480
-
-    switch (r) {
-    case 1: { // 90° CW: (x,y) -> (S-1-y, x)
-        *dw = h; *dh = w;
-        *dx = S - sy - h;
-        *dy = sx;
-        for (int32_t y = 0; y < h; y++) {
-            for (int32_t x = 0; x < w; x++) {
-                // src(x,y) -> dst(h-1-y, x)
-                rot_buf[x * h + (h - 1 - y)] = src[y * w + x];
-            }
-        }
-        break;
-    }
-    case 2: { // 180°: (x,y) -> (S-1-x, S-1-y)
-        *dw = w; *dh = h;
-        *dx = S - sx - w;
-        *dy = S - sy - h;
-        for (int32_t y = 0; y < h; y++) {
-            for (int32_t x = 0; x < w; x++) {
-                rot_buf[(h - 1 - y) * w + (w - 1 - x)] = src[y * w + x];
-            }
-        }
-        break;
-    }
-    case 3: { // 270° CW: (x,y) -> (y, S-1-x)
-        *dw = h; *dh = w;
-        *dx = sy;
-        *dy = S - sx - w;
-        for (int32_t y = 0; y < h; y++) {
-            for (int32_t x = 0; x < w; x++) {
-                // src(x,y) -> dst(y, w-1-x)
-                rot_buf[(w - 1 - x) * h + y] = src[y * w + x];
-            }
-        }
-        break;
-    }
-    default:
-        *dx = sx; *dy = sy; *dw = w; *dh = h;
-        break;
-    }
-}
-
-// LVGL flush callback — rotates partial strips and writes to display
-static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
-    int32_t w = area->x2 - area->x1 + 1;
-    int32_t h = area->y2 - area->y1 + 1;
-    uint16_t *src = (uint16_t*)px_map;
-    uint8_t r = imu_get_rotation();
-
-    if (r == 0) {
-        gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
-    } else {
-        int32_t dx, dy, dw, dh;
-        rotate_strip(src, w, h, area->x1, area->y1, r, &dx, &dy, &dw, &dh);
-        gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
-    }
-    lv_display_flush_ready(disp);
-}
-
-// CO5300 requires even-aligned flush regions
-static void rounder_cb(lv_event_t* e) {
-    lv_area_t *area = (lv_area_t*)lv_event_get_param(e);
-    area->x1 = area->x1 & ~1;
-    area->y1 = area->y1 & ~1;
-    area->x2 = area->x2 | 1;
-    area->y2 = area->y2 | 1;
-}
-
-// LVGL touch callback
 static void my_touch_cb(lv_indev_t* indev, lv_indev_data_t* data) {
     if (touch_pressed) {
         data->point.x = touch_x;
@@ -153,8 +98,97 @@ static void my_touch_cb(lv_indev_t* indev, lv_indev_data_t* data) {
         data->state = LV_INDEV_STATE_RELEASED;
     }
 }
+#endif // BOARD_HAS_TOUCH
 
-// Parse a JSON line into UsageData
+// ---- LVGL draw buffers (PSRAM-backed, partial render) ----
+// Use the larger dimension so the buffer also holds rotated strips: on
+// the Waveshare we rotate strips in software, so a BOARD_LCD_W-wide strip
+// could end up BOARD_LCD_W tall after a 90° rotation.
+#define BUF_LINES 40
+#define BUF_STRIDE  ((BOARD_LCD_W > BOARD_LCD_H) ? BOARD_LCD_W : BOARD_LCD_H)
+static uint16_t *buf1 = nullptr;
+static uint16_t *buf2 = nullptr;
+#if BOARD_HAS_IMU
+static uint16_t *rot_buf = nullptr;   // only the software-rotation path needs this
+#endif
+
+static uint32_t my_tick(void) { return millis(); }
+
+#if BOARD_HAS_IMU
+// CO5300 cannot exchange rows/columns in hardware — its MADCTL only does
+// axis flips — so when the IMU reports a 90°/180°/270° orientation we
+// rotate each LVGL strip in software before pushing pixels.
+static void rotate_strip(const uint16_t *src, int32_t w, int32_t h,
+                         int32_t sx, int32_t sy, uint8_t r,
+                         int32_t *dx, int32_t *dy, int32_t *dw, int32_t *dh) {
+    const int S = BOARD_LCD_W;   // square panel: W == H
+
+    switch (r) {
+    case 1: // 90° CW
+        *dw = h; *dh = w;
+        *dx = S - sy - h;
+        *dy = sx;
+        for (int32_t y = 0; y < h; y++)
+            for (int32_t x = 0; x < w; x++)
+                rot_buf[x * h + (h - 1 - y)] = src[y * w + x];
+        break;
+    case 2: // 180°
+        *dw = w; *dh = h;
+        *dx = S - sx - w;
+        *dy = S - sy - h;
+        for (int32_t y = 0; y < h; y++)
+            for (int32_t x = 0; x < w; x++)
+                rot_buf[(h - 1 - y) * w + (w - 1 - x)] = src[y * w + x];
+        break;
+    case 3: // 270° CW
+        *dw = h; *dh = w;
+        *dx = sy;
+        *dy = S - sx - w;
+        for (int32_t y = 0; y < h; y++)
+            for (int32_t x = 0; x < w; x++)
+                rot_buf[(w - 1 - x) * h + y] = src[y * w + x];
+        break;
+    default:
+        *dx = sx; *dy = sy; *dw = w; *dh = h;
+        break;
+    }
+}
+#endif // BOARD_HAS_IMU
+
+static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
+    int32_t w = area->x2 - area->x1 + 1;
+    int32_t h = area->y2 - area->y1 + 1;
+    uint16_t *src = (uint16_t*)px_map;
+
+#if BOARD_HAS_IMU
+    uint8_t r = imu_get_rotation();
+    if (r != 0) {
+        int32_t dx, dy, dw, dh;
+        rotate_strip(src, w, h, area->x1, area->y1, r, &dx, &dy, &dw, &dh);
+        gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
+        lv_display_flush_ready(disp);
+        return;
+    }
+#endif
+    gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
+    lv_display_flush_ready(disp);
+}
+
+#if BOARD_LCD_IS_AMOLED
+// CO5300 requires even-aligned flush regions; ST7789 doesn't care.
+static void rounder_cb(lv_event_t* e) {
+    lv_area_t *area = (lv_area_t*)lv_event_get_param(e);
+    area->x1 = area->x1 & ~1;
+    area->y1 = area->y1 & ~1;
+    area->x2 = area->x2 | 1;
+    area->y2 = area->y2 | 1;
+}
+#endif
+
+// ============================================================
+// JSON / serial command handling
+// ============================================================
+
 static bool parse_json(const char* json, UsageData* out) {
     JsonDocument doc;
     DeserializationError err = deserializeJson(doc, json);
@@ -173,13 +207,12 @@ static bool parse_json(const char* json, UsageData* out) {
     return true;
 }
 
-// Serial command buffer
 #define CMD_BUF_SIZE 64
 static char cmd_buf[CMD_BUF_SIZE];
 static int cmd_pos = 0;
 
-static void send_screenshot() {
-    const uint32_t w = LCD_WIDTH, h = LCD_HEIGHT;
+static void send_screenshot(void) {
+    const uint32_t w = BOARD_LCD_W, h = BOARD_LCD_H;
     const uint32_t row_bytes = w * 2;
     const uint32_t buf_size = row_bytes * h;
     uint8_t* sbuf = (uint8_t*)heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
@@ -208,14 +241,12 @@ static void send_screenshot() {
     heap_caps_free(sbuf);
 }
 
-static void check_serial_cmd() {
+static void check_serial_cmd(void) {
     while (Serial.available()) {
         char c = Serial.read();
         if (c == '\n' || c == '\r') {
             cmd_buf[cmd_pos] = '\0';
-            if (strcmp(cmd_buf, "screenshot") == 0) {
-                send_screenshot();
-            }
+            if (strcmp(cmd_buf, "screenshot") == 0) send_screenshot();
             cmd_pos = 0;
         } else if (cmd_pos < CMD_BUF_SIZE - 1) {
             cmd_buf[cmd_pos++] = c;
@@ -223,75 +254,90 @@ static void check_serial_cmd() {
     }
 }
 
-void setup() {
+// ============================================================
+// setup / loop
+// ============================================================
+
+void setup(void) {
     Serial.begin(115200);
     delay(300);
     Serial.println("{\"ready\":true}");
+    Serial.printf("Board: %s\n", BOARD_NAME);
+    Serial.printf("Display: %dx%d %s\n", BOARD_LCD_W, BOARD_LCD_H,
+                  BOARD_LCD_IS_AMOLED ? "AMOLED (CO5300)" : "LCD (ST7789)");
 
-    // Init I2C (shared by touch + PMU)
+#if defined(BOARD_LILYGO_T_DISPLAY_S3)
+    // Bring the panel power rail up first so the ST7789 has VCC when we
+    // talk to it. Then drive the backlight high so the user sees pixels.
+    pinMode(LCD_POWER_ON, OUTPUT);
+    digitalWrite(LCD_POWER_ON, HIGH);
+    pinMode(LCD_BL, OUTPUT);
+    digitalWrite(LCD_BL, HIGH);
+    pinMode(LCD_RD, OUTPUT);
+    digitalWrite(LCD_RD, HIGH);
+#endif
+
+#if BOARD_HAS_I2C
     Wire.begin(IIC_SDA, IIC_SCL);
+#endif
 
-    // Init display
     gfx->begin();
     gfx->fillScreen(0x0000);
-    gfx->setBrightness(200);
+    board_set_brightness(200);
+    Serial.println("Display init OK");
 
-    // Init PMU
     power_init();
-
-    // Init IMU (accelerometer for auto-rotation)
     imu_init();
 
-    // Init touch
+#if BOARD_HAS_TOUCH
     touch.setPins(TP_RST, TP_INT);
     if (!touch.begin(Wire, CST9220_ADDR, IIC_SDA, IIC_SCL)) {
         Serial.println("Touch init failed");
     } else {
-        touch.setMaxCoordinates(LCD_WIDTH, LCD_HEIGHT);
+        touch.setMaxCoordinates(BOARD_LCD_W, BOARD_LCD_H);
         touch.setSwapXY(true);
         touch.setMirrorXY(true, false);
         attachInterrupt(TP_INT, touch_isr, FALLING);
         Serial.println("Touch init OK");
     }
+#else
+    Serial.println("Touch: not present on this board");
+#endif
 
-    // Init LVGL
     lv_init();
     lv_tick_set_cb(my_tick);
 
-    // Allocate PSRAM-backed partial render buffers
-    buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-    buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-    // rot_buf needs to hold the largest possible strip after rotation
-    // A 480×40 strip rotated 90° becomes 40×480, same pixel count
-    rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    // PSRAM-backed partial render buffers. Sized to the wider edge so
+    // rotated strips fit too (Waveshare 480×40 rotates to 40×480).
+    const size_t buf_pixels = BUF_STRIDE * BUF_LINES;
+    buf1 = (uint16_t*)heap_caps_malloc(buf_pixels * 2, MALLOC_CAP_SPIRAM);
+    buf2 = (uint16_t*)heap_caps_malloc(buf_pixels * 2, MALLOC_CAP_SPIRAM);
+#if BOARD_HAS_IMU
+    rot_buf = (uint16_t*)heap_caps_malloc(buf_pixels * 2, MALLOC_CAP_SPIRAM);
+#endif
 
-    lv_display_t* disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
+    lv_display_t* disp = lv_display_create(BOARD_LCD_W, BOARD_LCD_H);
     lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
     lv_display_set_flush_cb(disp, my_flush_cb);
-    lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
+    lv_display_set_buffers(disp, buf1, buf2, buf_pixels * 2,
                            LV_DISPLAY_RENDER_MODE_PARTIAL);
 
-    // CO5300 even-alignment rounder
+#if BOARD_LCD_IS_AMOLED
     lv_display_add_event_cb(disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, NULL);
+#endif
 
+#if BOARD_HAS_TOUCH
     lv_indev_t* indev = lv_indev_create();
     lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
     lv_indev_set_read_cb(indev, my_touch_cb);
+#endif
 
-    // Init BLE data channel
     ble_init();
+    buttons_init();
+    Serial.println("Buttons init OK");
 
-    // Physical buttons: back (GPIO 0) and forward (GPIO 18)
-    pinMode(BTN_BACK, INPUT_PULLUP);
-    pinMode(BTN_FWD,  INPUT_PULLUP);
-
-    // Build dashboard
     ui_init();
-
-    // Show initial BLE status on Bluetooth screen
     ui_update_ble_status(ble_get_state(), ble_get_device_name(), ble_get_mac_address());
-
-    // Show initial battery status
     ui_update_battery(power_battery_pct(), power_is_charging());
 
     ui_show_screen(SCREEN_SPLASH);
@@ -301,18 +347,18 @@ void setup() {
 
 static ble_state_t last_ble_state = BLE_STATE_INIT;
 
-// Brightness ramp state for rotation transition
-// On rotation change we blank the panel, force a full LVGL redraw at the
-// new orientation, then ramp brightness back up over ~125ms so the
-// transition reads as deliberate instead of as a glitch.
+#if BOARD_HAS_IMU
+// On rotation change the panel is blanked, LVGL is forced to redraw at
+// the new orientation, then the brightness is ramped back up over ~125ms
+// so the transition reads as deliberate instead of a glitch.
 static void handle_rotation_change(void) {
     static uint8_t last_rotation = 0;
-    static uint8_t  ramp_step = 0;  // 0=idle, 1-4=ramping
+    static uint8_t  ramp_step = 0;   // 0=idle, 1-4=ramping
     static uint32_t ramp_last = 0;
 
     uint8_t rot = imu_get_rotation();
     if (rot != last_rotation) {
-        gfx->setBrightness(0);
+        board_set_brightness(0);
         last_rotation = rot;
         lv_obj_invalidate(lv_screen_active());
         ramp_step = 1;
@@ -325,56 +371,34 @@ static void handle_rotation_change(void) {
     ramp_last = now;
 
     static const uint8_t levels[] = {60, 120, 170, 200};
-    gfx->setBrightness(levels[ramp_step - 1]);
+    board_set_brightness(levels[ramp_step - 1]);
     if (ramp_step >= 4) ramp_step = 0;
     else                ramp_step++;
 }
+#endif
 
-void loop() {
+void loop(void) {
+#if BOARD_HAS_TOUCH
     touch_read();
+#endif
     lv_timer_handler();
     ui_tick_anim();
     ble_tick();
     power_tick();
     imu_tick();
     splash_tick();
+    buttons_tick();
 
-    // Three-button input (global, screen-independent):
-    //   LEFT  (GPIO 0)  → Space (voice-mode push-to-talk; press & release tracked)
-    //   RIGHT (GPIO 18) → Shift+Tab (Claude Code mode toggle)
-    //   PWR   (AXP)     → cycle screens; on splash, cycle animations
-    {
-        static bool back_was = false, fwd_was = false;
-        bool back_now = (digitalRead(BTN_BACK) == LOW);
-        bool fwd_now  = (digitalRead(BTN_FWD)  == LOW);
-
-        if (back_now != back_was) {
-            if (back_now) ble_keyboard_press(0x2C, 0);  // HID Space, no mods
-            else          ble_keyboard_release();
-            back_was = back_now;
-        }
-        if (fwd_now != fwd_was) {
-            if (fwd_now) ble_keyboard_press(0x2B, 0x02);  // HID Tab + LEFT_SHIFT
-            else         ble_keyboard_release();
-            fwd_was = fwd_now;
-        }
-
-        if (power_pwr_pressed()) {
-            if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
-            else                                          ui_cycle_screen();
-        }
-    }
-
+#if BOARD_HAS_IMU
     handle_rotation_change();
+#endif
 
-    // Update BLE status on screen when state changes
     ble_state_t bs = ble_get_state();
     if (bs != last_ble_state) {
         last_ble_state = bs;
         ui_update_ble_status(bs, ble_get_device_name(), ble_get_mac_address());
     }
 
-    // Update battery indicator
     static int last_pct = -2;
     static bool last_charging = false;
     int pct = power_battery_pct();
@@ -385,10 +409,8 @@ void loop() {
         ui_update_battery(pct, charging);
     }
 
-    // Check for serial commands (screenshot, etc.)
     check_serial_cmd();
 
-    // Process incoming BLE data
     if (ble_has_data()) {
         if (parse_json(ble_get_data(), &usage)) {
             int g_before = usage_rate_group();
@@ -396,7 +418,7 @@ void loop() {
             int g_after = usage_rate_group();
             if (g_after != g_before) {
                 Serial.printf("usage rate: group %d -> %d (s=%.2f%%)\n",
-                    g_before, g_after, usage.session_pct);
+                              g_before, g_after, usage.session_pct);
                 if (splash_is_active()) splash_pick_for_current_rate();
             }
             ui_update(&usage);

--- a/firmware/src/power.cpp
+++ b/firmware/src/power.cpp
@@ -2,15 +2,21 @@
 #include "display_cfg.h"
 #include <Arduino.h>
 
+#ifndef BAT_CHARGE_DETECT_USB_CDC
+#define BAT_CHARGE_DETECT_USB_CDC 0
+#endif
+
+#if BOARD_HAS_BATTERY_ADC && BAT_CHARGE_DETECT_USB_CDC
+#include <HWCDC.h>
+#endif
+
 // Two paths share this file:
 //   BOARD_HAS_PMU         — AXP2101 over I2C (Waveshare): battery % and
 //                            charging status come straight from the PMU,
 //                            and the PMU's PKEY drives the middle button.
-//   BOARD_HAS_BATTERY_ADC — Plain ADC voltage sense (LILYGO): battery
-//                            percentage stays unknown (-1) until the
-//                            divider ratio is calibrated; we still log
-//                            the raw ADC value at boot so calibration is
-//                            a one-shot exercise.
+//   BOARD_HAS_BATTERY_ADC — Plain ADC voltage sense: battery percentage
+//                            is estimated from LiPo voltage. Boards may
+//                            opt into USB CDC as an external-power hint.
 //
 // Both paths expose the same power_*() API so ui.cpp doesn't care which
 // board it's running on.
@@ -79,22 +85,79 @@ bool power_pwr_pressed(void) {
 #define BAT_POLL_MS       2000
 static uint32_t last_bat_ms = 0;
 static int      cached_raw  = 0;
+static int      cached_pin_mv = 0;
 static float    cached_volt = 0.0f;
+static int      cached_pct = -1;
+static bool     cached_charging = false;
+
+static int voltage_to_percent(float vbat) {
+    if (vbat < 2.50f) {
+        return -1;  // Battery absent or ADC not connected.
+    }
+
+    struct BatteryPoint {
+        float volts;
+        int percent;
+    };
+
+    static const BatteryPoint curve[] = {
+        {3.20f, 0},
+        {3.50f, 5},
+        {3.60f, 10},
+        {3.70f, 20},
+        {3.75f, 35},
+        {3.80f, 50},
+        {3.90f, 65},
+        {4.00f, 80},
+        {4.10f, 90},
+        {4.20f, 100},
+    };
+
+    if (vbat <= curve[0].volts) return curve[0].percent;
+
+    const size_t last = sizeof(curve) / sizeof(curve[0]) - 1;
+    if (vbat >= curve[last].volts) return curve[last].percent;
+
+    for (size_t i = 1; i <= last; ++i) {
+        if (vbat <= curve[i].volts) {
+            float span = curve[i].volts - curve[i - 1].volts;
+            float pos = (vbat - curve[i - 1].volts) / span;
+            return curve[i - 1].percent +
+                   (int)((curve[i].percent - curve[i - 1].percent) * pos + 0.5f);
+        }
+    }
+
+    return -1;
+}
+
+static bool external_power_present(void) {
+#if BAT_CHARGE_DETECT_USB_CDC && defined(ARDUINO_USB_MODE) && ARDUINO_USB_MODE && \
+    defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+    return HWCDC::isPlugged();
+#else
+    return false;
+#endif
+}
 
 static void read_battery(void) {
     cached_raw = analogRead(BAT_ADC_GPIO);
-    // V_pin = raw / max * V_ref; V_bat = V_pin * divider * correction
-    float v_pin = ((float)cached_raw / (float)BAT_ADC_MAX) * BAT_ADC_REF_VOLTAGE;
+    cached_pin_mv = analogReadMilliVolts(BAT_ADC_GPIO);
+    float v_pin = cached_pin_mv > 0
+        ? (float)cached_pin_mv / 1000.0f
+        : ((float)cached_raw / (float)BAT_ADC_MAX) * BAT_ADC_REF_VOLTAGE;
     cached_volt = v_pin * BAT_ADC_DIVIDER_RATIO * BAT_ADC_CORRECTION_FACTOR;
+    cached_pct = voltage_to_percent(cached_volt);
+    cached_charging = external_power_present() && cached_pct >= 0;
 }
 
 void power_init(void) {
     analogReadResolution(12);
+    analogSetPinAttenuation(BAT_ADC_GPIO, ADC_11db);
     pinMode(BAT_ADC_GPIO, INPUT);
     read_battery();
-    Serial.printf("BAT ADC init OK (GPIO%d raw=%d v=%.2fV)\n",
-                  BAT_ADC_GPIO, cached_raw, cached_volt);
-    Serial.println("Battery percent: unknown (ADC un-calibrated)");
+    Serial.printf("BAT ADC init OK (GPIO%d raw=%d pin=%dmV vbat=%.2fV pct=%d usb=%d)\n",
+                  BAT_ADC_GPIO, cached_raw, cached_pin_mv, cached_volt,
+                  cached_pct, cached_charging ? 1 : 0);
 }
 
 void power_tick(void) {
@@ -104,12 +167,8 @@ void power_tick(void) {
     read_battery();
 }
 
-// Returning -1 makes ui_update_battery() show the "no battery / unknown"
-// icon. Once a real divider ratio + voltage-to-percent curve is in hand,
-// drop the conversion in here. Keeping it conservative avoids showing
-// wildly wrong percentages on the dashboard.
-int  power_battery_pct(void) { return -1; }
-bool power_is_charging(void) { return false; }
+int  power_battery_pct(void) { return cached_pct; }
+bool power_is_charging(void) { return cached_charging; }
 bool power_pwr_pressed(void) { return false; }
 
 #else

--- a/firmware/src/power.cpp
+++ b/firmware/src/power.cpp
@@ -2,9 +2,24 @@
 #include "display_cfg.h"
 #include <Arduino.h>
 
-// Poll intervals
+// Two paths share this file:
+//   BOARD_HAS_PMU         — AXP2101 over I2C (Waveshare): battery % and
+//                            charging status come straight from the PMU,
+//                            and the PMU's PKEY drives the middle button.
+//   BOARD_HAS_BATTERY_ADC — Plain ADC voltage sense (LILYGO): battery
+//                            percentage stays unknown (-1) until the
+//                            divider ratio is calibrated; we still log
+//                            the raw ADC value at boot so calibration is
+//                            a one-shot exercise.
+//
+// Both paths expose the same power_*() API so ui.cpp doesn't care which
+// board it's running on.
+
+#if BOARD_HAS_PMU
+
 #define BATTERY_POLL_MS   2000
 #define CHARGING_POLL_MS  500
+#define PWR_POLL_MS       50
 
 static int      cached_pct      = -1;
 static bool     cached_charging = false;
@@ -12,7 +27,6 @@ static bool     pwr_pressed_flag = false;
 static uint32_t last_battery_ms  = 0;
 static uint32_t last_charging_ms = 0;
 static uint32_t last_pwr_ms      = 0;
-#define PWR_POLL_MS 50
 
 void power_init(void) {
     if (!pmu.begin(Wire, AXP2101_ADDR, IIC_SDA, IIC_SCL)) {
@@ -24,7 +38,6 @@ void power_init(void) {
     pmu.enableBattDetection();
     pmu.enableBattVoltageMeasure();
 
-    // Enable PWR button short-press IRQ (mid button for cycling screens)
     pmu.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
     pmu.clearIrqStatus();
     pmu.enableIRQ(XPOWERS_AXP2101_PKEY_SHORT_IRQ);
@@ -46,29 +59,66 @@ void power_tick(void) {
         cached_pct = pmu.getBatteryPercent();
     }
 
-    // Poll PWR button (AXP2101 short-press IRQ)
     if (now - last_pwr_ms >= PWR_POLL_MS) {
         last_pwr_ms = now;
         pmu.getIrqStatus();
-        if (pmu.isPekeyShortPressIrq()) {
-            pwr_pressed_flag = true;
-        }
+        if (pmu.isPekeyShortPressIrq()) pwr_pressed_flag = true;
         pmu.clearIrqStatus();
     }
 }
 
-int power_battery_pct(void) {
-    return cached_pct;
-}
-
-bool power_is_charging(void) {
-    return cached_charging;
-}
-
+int  power_battery_pct(void)   { return cached_pct; }
+bool power_is_charging(void)   { return cached_charging; }
 bool power_pwr_pressed(void) {
-    if (pwr_pressed_flag) {
-        pwr_pressed_flag = false;
-        return true;
-    }
+    if (pwr_pressed_flag) { pwr_pressed_flag = false; return true; }
     return false;
 }
+
+#elif BOARD_HAS_BATTERY_ADC
+
+#define BAT_POLL_MS       2000
+static uint32_t last_bat_ms = 0;
+static int      cached_raw  = 0;
+static float    cached_volt = 0.0f;
+
+static void read_battery(void) {
+    cached_raw = analogRead(BAT_ADC_GPIO);
+    // V_pin = raw / max * V_ref; V_bat = V_pin * divider * correction
+    float v_pin = ((float)cached_raw / (float)BAT_ADC_MAX) * BAT_ADC_REF_VOLTAGE;
+    cached_volt = v_pin * BAT_ADC_DIVIDER_RATIO * BAT_ADC_CORRECTION_FACTOR;
+}
+
+void power_init(void) {
+    analogReadResolution(12);
+    pinMode(BAT_ADC_GPIO, INPUT);
+    read_battery();
+    Serial.printf("BAT ADC init OK (GPIO%d raw=%d v=%.2fV)\n",
+                  BAT_ADC_GPIO, cached_raw, cached_volt);
+    Serial.println("Battery percent: unknown (ADC un-calibrated)");
+}
+
+void power_tick(void) {
+    uint32_t now = millis();
+    if (now - last_bat_ms < BAT_POLL_MS) return;
+    last_bat_ms = now;
+    read_battery();
+}
+
+// Returning -1 makes ui_update_battery() show the "no battery / unknown"
+// icon. Once a real divider ratio + voltage-to-percent curve is in hand,
+// drop the conversion in here. Keeping it conservative avoids showing
+// wildly wrong percentages on the dashboard.
+int  power_battery_pct(void) { return -1; }
+bool power_is_charging(void) { return false; }
+bool power_pwr_pressed(void) { return false; }
+
+#else
+
+// No battery hardware at all — keep the API alive so callers compile.
+void power_init(void)        { Serial.println("power: no battery hardware on this board"); }
+void power_tick(void)        {}
+int  power_battery_pct(void) { return -1; }
+bool power_is_charging(void) { return false; }
+bool power_pwr_pressed(void) { return false; }
+
+#endif

--- a/firmware/src/splash.cpp
+++ b/firmware/src/splash.cpp
@@ -2,13 +2,19 @@
 #include "splash_animations.h"
 #include "theme.h"
 #include "usage_rate.h"
+#include "display_cfg.h"
 #include <Arduino.h>
 #include <string.h>
 #include <esp_heap_caps.h>
 
-// 20x20 grid scaled 24x to fill 480x480
+// 20x20 pixel-art grid. Cell size is chosen at compile time so the
+// canvas always fits within the panel: pick the smallest screen edge,
+// divide by the grid size, and the result is the largest integer scale
+// that still fits. On Waveshare (480x480) that's CELL=24 → 480x480; on
+// LILYGO 170x320 that's CELL=8 → 160x160 (centered).
 #define GRID         20
-#define CELL         24
+#define SPLASH_MIN_EDGE  ((BOARD_LCD_W < BOARD_LCD_H) ? BOARD_LCD_W : BOARD_LCD_H)
+#define CELL         (SPLASH_MIN_EDGE / GRID)
 #define CANVAS_W     (GRID * CELL)
 #define CANVAS_H     (GRID * CELL)
 
@@ -20,7 +26,7 @@ LV_FONT_DECLARE(font_styrene_28);
 static lv_obj_t *splash_container = NULL;
 static lv_obj_t *canvas = NULL;
 static lv_obj_t *label_status = NULL;     // shown only when no animations loaded
-static uint16_t *canvas_buf = NULL;        // 480x480 RGB565 (PSRAM)
+static uint16_t *canvas_buf = NULL;        // CANVAS_W x CANVAS_H RGB565 (PSRAM)
 
 static uint16_t cur_anim = 0;
 static uint16_t cur_frame = 0;
@@ -69,8 +75,11 @@ static void resolve_group_lists(void) {
 }
 
 static void render_frame(const uint8_t *cells, const uint16_t *palette) {
+    // CANVAS_W is a compile-time constant per board but VLAs on the
+    // stack are fine for our two configurations (max 480 entries on
+    // Waveshare). Keep it dynamic so the same code handles both.
+    uint16_t row[CANVAS_W];
     for (int gy = 0; gy < GRID; gy++) {
-        uint16_t row[CANVAS_W];
         for (int gx = 0; gx < GRID; gx++) {
             uint8_t code = cells[gy * GRID + gx];
             uint16_t color = (palette && code < SPLASH_PALETTE_SIZE) ? palette[code] : COL_EMPTY;
@@ -99,7 +108,7 @@ void splash_init(lv_obj_t *parent) {
     }
 
     splash_container = lv_obj_create(parent);
-    lv_obj_set_size(splash_container, 480, 480);
+    lv_obj_set_size(splash_container, BOARD_LCD_W, BOARD_LCD_H);
     lv_obj_set_pos(splash_container, 0, 0);
     lv_obj_set_style_bg_color(splash_container, THEME_BG, 0);
     lv_obj_set_style_bg_opa(splash_container, LV_OPA_COVER, 0);

--- a/firmware/src/splash.h
+++ b/firmware/src/splash.h
@@ -2,8 +2,9 @@
 #include <stdint.h>
 #include <lvgl.h>
 
-// Initialize splash module. Creates the canvas widget inside `parent` and
-// allocates the 480x480 pixel buffer (PSRAM).
+// Initialize splash module. Creates the canvas widget inside `parent`
+// and allocates the pixel buffer in PSRAM. Canvas size is derived from
+// the board's panel dimensions in splash.cpp.
 void splash_init(lv_obj_t *parent);
 
 // Advance animation frame if hold time elapsed. Call from main loop.

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -130,6 +130,12 @@ static void global_click_cb(lv_event_t* e);
 #if BOARD_HAS_TOUCH
 static void ble_reset_click_cb(lv_event_t* e);
 #endif
+// Touch-only nav (no physical buttons): long-press Usage → Bluetooth.
+#if BOARD_HAS_TOUCH && (BOARD_BTN_COUNT == 0) && !BOARD_HAS_PWR_BUTTON
+static void long_press_cycle_cb(lv_event_t* e);
+static bool ignore_click_after_long_press = false;
+static uint32_t ignore_click_since_ms = 0;
+#endif
 
 static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     lv_obj_t* panel = lv_obj_create(parent);
@@ -243,6 +249,9 @@ static void init_usage_screen(lv_obj_t* scr) {
     lv_obj_set_style_pad_all(usage_container, 0, 0);
     lv_obj_clear_flag(usage_container, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_event_cb(usage_container, global_click_cb, LV_EVENT_CLICKED, NULL);
+#if BOARD_HAS_TOUCH && (BOARD_BTN_COUNT == 0) && !BOARD_HAS_PWR_BUTTON
+    lv_obj_add_event_cb(usage_container, long_press_cycle_cb, LV_EVENT_LONG_PRESSED, NULL);
+#endif
 
     lbl_title = lv_label_create(usage_container);
     lv_label_set_text(lbl_title, "Usage");
@@ -274,6 +283,10 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_style_border_width(ble_container, 0, 0);
     lv_obj_set_style_pad_all(ble_container, 0, 0);
     lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_SCROLLABLE);
+#if BOARD_HAS_TOUCH && (BOARD_BTN_COUNT == 0) && !BOARD_HAS_PWR_BUTTON
+    // Tap anywhere on BT screen (outside Reset zone) → back to Usage.
+    lv_obj_add_event_cb(ble_container, global_click_cb, LV_EVENT_CLICKED, NULL);
+#endif
 
     lv_obj_t* lbl_ble_title = lv_label_create(ble_container);
     lv_label_set_text(lbl_ble_title, "Bluetooth");
@@ -295,6 +308,8 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
 
     lbl_ble_status = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_status, "Initializing...");
+    lv_label_set_long_mode(lbl_ble_status, LV_LABEL_LONG_DOT);
+    lv_obj_set_width(lbl_ble_status, UI_CONTENT_W - 2 * UI_PANEL_PAD - UI_BLE_STATUS_X);
     lv_obj_set_style_text_font(lbl_ble_status, UI_FONT_BLE_STATUS, 0);
     lv_obj_set_style_text_color(lbl_ble_status, COL_DIM, 0);
     lv_obj_set_pos(lbl_ble_status, UI_BLE_STATUS_X, 2);
@@ -304,7 +319,7 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     const int ble_text_w = UI_CONTENT_W - 2 * UI_PANEL_PAD;
 
     lbl_ble_device = lv_label_create(p_info);
-    lv_label_set_text(lbl_ble_device, "Device: ---");
+    lv_label_set_text(lbl_ble_device, UI_BLE_DEVICE_PREFIX "---");
     lv_label_set_long_mode(lbl_ble_device, LV_LABEL_LONG_WRAP);
     lv_obj_set_width(lbl_ble_device, ble_text_w);
     lv_obj_set_style_text_font(lbl_ble_device, UI_FONT_BODY, 0);
@@ -312,7 +327,7 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_pos(lbl_ble_device, 0, UI_BLE_DEVICE_Y);
 
     lbl_ble_mac = lv_label_create(p_info);
-    lv_label_set_text(lbl_ble_mac, "Address: ---");
+    lv_label_set_text(lbl_ble_mac, UI_BLE_MAC_PREFIX "---");
     lv_label_set_long_mode(lbl_ble_mac, LV_LABEL_LONG_WRAP);
     lv_obj_set_width(lbl_ble_mac, ble_text_w);
     lv_obj_set_style_text_font(lbl_ble_mac, UI_FONT_BODY, 0);
@@ -341,6 +356,8 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     init_icon_dsc(&icon_trash_dsc, ICON_TRASH2_W, ICON_TRASH2_H, icon_trash2_data);
     lv_obj_t* trash_img = lv_image_create(reset_zone);
     lv_image_set_src(trash_img, &icon_trash_dsc);
+    lv_obj_set_size(trash_img, UI_ICON_W, UI_ICON_H);
+    lv_image_set_inner_align(trash_img, LV_IMAGE_ALIGN_STRETCH);
 
     lv_obj_t* reset_lbl = lv_label_create(reset_zone);
     lv_label_set_text(reset_lbl, "Reset Bluetooth");
@@ -407,6 +424,8 @@ void ui_init(void) {
     if (UI_SHOW_LOGO) {
         logo_img = lv_image_create(scr);
         lv_image_set_src(logo_img, &logo_dsc);
+        lv_obj_set_size(logo_img, UI_LOGO_W, UI_LOGO_H);
+        lv_image_set_inner_align(logo_img, LV_IMAGE_ALIGN_STRETCH);
         lv_obj_set_pos(logo_img, UI_LOGO_X, UI_LOGO_Y);
     } else {
         logo_img = NULL;
@@ -418,9 +437,10 @@ void ui_init(void) {
     // source. Without this LVGL keeps the bounding box at the source
     // dimensions (48x48), so any positioning past the right edge of a
     // compact panel clips the visible icon.
-    lv_obj_set_size(battery_img, UI_ICON_W, UI_ICON_H);
+    lv_obj_set_size(battery_img, UI_BATTERY_ICON_W, UI_BATTERY_ICON_H);
     lv_image_set_inner_align(battery_img, LV_IMAGE_ALIGN_STRETCH);
     lv_obj_align(battery_img, LV_ALIGN_TOP_RIGHT, -UI_MARGIN, UI_TITLE_Y);
+    lv_obj_move_foreground(battery_img);
 }
 
 void ui_update(const UsageData* data) {
@@ -483,7 +503,23 @@ static void apply_battery_visibility(void) {
 // they have their own event callback, e.g. the Reset Bluetooth zone).
 static void global_click_cb(lv_event_t* e) {
     (void)e;
+#if BOARD_HAS_TOUCH && (BOARD_BTN_COUNT == 0) && !BOARD_HAS_PWR_BUTTON
+    if (ignore_click_after_long_press) {
+        uint32_t elapsed = lv_tick_get() - ignore_click_since_ms;
+        ignore_click_after_long_press = false;
+        if (elapsed < 1000 && ui_get_current_screen() == SCREEN_BLUETOOTH) {
+            return;
+        }
+    }
+
+    // Touch-only board: tap on BT → Usage; tap elsewhere → toggle splash.
+    if (ui_get_current_screen() == SCREEN_BLUETOOTH) {
+        ui_show_screen(SCREEN_USAGE);
+        return;
+    }
+#else
     if (ui_get_current_screen() == SCREEN_BLUETOOTH) return;
+#endif
     ui_toggle_splash();
 }
 
@@ -491,6 +527,18 @@ static void global_click_cb(lv_event_t* e) {
 static void ble_reset_click_cb(lv_event_t* e) {
     (void)e;
     ble_clear_bonds();
+}
+#endif
+
+#if BOARD_HAS_TOUCH && (BOARD_BTN_COUNT == 0) && !BOARD_HAS_PWR_BUTTON
+// Long-press on Usage navigates to Bluetooth on touch-only boards.
+static void long_press_cycle_cb(lv_event_t* e) {
+    (void)e;
+    if (ui_get_current_screen() == SCREEN_USAGE) {
+        ignore_click_after_long_press = true;
+        ignore_click_since_ms = lv_tick_get();
+        ui_cycle_screen();
+    }
 }
 #endif
 
@@ -514,6 +562,7 @@ void ui_show_screen(screen_t screen) {
     if (screen != SCREEN_SPLASH) prev_non_splash_screen = screen;
     current_screen = screen;
     apply_battery_visibility();
+    if (battery_img) lv_obj_move_foreground(battery_img);
 }
 
 void ui_cycle_screen(void) {
@@ -550,12 +599,12 @@ void ui_update_ble_status(ble_state_t state, const char* name, const char* mac) 
 
     if (name) {
         static char nbuf[48];
-        snprintf(nbuf, sizeof(nbuf), "Device: %s", name);
+        snprintf(nbuf, sizeof(nbuf), UI_BLE_DEVICE_PREFIX "%s", name);
         lv_label_set_text(lbl_ble_device, nbuf);
     }
     if (mac) {
         static char mbuf[48];
-        snprintf(mbuf, sizeof(mbuf), "Address: %s", mac);
+        snprintf(mbuf, sizeof(mbuf), UI_BLE_MAC_PREFIX "%s", mac);
         lv_label_set_text(lbl_ble_mac, mbuf);
     }
 }

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -1,20 +1,13 @@
 #include "ui.h"
 #include "splash.h"
+#include "ui_layout.h"
 #include <lvgl.h>
 #include "logo.h"
 #include "icons.h"
 #include "display_cfg.h"
-
-// Custom fonts (scaled for 314 PPI, ~1.9x from original 165 PPI)
-LV_FONT_DECLARE(font_tiempos_56);
-LV_FONT_DECLARE(font_styrene_48);
-LV_FONT_DECLARE(font_styrene_28);
-LV_FONT_DECLARE(font_styrene_24);
-LV_FONT_DECLARE(font_styrene_20);
-LV_FONT_DECLARE(font_mono_32);
-
-// Anthropic brand palette — design tokens live in theme.h
 #include "theme.h"
+
+// Color tokens — design palette lives in theme.h.
 #define COL_BG        THEME_BG
 #define COL_PANEL     THEME_PANEL
 #define COL_TEXT      THEME_TEXT
@@ -25,13 +18,10 @@ LV_FONT_DECLARE(font_mono_32);
 #define COL_RED       THEME_RED
 #define COL_BAR_BG    THEME_BAR_BG
 
-// ---- Layout constants for 480x480 (scaled for 2.16" high-DPI + rounded corners) ----
-#define SCR_W         480
-#define SCR_H         480
-#define MARGIN        20    // wider margin for rounded display corners
-#define TITLE_Y       30
-#define CONTENT_Y     100
-#define CONTENT_W     (SCR_W - 2 * MARGIN)   // 440
+// Screen dimensions and layout tokens come from ui_layout.h, which picks
+// values appropriate for the current BOARD_*.
+#define SCR_W         BOARD_LCD_W
+#define SCR_H         BOARD_LCD_H
 
 // ---- Usage screen widgets ----
 static lv_obj_t* usage_container;
@@ -52,16 +42,15 @@ static lv_obj_t* lbl_ble_status;
 static lv_obj_t* lbl_ble_device;
 static lv_obj_t* lbl_ble_mac;
 
-// ---- Battery indicator (shared, on top) ----
+// ---- Shared overlay widgets ----
 static lv_obj_t* battery_img;
 static lv_obj_t* logo_img;
 static lv_image_dsc_t battery_dscs[5];  // empty, low, medium, full, charging
-
-// ---- Shared ----
 static lv_image_dsc_t logo_dsc;
+
 static screen_t current_screen = SCREEN_USAGE;
 
-// Animation state
+// ---- Spinner / "thinking" animation ----
 static uint32_t anim_last_ms = 0;
 static uint8_t anim_spinner_idx = 0;
 static uint8_t anim_phase = 0;
@@ -138,7 +127,9 @@ static void format_reset_time(int mins, char* buf, size_t len) {
 
 // Forward decls — callbacks defined near ui_show_screen below
 static void global_click_cb(lv_event_t* e);
+#if BOARD_HAS_TOUCH
 static void ble_reset_click_cb(lv_event_t* e);
+#endif
 
 static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     lv_obj_t* panel = lv_obj_create(parent);
@@ -148,10 +139,10 @@ static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(panel, 8, 0);
     lv_obj_set_style_border_width(panel, 0, 0);
-    lv_obj_set_style_pad_left(panel, 16, 0);
-    lv_obj_set_style_pad_right(panel, 16, 0);
-    lv_obj_set_style_pad_top(panel, 12, 0);
-    lv_obj_set_style_pad_bottom(panel, 12, 0);
+    lv_obj_set_style_pad_left(panel, UI_PANEL_PAD, 0);
+    lv_obj_set_style_pad_right(panel, UI_PANEL_PAD, 0);
+    lv_obj_set_style_pad_top(panel, UI_PANEL_PAD - 4, 0);
+    lv_obj_set_style_pad_bottom(panel, UI_PANEL_PAD - 4, 0);
     lv_obj_clear_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
     // Bubble click events up to the screen / usage_container so a tap anywhere
     // on the panel fires the global click handler.
@@ -197,19 +188,18 @@ static void init_icon_dsc_rgb565a8(lv_image_dsc_t* dsc, int w, int h, const uint
 static lv_obj_t* make_pill(lv_obj_t* parent, const char* text) {
     lv_obj_t* lbl = lv_label_create(parent);
     lv_label_set_text(lbl, text);
-    lv_obj_set_style_text_font(lbl, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(lbl, UI_FONT_PILL, 0);
     lv_obj_set_style_text_color(lbl, COL_TEXT, 0);
     lv_obj_set_style_bg_color(lbl, COL_BAR_BG, 0);
     lv_obj_set_style_bg_opa(lbl, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(lbl, LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_pad_left(lbl, 18, 0);
-    lv_obj_set_style_pad_right(lbl, 18, 0);
-    lv_obj_set_style_pad_top(lbl, 6, 0);
-    lv_obj_set_style_pad_bottom(lbl, 6, 0);
+    lv_obj_set_style_pad_left(lbl, 10, 0);
+    lv_obj_set_style_pad_right(lbl, 10, 0);
+    lv_obj_set_style_pad_top(lbl, 4, 0);
+    lv_obj_set_style_pad_bottom(lbl, 4, 0);
     return lbl;
 }
 
-// ---- Battery icon initialization ----
 static void init_battery_icons(void) {
     init_icon_dsc_rgb565a8(&battery_dscs[0], ICON_BATTERY_W, ICON_BATTERY_H, icon_battery_data);
     init_icon_dsc_rgb565a8(&battery_dscs[1], ICON_BATTERY_LOW_W, ICON_BATTERY_LOW_H, icon_battery_low_data);
@@ -218,35 +208,30 @@ static void init_battery_icons(void) {
     init_icon_dsc_rgb565a8(&battery_dscs[4], ICON_BATTERY_CHARGING_W, ICON_BATTERY_CHARGING_H, icon_battery_charging_data);
 }
 
-// ======== Usage Screen (480x480) ========
-
-#define PANEL_H     150
-#define PANEL_GAP   16
+// ======== Usage Screen ========
 
 // One Session/Weekly panel: big % label, pill on the right, bar, reset label.
-// Pill y=1: symmetric inside the panel — panel-outer-top → pill-top equals
-// pill-bottom → bar-top (pill height 42 + panel pad_top 12 + bar y=56).
 static void make_usage_panel(lv_obj_t* parent, int y, const char* pill_text,
                              lv_obj_t** out_pct, lv_obj_t** out_pill,
                              lv_obj_t** out_bar, lv_obj_t** out_reset) {
-    lv_obj_t* panel = make_panel(parent, MARGIN, y, CONTENT_W, PANEL_H);
+    lv_obj_t* panel = make_panel(parent, UI_MARGIN, y, UI_CONTENT_W, UI_PANEL_H);
 
     *out_pct = lv_label_create(panel);
     lv_label_set_text(*out_pct, "---%");
-    lv_obj_set_style_text_font(*out_pct, &font_styrene_48, 0);
+    lv_obj_set_style_text_font(*out_pct, UI_FONT_PCT, 0);
     lv_obj_set_style_text_color(*out_pct, COL_TEXT, 0);
     lv_obj_set_pos(*out_pct, 0, 0);
 
     *out_pill = make_pill(panel, pill_text);
     lv_obj_align(*out_pill, LV_ALIGN_TOP_RIGHT, 0, 1);
 
-    *out_bar = make_bar(panel, 0, 56, CONTENT_W - 32, 24);
+    *out_bar = make_bar(panel, 0, UI_BAR_Y, UI_CONTENT_W - 2 * UI_PANEL_PAD, UI_BAR_H);
 
     *out_reset = lv_label_create(panel);
     lv_label_set_text(*out_reset, "---");
-    lv_obj_set_style_text_font(*out_reset, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(*out_reset, UI_FONT_DIM, 0);
     lv_obj_set_style_text_color(*out_reset, COL_DIM, 0);
-    lv_obj_set_pos(*out_reset, 0, 94);
+    lv_obj_set_pos(*out_reset, 0, UI_RESET_Y);
 }
 
 static void init_usage_screen(lv_obj_t* scr) {
@@ -261,25 +246,25 @@ static void init_usage_screen(lv_obj_t* scr) {
 
     lbl_title = lv_label_create(usage_container);
     lv_label_set_text(lbl_title, "Usage");
-    lv_obj_set_style_text_font(lbl_title, &font_tiempos_56, 0);
+    lv_obj_set_style_text_font(lbl_title, UI_FONT_TITLE, 0);
     lv_obj_set_style_text_color(lbl_title, COL_TEXT, 0);
-    lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 16, TITLE_Y);
+    lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, UI_TITLE_X_OFFSET, UI_TITLE_Y);
 
-    make_usage_panel(usage_container, CONTENT_Y, "Current",
+    make_usage_panel(usage_container, UI_CONTENT_Y, "Current",
                      &lbl_session_pct, &lbl_session_label,
                      &bar_session, &lbl_session_reset);
-    make_usage_panel(usage_container, CONTENT_Y + PANEL_H + PANEL_GAP, "Weekly",
+    make_usage_panel(usage_container, UI_CONTENT_Y + UI_PANEL_H + UI_PANEL_GAP, "Weekly",
                      &lbl_weekly_pct, &lbl_weekly_label,
                      &bar_weekly, &lbl_weekly_reset);
 
     lbl_anim = lv_label_create(usage_container);
     lv_label_set_text(lbl_anim, "");
-    lv_obj_set_style_text_font(lbl_anim, &font_mono_32, 0);
+    lv_obj_set_style_text_font(lbl_anim, UI_FONT_ANIM, 0);
     lv_obj_set_style_text_color(lbl_anim, COL_ACCENT, 0);
-    lv_obj_align(lbl_anim, LV_ALIGN_BOTTOM_MID, 0, -15);
+    lv_obj_align(lbl_anim, LV_ALIGN_BOTTOM_MID, 0, -8);
 }
 
-// ======== Bluetooth Screen (480x480) ========
+// ======== Bluetooth Screen ========
 
 static void init_bluetooth_screen(lv_obj_t* scr) {
     ble_container = lv_obj_create(scr);
@@ -290,47 +275,58 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_style_pad_all(ble_container, 0, 0);
     lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_SCROLLABLE);
 
-    // Title
     lv_obj_t* lbl_ble_title = lv_label_create(ble_container);
     lv_label_set_text(lbl_ble_title, "Bluetooth");
-    lv_obj_set_style_text_font(lbl_ble_title, &font_tiempos_56, 0);
+    lv_obj_set_style_text_font(lbl_ble_title, UI_FONT_TITLE, 0);
     lv_obj_set_style_text_color(lbl_ble_title, COL_TEXT, 0);
-    lv_obj_align(lbl_ble_title, LV_ALIGN_TOP_MID, 16, TITLE_Y);
+    lv_obj_align(lbl_ble_title, LV_ALIGN_TOP_MID, UI_TITLE_X_OFFSET, UI_TITLE_Y);
 
-    // Info panel (taller for 480x480)
-    lv_obj_t* p_info = make_panel(ble_container, MARGIN, CONTENT_Y, CONTENT_W, 160);
+    lv_obj_t* p_info = make_panel(ble_container, UI_MARGIN, UI_CONTENT_Y,
+                                  UI_CONTENT_W, UI_BLE_PANEL_H);
 
-    // Bluetooth icon + status row
     static lv_image_dsc_t icon_bt_dsc;
     init_icon_dsc(&icon_bt_dsc, ICON_BLUETOOTH_W, ICON_BLUETOOTH_H, icon_bluetooth_data);
 
     lv_obj_t* bt_img = lv_image_create(p_info);
     lv_image_set_src(bt_img, &icon_bt_dsc);
+    lv_obj_set_size(bt_img, UI_ICON_W, UI_ICON_H);
+    lv_image_set_inner_align(bt_img, LV_IMAGE_ALIGN_STRETCH);
     lv_obj_set_pos(bt_img, 0, 0);
 
     lbl_ble_status = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_status, "Initializing...");
-    lv_obj_set_style_text_font(lbl_ble_status, &font_styrene_48, 0);
+    lv_obj_set_style_text_font(lbl_ble_status, UI_FONT_BLE_STATUS, 0);
     lv_obj_set_style_text_color(lbl_ble_status, COL_DIM, 0);
-    lv_obj_set_pos(lbl_ble_status, 56, 2);
+    lv_obj_set_pos(lbl_ble_status, UI_BLE_STATUS_X, 2);
+
+    // Width-bounded labels with wrap so long device names / MAC addresses
+    // can't overflow the panel and trigger LVGL's scroll fallback.
+    const int ble_text_w = UI_CONTENT_W - 2 * UI_PANEL_PAD;
 
     lbl_ble_device = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_device, "Device: ---");
-    lv_obj_set_style_text_font(lbl_ble_device, &font_styrene_28, 0);
+    lv_label_set_long_mode(lbl_ble_device, LV_LABEL_LONG_WRAP);
+    lv_obj_set_width(lbl_ble_device, ble_text_w);
+    lv_obj_set_style_text_font(lbl_ble_device, UI_FONT_BODY, 0);
     lv_obj_set_style_text_color(lbl_ble_device, COL_DIM, 0);
-    lv_obj_set_pos(lbl_ble_device, 0, 64);
+    lv_obj_set_pos(lbl_ble_device, 0, UI_BLE_DEVICE_Y);
 
     lbl_ble_mac = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_mac, "Address: ---");
-    lv_obj_set_style_text_font(lbl_ble_mac, &font_styrene_28, 0);
+    lv_label_set_long_mode(lbl_ble_mac, LV_LABEL_LONG_WRAP);
+    lv_obj_set_width(lbl_ble_mac, ble_text_w);
+    lv_obj_set_style_text_font(lbl_ble_mac, UI_FONT_BODY, 0);
     lv_obj_set_style_text_color(lbl_ble_mac, COL_DIM, 0);
-    lv_obj_set_pos(lbl_ble_mac, 0, 100);
+    lv_obj_set_pos(lbl_ble_mac, 0, UI_BLE_MAC_Y);
 
-    // Reset Bluetooth tap zone with trash icon
-    int reset_y = CONTENT_Y + 160 + 16;
+#if BOARD_HAS_TOUCH
+    // Reset Bluetooth tap zone with trash icon — only meaningful with
+    // touch. On button-only boards we'd need a different gesture, so we
+    // just omit the widget rather than ship something un-reachable.
+    int reset_y = UI_CONTENT_Y + UI_BLE_PANEL_H + 16;
     lv_obj_t* reset_zone = lv_obj_create(ble_container);
-    lv_obj_set_pos(reset_zone, MARGIN, reset_y);
-    lv_obj_set_size(reset_zone, CONTENT_W, 110);
+    lv_obj_set_pos(reset_zone, UI_MARGIN, reset_y);
+    lv_obj_set_size(reset_zone, UI_CONTENT_W, UI_BLE_RESET_H);
     lv_obj_set_style_bg_color(reset_zone, COL_PANEL, 0);
     lv_obj_set_style_bg_opa(reset_zone, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(reset_zone, 8, 0);
@@ -348,23 +344,32 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
 
     lv_obj_t* reset_lbl = lv_label_create(reset_zone);
     lv_label_set_text(reset_lbl, "Reset Bluetooth");
-    lv_obj_set_style_text_font(reset_lbl, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(reset_lbl, UI_FONT_BODY, 0);
     lv_obj_set_style_text_color(reset_lbl, COL_DIM, 0);
+#endif
 
-    // Attribution
+    // Attribution. Width-bounded with wrap + center align so long names
+    // don't overflow on compact panels.
+    const int credit_w = SCR_W - 2 * UI_MARGIN;
+
     lv_obj_t* lbl_credit = lv_label_create(ble_container);
     lv_label_set_text(lbl_credit, "Built by @hermannbjorgvin");
-    lv_obj_set_style_text_font(lbl_credit, &font_styrene_24, 0);
+    lv_label_set_long_mode(lbl_credit, LV_LABEL_LONG_WRAP);
+    lv_obj_set_width(lbl_credit, credit_w);
+    lv_obj_set_style_text_align(lbl_credit, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_style_text_font(lbl_credit, UI_FONT_CREDIT, 0);
     lv_obj_set_style_text_color(lbl_credit, COL_DIM, 0);
-    lv_obj_align(lbl_credit, LV_ALIGN_BOTTOM_MID, 0, -46);
+    lv_obj_align(lbl_credit, LV_ALIGN_BOTTOM_MID, 0, -UI_CREDIT_OFFSET);
 
     lv_obj_t* lbl_credit2 = lv_label_create(ble_container);
     lv_label_set_text(lbl_credit2, "Clawd animation by @amaanbuilds");
-    lv_obj_set_style_text_font(lbl_credit2, &font_styrene_20, 0);
+    lv_label_set_long_mode(lbl_credit2, LV_LABEL_LONG_WRAP);
+    lv_obj_set_width(lbl_credit2, credit_w);
+    lv_obj_set_style_text_align(lbl_credit2, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_style_text_font(lbl_credit2, UI_FONT_CREDIT_SMALL, 0);
     lv_obj_set_style_text_color(lbl_credit2, COL_DIM, 0);
-    lv_obj_align(lbl_credit2, LV_ALIGN_BOTTOM_MID, 0, -20);
+    lv_obj_align(lbl_credit2, LV_ALIGN_BOTTOM_MID, 0, -UI_CREDIT2_OFFSET);
 
-    // Start hidden
     lv_obj_add_flag(ble_container, LV_OBJ_FLAG_HIDDEN);
 }
 
@@ -374,41 +379,54 @@ void ui_init(void) {
     lv_obj_t* scr = lv_screen_active();
     lv_obj_set_style_bg_color(scr, COL_BG, 0);
     lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
+    // LVGL marks the screen object scrollable by default; on a 170x320
+    // panel any small overflow draws a thin scrollbar at the bottom edge.
+    // Lock the screen so children render inside the viewport only.
+    lv_obj_clear_flag(scr, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_scrollbar_mode(scr, LV_SCROLLBAR_MODE_OFF);
 
-    // Logo (shared, always visible, on top of all containers)
-    // Logo is RGB565A8 (planar: w*h RGB565 then w*h alpha) so it composites
-    // cleanly against whatever bg is behind it.
     init_icon_dsc_rgb565a8(&logo_dsc, LOGO_WIDTH, LOGO_HEIGHT, logo_data);
-
-    // Initialize battery icon descriptors
     init_battery_icons();
 
     init_usage_screen(scr);
     init_bluetooth_screen(scr);
     splash_init(scr);
 
-    // Splash is touch-toggled — tap anywhere on the splash dismisses it
+    // Splash is touch-toggled on Waveshare. On button-only boards the
+    // splash is reached via the dedicated button mapping in buttons.cpp,
+    // so we skip the click handler entirely there.
+#if BOARD_HAS_TOUCH
     if (splash_get_root()) {
         lv_obj_add_event_cb(splash_get_root(), global_click_cb, LV_EVENT_CLICKED, NULL);
     }
+#endif
 
-    // Logo on top of all containers (inset for rounded corners)
-    logo_img = lv_image_create(scr);
-    lv_image_set_src(logo_img, &logo_dsc);
-    lv_obj_set_pos(logo_img, MARGIN, TITLE_Y - 10);
+    // Logo and battery overlays sit on top of every screen. On compact
+    // displays the 80x80 logo doesn't fit, so UI_SHOW_LOGO compiles it
+    // out and we just rely on the title text.
+    if (UI_SHOW_LOGO) {
+        logo_img = lv_image_create(scr);
+        lv_image_set_src(logo_img, &logo_dsc);
+        lv_obj_set_pos(logo_img, UI_LOGO_X, UI_LOGO_Y);
+    } else {
+        logo_img = NULL;
+    }
 
-    // Battery indicator on top of all containers (upper-right, inset)
     battery_img = lv_image_create(scr);
     lv_image_set_src(battery_img, &battery_dscs[0]);
-    lv_obj_set_pos(battery_img, SCR_W - 48 - MARGIN, TITLE_Y);
+    // Constrain the widget to the target draw size and stretch the
+    // source. Without this LVGL keeps the bounding box at the source
+    // dimensions (48x48), so any positioning past the right edge of a
+    // compact panel clips the visible icon.
+    lv_obj_set_size(battery_img, UI_ICON_W, UI_ICON_H);
+    lv_image_set_inner_align(battery_img, LV_IMAGE_ALIGN_STRETCH);
+    lv_obj_align(battery_img, LV_ALIGN_TOP_RIGHT, -UI_MARGIN, UI_TITLE_Y);
 }
 
 void ui_update(const UsageData* data) {
     if (!data->valid) return;
 
     int s_pct = (int)(data->session_pct + 0.5f);
-
-    // Usage screen
     lv_label_set_text_fmt(lbl_session_pct, "%d%%", s_pct);
     lv_bar_set_value(bar_session, s_pct, LV_ANIM_ON);
     lv_obj_set_style_bg_color(bar_session, pct_color(data->session_pct), LV_PART_INDICATOR);
@@ -451,28 +469,30 @@ void ui_tick_anim(void) {
 }
 
 static screen_t prev_non_splash_screen = SCREEN_USAGE;
+
 // Hide the battery indicator on the splash screen — the icon is visually
 // noisy over the pixel-art creature animations.
 static void apply_battery_visibility(void) {
     if (!battery_img) return;
     if (current_screen == SCREEN_SPLASH) lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
-    else                                  lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+    else                                 lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
 }
 
-// LVGL handles click debouncing internally. Screen-level handler fires when
-// no child consumed the event (children only consume if they have their own
-// event callback, e.g. the Reset Bluetooth zone). On BT screen we skip the
-// splash toggle so only the reset zone is interactive there.
+// LVGL handles click debouncing internally. The screen-level handler
+// only fires when no child consumed the event (children only consume if
+// they have their own event callback, e.g. the Reset Bluetooth zone).
 static void global_click_cb(lv_event_t* e) {
     (void)e;
     if (ui_get_current_screen() == SCREEN_BLUETOOTH) return;
     ui_toggle_splash();
 }
 
+#if BOARD_HAS_TOUCH
 static void ble_reset_click_cb(lv_event_t* e) {
     (void)e;
     ble_clear_bonds();
 }
+#endif
 
 void ui_show_screen(screen_t screen) {
     lv_obj_add_flag(usage_container, LV_OBJ_FLAG_HIDDEN);
@@ -486,10 +506,9 @@ void ui_show_screen(screen_t screen) {
     default: break;
     }
 
-    // Hide the logo overlay on the splash screen so the animation has a clean canvas
     if (logo_img) {
         if (screen == SCREEN_SPLASH) lv_obj_add_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
-        else                          lv_obj_clear_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
+        else                         lv_obj_clear_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
     }
 
     if (screen != SCREEN_SPLASH) prev_non_splash_screen = screen;
@@ -507,9 +526,7 @@ void ui_toggle_splash(void) {
     else                                  ui_show_screen(SCREEN_SPLASH);
 }
 
-screen_t ui_get_current_screen(void) {
-    return current_screen;
-}
+screen_t ui_get_current_screen(void) { return current_screen; }
 
 void ui_update_ble_status(ble_state_t state, const char* name, const char* mac) {
     switch (state) {
@@ -546,17 +563,17 @@ void ui_update_ble_status(ble_state_t state, const char* name, const char* mac) 
 void ui_update_battery(int percent, bool charging) {
     int idx;
     if (charging) {
-        idx = 4;  // charging icon
+        idx = 4;
     } else if (percent < 0) {
-        idx = 0;  // no battery / unknown
+        idx = 0;
     } else if (percent <= 10) {
-        idx = 0;  // empty
+        idx = 0;
     } else if (percent <= 35) {
-        idx = 1;  // low
+        idx = 1;
     } else if (percent <= 75) {
-        idx = 2;  // medium
+        idx = 2;
     } else {
-        idx = 3;  // full
+        idx = 3;
     }
     lv_image_set_src(battery_img, &battery_dscs[idx]);
     apply_battery_visibility();

--- a/firmware/src/ui_layout.h
+++ b/firmware/src/ui_layout.h
@@ -1,0 +1,116 @@
+#pragma once
+//
+// Per-board UI layout tokens.
+//
+// All sizing/spacing/font choices for the dashboard live here so ui.cpp
+// can stay board-agnostic. When porting to a new display, add a
+// BOARD_<NAME> block below — pick fonts that fit, decide whether the
+// logo and battery icon make sense at this scale, and you're done.
+//
+
+#include "display_cfg.h"
+#include <lvgl.h>
+
+LV_FONT_DECLARE(font_tiempos_56);
+LV_FONT_DECLARE(font_tiempos_34);
+LV_FONT_DECLARE(font_styrene_48);
+LV_FONT_DECLARE(font_styrene_28);
+LV_FONT_DECLARE(font_styrene_24);
+LV_FONT_DECLARE(font_styrene_20);
+LV_FONT_DECLARE(font_styrene_16);
+LV_FONT_DECLARE(font_styrene_14);
+LV_FONT_DECLARE(font_styrene_12);
+LV_FONT_DECLARE(font_mono_32);
+LV_FONT_DECLARE(font_mono_18);
+
+#if defined(BOARD_WAVESHARE_AMOLED_216)
+
+// Original 480x480 layout, tuned for the round-square AMOLED's rounded
+// corners (wider 20 px margins).
+#define UI_MARGIN              20
+#define UI_TITLE_Y             30
+#define UI_CONTENT_Y           100
+#define UI_PANEL_H             150
+#define UI_PANEL_GAP           16
+#define UI_PANEL_PAD           16
+#define UI_BAR_H               24
+#define UI_BAR_Y               56
+#define UI_RESET_Y             94
+
+#define UI_BLE_PANEL_H         160
+#define UI_BLE_RESET_H         110
+#define UI_BLE_STATUS_X        56
+#define UI_BLE_DEVICE_Y        64
+#define UI_BLE_MAC_Y           100
+#define UI_CREDIT_OFFSET       46
+#define UI_CREDIT2_OFFSET      20
+
+#define UI_FONT_TITLE          (&font_tiempos_56)
+#define UI_FONT_PCT            (&font_styrene_48)
+#define UI_FONT_BODY           (&font_styrene_28)
+#define UI_FONT_DIM            (&font_styrene_28)
+#define UI_FONT_PILL           (&font_styrene_28)
+#define UI_FONT_ANIM           (&font_mono_32)
+#define UI_FONT_CREDIT         (&font_styrene_24)
+#define UI_FONT_CREDIT_SMALL   (&font_styrene_20)
+#define UI_FONT_BLE_STATUS     (&font_styrene_48)
+
+// 48x48 icons drawn at native size.
+#define UI_ICON_W              48
+#define UI_ICON_H              48
+#define UI_SHOW_LOGO           1
+#define UI_LOGO_X              UI_MARGIN
+#define UI_LOGO_Y              (UI_TITLE_Y - 10)
+#define UI_TITLE_X_OFFSET      16          // shift past the logo on the left
+
+// Touch-only Bluetooth reset zone — gated by BOARD_HAS_TOUCH.
+
+#elif defined(BOARD_LILYGO_T_DISPLAY_S3)
+
+// 170x320 ST7789. No rounded corners, no touch — every interactive
+// element has to be reachable via the two physical buttons, so the BLE
+// "Reset Bluetooth" tap zone is omitted (BOARD_HAS_TOUCH is 0 and ui.cpp
+// guards on that).
+#define UI_MARGIN              8
+#define UI_TITLE_Y             4
+#define UI_CONTENT_Y           42
+#define UI_PANEL_H             96
+#define UI_PANEL_GAP           6
+#define UI_PANEL_PAD           8
+#define UI_BAR_H               12
+#define UI_BAR_Y               36
+#define UI_RESET_Y             60
+
+#define UI_BLE_PANEL_H         170
+#define UI_BLE_RESET_H         0          // not used; reset zone not built
+#define UI_BLE_STATUS_X        32
+#define UI_BLE_DEVICE_Y        40
+#define UI_BLE_MAC_Y           96
+// Credits wrap to two lines each on this width (12px font) — leave room
+// for ~26 px per label plus an 8 px gap between them.
+#define UI_CREDIT_OFFSET       40
+#define UI_CREDIT2_OFFSET      8
+
+#define UI_FONT_TITLE          (&font_styrene_24)
+#define UI_FONT_PCT            (&font_styrene_28)
+#define UI_FONT_BODY           (&font_styrene_14)
+#define UI_FONT_DIM            (&font_styrene_12)
+#define UI_FONT_PILL           (&font_styrene_12)
+#define UI_FONT_ANIM           (&font_mono_18)
+#define UI_FONT_CREDIT         (&font_styrene_12)
+#define UI_FONT_CREDIT_SMALL   (&font_styrene_12)
+#define UI_FONT_BLE_STATUS     (&font_styrene_16)
+
+// 48x48 icons would dwarf this panel — draw them at 24x24 by setting
+// the widget size explicitly and letting LVGL stretch the source.
+#define UI_ICON_W              24
+#define UI_ICON_H              24
+#define UI_SHOW_LOGO           0          // 80x80 logo doesn't fit
+#define UI_LOGO_X              0
+#define UI_LOGO_Y              0
+#define UI_TITLE_X_OFFSET      -8         // nudge left so the title clears the battery icon
+
+#endif
+
+// Common derived constant.
+#define UI_CONTENT_W           (BOARD_LCD_W - 2 * UI_MARGIN)

--- a/firmware/src/ui_layout.h
+++ b/firmware/src/ui_layout.h
@@ -110,7 +110,73 @@ LV_FONT_DECLARE(font_mono_18);
 #define UI_LOGO_Y              0
 #define UI_TITLE_X_OFFSET      -8         // nudge left so the title clears the battery icon
 
+#elif defined(BOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_2)
+
+// 240x320 ST7789 IPS, capacitive touch, no rounded corners. Sits in
+// between the LILYGO (170 wide) and Waveshare AMOLED (480 wide) layouts
+// — the BLE Reset Bluetooth tap zone is kept because the board has
+// touch.
+#define UI_MARGIN              12
+#define UI_TITLE_Y             8
+#define UI_CONTENT_Y           54
+#define UI_PANEL_H             108
+#define UI_PANEL_GAP           10
+#define UI_PANEL_PAD           12
+#define UI_BAR_H               16
+#define UI_BAR_Y               44
+#define UI_RESET_Y             70
+
+#define UI_BLE_PANEL_H         124
+#define UI_BLE_RESET_H         54
+#define UI_BLE_STATUS_X        38
+#define UI_BLE_DEVICE_Y        42
+#define UI_BLE_MAC_Y           76
+#define UI_BLE_DEVICE_PREFIX   "Name: "
+#define UI_BLE_MAC_PREFIX      "MAC: "
+#define UI_CREDIT_OFFSET       42
+#define UI_CREDIT2_OFFSET      16
+
+#define UI_FONT_TITLE          (&font_styrene_28)
+#define UI_FONT_PCT            (&font_styrene_48)
+#define UI_FONT_BODY           (&font_styrene_16)
+#define UI_FONT_DIM            (&font_styrene_14)
+#define UI_FONT_PILL           (&font_styrene_16)
+#define UI_FONT_ANIM           (&font_mono_18)
+#define UI_FONT_CREDIT         (&font_styrene_14)
+#define UI_FONT_CREDIT_SMALL   (&font_styrene_12)
+#define UI_FONT_BLE_STATUS     (&font_styrene_20)
+
+// 48x48 icons drawn at 28x28 — wider than LILYGO but still leaves room
+// next to the title at this panel width.
+#define UI_ICON_W              28
+#define UI_ICON_H              28
+#define UI_SHOW_LOGO           1
+#define UI_LOGO_X              24
+#define UI_LOGO_Y              10
+#define UI_LOGO_W              24
+#define UI_LOGO_H              24
+#define UI_TITLE_X_OFFSET      8          // logo on the left, battery on the right
+
 #endif
 
 // Common derived constant.
 #define UI_CONTENT_W           (BOARD_LCD_W - 2 * UI_MARGIN)
+
+#ifndef UI_BLE_DEVICE_PREFIX
+#define UI_BLE_DEVICE_PREFIX   "Device: "
+#endif
+#ifndef UI_BLE_MAC_PREFIX
+#define UI_BLE_MAC_PREFIX      "Address: "
+#endif
+#ifndef UI_BATTERY_ICON_W
+#define UI_BATTERY_ICON_W      UI_ICON_W
+#endif
+#ifndef UI_BATTERY_ICON_H
+#define UI_BATTERY_ICON_H      UI_ICON_H
+#endif
+#ifndef UI_LOGO_W
+#define UI_LOGO_W              80
+#endif
+#ifndef UI_LOGO_H
+#define UI_LOGO_H              80
+#endif

--- a/screenshot.sh
+++ b/screenshot.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
-# Take a screenshot from the Waveshare AMOLED display via LVGL snapshot.
+# Capture a screenshot via the firmware's LVGL snapshot command.
+# Works on both Waveshare (480x480) and LILYGO (170x320) — the device
+# reports its own dimensions in the SCREENSHOT_START header, which we
+# pipe through to ffmpeg so the same script handles any panel.
+#
 # Usage: ./screenshot.sh [output.png] [port]
 
 OUTPUT="${1:-screenshot.png}"
 PORT="${2:-/dev/ttyACM0}"
 
 TMPRAW=$(mktemp /tmp/screenshot_XXXXXX.raw)
-trap "rm -f '$TMPRAW'" EXIT
+SIZEFILE=$(mktemp /tmp/screenshot_XXXXXX.size)
+trap "rm -f '$TMPRAW' '$SIZEFILE'" EXIT
 
 echo "Taking screenshot from $PORT..."
 
-python3 - "$PORT" "$TMPRAW" << 'PYEOF'
+python3 - "$PORT" "$TMPRAW" "$SIZEFILE" << 'PYEOF'
 import serial, sys
 
-port_path, raw_path = sys.argv[1], sys.argv[2]
+port_path, raw_path, size_path = sys.argv[1], sys.argv[2], sys.argv[3]
 
 port = serial.Serial(port_path, 115200, timeout=10)
 port.reset_input_buffer()
@@ -40,6 +45,8 @@ while len(data) < raw_size:
 
 with open(raw_path, "wb") as f:
     f.write(data)
+with open(size_path, "w") as f:
+    f.write(f"{w} {h}\n")
 
 for _ in range(10):
     line = port.readline().decode("utf-8", errors="replace").strip()
@@ -55,12 +62,14 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-ffmpeg -y -f rawvideo -pixel_format rgb565le -video_size 480x480 \
+read W H < "$SIZEFILE"
+
+ffmpeg -y -f rawvideo -pixel_format rgb565le -video_size "${W}x${H}" \
     -i "$TMPRAW" -update 1 -frames:v 1 "$OUTPUT" 2>/dev/null || true
 
 
 if [ -f "$OUTPUT" ]; then
-    echo "Saved: $OUTPUT"
+    echo "Saved: $OUTPUT (${W}x${H})"
 else
     echo "Error: conversion failed"
     exit 1


### PR DESCRIPTION
## Summary
- Ports the firmware to two additional ESP32-S3 boards: LILYGO T-Display S3 Basic and Waveshare ESP32-S3-Touch-LCD-2.
- Keeps the original Waveshare ESP32-S3-Touch-AMOLED-2.16 target working from the same source tree.
- Introduces the board abstraction needed for multiple displays, input schemes, power sources, and UI layouts without spreading one-off `#ifdef`s throughout the app.

<img width="764" height="824" alt="image" src="https://github.com/user-attachments/assets/70103682-3cf0-498a-a5be-0d15784bed58" />
<img width="764" height="824" alt="image" src="https://github.com/user-attachments/assets/19c7f2c9-2897-46b1-a687-312e49385814" />
<img width="877" height="939" alt="image" src="https://github.com/user-attachments/assets/14f9e982-4164-4158-a553-b0b099a58293" />
<img width="877" height="939" alt="image" src="https://github.com/user-attachments/assets/45618f22-1320-4635-8ffb-b1b7dc11a3ab" />
<img width="877" height="939" alt="image" src="https://github.com/user-attachments/assets/d0b267bb-c578-46ea-9008-16bc04b63438" />


## What changed
**Board support**
- Adds board headers under `firmware/src/boards/` for the original Waveshare AMOLED, LILYGO T-Display S3, and Waveshare ESP32-S3-Touch-LCD-2.
- Adds PlatformIO environments for `waveshare_amoled_216`, `lilygo_t_display_s3`, and `waveshare_esp32_s3_touch_lcd_2`.
- Updates `display_cfg.h` and `main.cpp` so each board selects the right GFX bus/driver, display size, touch driver, backlight behavior, PMU/ADC path, and optional peripherals.

**Input and navigation**
- Centralizes physical button handling in `buttons.cpp` / `buttons.h`.
- Keeps the original Waveshare AMOLED button behavior: side buttons for BLE HID Space / Shift+Tab and PMU PKEY for screen cycling.
- Adds LILYGO two-button navigation with short/long press actions for splash, screen cycling, Space hold, and Shift+Tab.
- Adds Touch-LCD-2 touch-only navigation because KEY1 is hardware reset and KEY2 shares GPIO0 with BOOT/LCD reset: tap Usage toggles splash, long-press Usage opens Bluetooth, and tap Bluetooth returns to Usage.
- Fixes the Touch-LCD-2 long-press release path so Usage -> Bluetooth does not immediately bounce back to Usage.

**UI**
- Adds `ui_layout.h` with per-board layout tokens for margins, panel heights, font choices, icon sizes, BLE labels, and credits.
- Scales the existing UI down for 170x320 and 240x320 panels while preserving the 480x480 AMOLED layout.
- Bounds and stretches battery, Bluetooth, trash, and Claude Code logo icons so compact panels do not clip or reserve the wrong source-size boxes.
- Tightens the Touch-LCD-2 Bluetooth screen with shorter `Name:` / `MAC:` labels, bounded status text, smaller fonts, and a retained touch reset zone.
- Updates splash rendering so pixel-art animations scale from the smaller panel edge instead of assuming 480x480.

**Power and battery**
- Keeps the AXP2101 PMU path for the original Waveshare AMOLED.
- Adds ADC-based battery estimation for boards without a PMU using `analogReadMilliVolts()`, board-specific divider ratios, and a simple LiPo voltage-to-percent curve.
- Adds USB CDC external-power detection for the Touch-LCD-2 so the UI shows the plugged-in/charging icon while USB is present. This is an external-power hint, not charger IC telemetry.

**Build and tooling**
- Splits `platformio.ini` into a shared `[common]` block plus per-board environments and dependencies.
- Updates `screenshot.sh` to read panel dimensions from the firmware `SCREENSHOT_START` header instead of hardcoding 480x480.
- Updates README hardware support and flashing instructions for all supported targets.

## Test plan
- [x] `pio run -d firmware -e waveshare_amoled_216` builds clean
- [x] `pio run -d firmware -e lilygo_t_display_s3` builds clean
- [x] `pio run -d firmware -e waveshare_esp32_s3_touch_lcd_2` builds clean
- [x] Flashed and tested LILYGO T-Display S3: boots, splash animation runs, Usage/Bluetooth render at 170x320, BLE pairing works, and both buttons fire the documented actions
- [x] Flashed and tested Waveshare ESP32-S3-Touch-LCD-2 over `/dev/ttyACM0`: Usage/Bluetooth render at 240x320 with scaled logo/icons and corrected Bluetooth layout
- [x] Verified Touch-LCD-2 touch navigation: long-press Usage -> Bluetooth, release does not bounce back, tap Bluetooth -> Usage
- [x] Verified Touch-LCD-2 battery UI: plugged-in/charging icon appears with USB connected and battery bars appear when USB is disconnected