### PR TITLE
Feature/sensecap indicator d1l

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ firmware/.vscode/
 # Claude Code
 .claude/
 
+# Git worktrees
+.worktrees/
+
 # Node tooling deps (npm install --no-save)
 tools/node_modules/
 tools/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,10 @@ firmware/.vscode/
 tools/node_modules/
 tools/package-lock.json
 
-# Mac daemon venv
+# Python venvs
 daemon/.venv/
+firmware/.venv/
+firmware/.pio_home/
 
 # Python bytecode cache
 __pycache__/

--- a/docs/superpowers/plans/2026-05-18-sensecap-tap-animation.md
+++ b/docs/superpowers/plans/2026-05-18-sensecap-tap-animation.md
@@ -1,0 +1,199 @@
+# SenseCAP Tap-to-Cycle-Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On the SenseCAP splash screen, tapping cycles to the next pixel-art animation; tapping on Usage or Bluetooth screens does nothing.
+
+**Architecture:** Single change in `ui.cpp` — `global_click_cb` now dispatches on `current_screen`: splash → `splash_next()`, anything else → no-op. Two dead click listeners (usage_container, ble_container) are removed as cleanup. No new files, no new functions.
+
+**Tech Stack:** C++, LVGL 9, Arduino/ESP-IDF, PlatformIO
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `firmware/src/ui.cpp` | 3 edits: `global_click_cb`, `init_usage_screen`, `init_bluetooth_screen` |
+
+---
+
+## Context you need
+
+**Working directory for all commands:** `.worktrees/sensecap-port/`
+
+**Build + flash:**
+```bash
+pio run -d firmware -t upload --upload-port /dev/ttyACM0
+```
+
+**Screenshot (verify visually):**
+```bash
+./screenshot.sh out.png /dev/ttyACM0
+```
+Read `out.png` with the Read tool to verify the frame.
+
+**Serial monitor (watch logs):**
+```bash
+pio device monitor -d firmware -p /dev/ttyACM0 -b 115200
+```
+`splash: -> <name>` is printed by `splash_next()` each time the animation advances.
+
+**No unit tests exist for this firmware** — correctness is verified by flashing and using the screenshot tool plus serial output.
+
+---
+
+### Task 1: Swap `global_click_cb` body for `TARGET_SENSECAP`
+
+**Files:**
+- Modify: `firmware/src/ui.cpp:476-487`
+
+- [ ] **Step 1: Edit `global_click_cb`**
+
+Find this block in `ui.cpp` (around line 476):
+
+```cpp
+static void global_click_cb(lv_event_t* e) {
+    (void)e;
+#ifdef TARGET_SENSECAP
+    // Suppress the spurious LV_EVENT_CLICKED that fires at the end of a swipe gesture.
+    extern uint32_t sensecap_last_gesture_ms;
+    if ((lv_tick_get() - sensecap_last_gesture_ms) < 400) return;
+    ui_cycle_screen();
+#else
+```
+
+Replace the `TARGET_SENSECAP` branch body so the function reads:
+
+```cpp
+static void global_click_cb(lv_event_t* e) {
+    (void)e;
+#ifdef TARGET_SENSECAP
+    // Suppress the spurious LV_EVENT_CLICKED that fires at the end of a swipe gesture.
+    extern uint32_t sensecap_last_gesture_ms;
+    if ((lv_tick_get() - sensecap_last_gesture_ms) < 400) return;
+    if (current_screen == SCREEN_SPLASH) splash_next();
+#else
+```
+
+- [ ] **Step 2: Build to verify no compile errors**
+
+```bash
+pio run -d firmware
+```
+Expected: `SUCCESS` with no errors or warnings about undefined symbols.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add firmware/src/ui.cpp
+git commit -m "On SenseCAP splash, tap cycles animation instead of changing screen"
+```
+
+---
+
+### Task 2: Remove dead click listener from `usage_container`
+
+**Files:**
+- Modify: `firmware/src/ui.cpp` — `init_usage_screen()`
+
+- [ ] **Step 1: Remove the listener**
+
+Find this line inside `init_usage_screen()` (around line 260):
+
+```cpp
+    lv_obj_add_event_cb(usage_container, global_click_cb, LV_EVENT_CLICKED, NULL);
+```
+
+Delete it entirely.
+
+- [ ] **Step 2: Build to verify no compile errors**
+
+```bash
+pio run -d firmware
+```
+Expected: `SUCCESS`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add firmware/src/ui.cpp
+git commit -m "Remove dead usage_container click listener (tap is now a no-op on non-splash screens)"
+```
+
+---
+
+### Task 3: Remove dead click listener from `ble_container`
+
+**Files:**
+- Modify: `firmware/src/ui.cpp` — `init_bluetooth_screen()`
+
+- [ ] **Step 1: Remove the listener**
+
+Find this block inside `init_bluetooth_screen()` (around line 292):
+
+```cpp
+#ifdef TARGET_SENSECAP
+    lv_obj_add_event_cb(ble_container, global_click_cb, LV_EVENT_CLICKED, NULL);
+#endif
+```
+
+Delete all three lines.
+
+- [ ] **Step 2: Build to verify no compile errors**
+
+```bash
+pio run -d firmware
+```
+Expected: `SUCCESS`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add firmware/src/ui.cpp
+git commit -m "Remove dead ble_container click listener (tap no-op on non-splash screens)"
+```
+
+---
+
+### Task 4: Flash, test, and verify
+
+**Files:** none — verification only
+
+- [ ] **Step 1: Flash**
+
+```bash
+pio run -d firmware -t upload --upload-port /dev/ttyACM0
+```
+Expected: `SUCCESS`, device reboots.
+
+- [ ] **Step 2: Navigate to splash screen**
+
+Swipe left or right until you reach the Splash screen (pixel-art animation).
+
+- [ ] **Step 3: Verify tap cycles animation**
+
+Tap the screen. Check serial output:
+```
+splash: -> <animation name>
+```
+Each tap should print a new animation name. Tap several times and confirm a different animation plays each time.
+
+- [ ] **Step 4: Screenshot a frame to confirm visually**
+
+```bash
+./screenshot.sh out.png /dev/ttyACM0
+```
+Read `out.png` with the Read tool and confirm the pixel-art character has changed from the previous animation.
+
+- [ ] **Step 5: Verify swipe still navigates screens**
+
+Swipe left from splash — should go to Usage screen.  
+Swipe right from splash — should go to Bluetooth screen.  
+Confirm no spurious animation advance happens at the end of the swipe (the 400 ms guard).
+
+- [ ] **Step 6: Verify tap on Usage and Bluetooth does nothing**
+
+Navigate to Usage screen. Tap. Confirm screen does not change.  
+Navigate to Bluetooth screen. Tap outside the Reset zone. Confirm screen does not change.  
+Tap the "Reset Bluetooth" zone — confirm it still triggers a BLE bond clear (serial log: `BLE bonds cleared` or similar).

--- a/docs/superpowers/specs/2026-05-18-sensecap-tap-animation-design.md
+++ b/docs/superpowers/specs/2026-05-18-sensecap-tap-animation-design.md
@@ -1,0 +1,48 @@
+# SenseCAP tap-to-cycle-animation
+
+**Date:** 2026-05-18  
+**Branch:** sensecap-port
+
+## Problem
+
+On the SenseCAP Indicator D1L, swiping left/right navigates between screens (Splash → Usage → Bluetooth → Splash). There are 13 pixel-art animations on the Splash screen but only the usage-rate-appropriate one plays automatically. There is no way to manually cycle through them on SenseCAP (the Waveshare board uses a physical PMU button for this, which SenseCAP lacks).
+
+Tapping on any screen currently calls `ui_cycle_screen()` (Usage ↔ Bluetooth), which duplicates swipe behavior and gives no access to the other animations.
+
+## Goal
+
+- Splash screen: tap → advance to the next animation (`splash_next()`)
+- Usage / Bluetooth screens: tap → do nothing (screen navigation is swipe-only)
+- Reset Bluetooth zone: unaffected (already uses `lv_event_stop_bubbling()`)
+
+## Design
+
+### `global_click_cb` (`ui.cpp`)
+
+Replace the `TARGET_SENSECAP` branch body:
+
+```c
+// Before
+if ((lv_tick_get() - sensecap_last_gesture_ms) < 400) return;
+ui_cycle_screen();
+
+// After
+if ((lv_tick_get() - sensecap_last_gesture_ms) < 400) return;
+if (current_screen == SCREEN_SPLASH) splash_next();
+// non-splash: tap is a no-op; screen navigation is swipe-only
+```
+
+The 400 ms swipe-suppression guard is kept so a rightward swipe off the splash screen does not immediately advance the animation.
+
+### Remove dead click listeners (`ui.cpp`)
+
+| Location | Listener | Action |
+|---|---|---|
+| `init_usage_screen()` | `global_click_cb` on `usage_container` | Remove |
+| `init_bluetooth_screen()` (inside `#ifdef TARGET_SENSECAP`) | `global_click_cb` on `ble_container` | Remove |
+
+The splash container listener stays — it is what routes taps on splash to `global_click_cb`.
+
+## Files changed
+
+- `firmware/src/ui.cpp` — two removals + one substitution, all inside existing `#ifdef TARGET_SENSECAP` guards

--- a/firmware/.env
+++ b/firmware/.env
@@ -1,0 +1,1 @@
+PLATFORMIO_CORE_DIR=./.pio_home

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,13 +1,3 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
-
 [env:waveshare_amoled_216]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
 board = esp32-s3-devkitc-1
@@ -15,36 +5,41 @@ framework = arduino
 board_build.arduino.memory_type = qio_opi
 upload_speed = 921600
 monitor_speed = 115200
-build_flags = 
-	-DARDUINO_USB_CDC_ON_BOOT=1
-	-DBOARD_HAS_PSRAM
-	-DXPOWERS_CHIP_AXP2101
-	-DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
-	-DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
-	-DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
-	-DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
-	-DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
-	-DLV_CONF_SKIP
-	-DLV_COLOR_DEPTH=16
-	-DLV_USE_LOG=0
-	-DLV_USE_BAR=1
-	-DLV_USE_LABEL=1
-	-DLV_USE_ARC=1
-	-DLV_USE_BTN=1
-	-DLV_USE_LINE=1
-	-DLV_USE_OBJ=1
-	-DLV_USE_IMG=1
-	-DLV_USE_IMAGE=1
-	-DLV_USE_ANIMIMG=0
-	-DLV_TICK_CUSTOM=1
-	-DLV_USE_SNAPSHOT=1
-lib_deps = 
-	moononournation/GFX Library for Arduino@^1.5.6
-	lewisxhe/SensorLib@^0.2.6
-	lewisxhe/XPowersLib@^0.2.7
-	lvgl/lvgl@^9.2.0
-	bblanchon/ArduinoJson@^7.0.0
-	h2zero/NimBLE-Arduino@^2.1.1
+
+build_flags =
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    ; AXP2101 PMU
+    -DXPOWERS_CHIP_AXP2101
+    ; NimBLE config — peripheral-only, single connection
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+    ; LVGL config via build flags
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    moononournation/GFX Library for Arduino@^1.5.6
+    lewisxhe/SensorLib@^0.2.6
+    lewisxhe/XPowersLib@^0.2.7
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1
 
 [env:sensecap_indicator_d1l]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
@@ -53,35 +48,42 @@ framework = arduino
 board_build.arduino.memory_type = qio_opi
 upload_speed = 921600
 monitor_speed = 115200
-build_flags = 
-	-DARDUINO_USB_CDC_ON_BOOT=1
-	-DBOARD_HAS_PSRAM
-	-DTARGET_SENSECAP
-	-DTOUCH_MODULES_FT5x06
-	-DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
-	-DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
-	-DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
-	-DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
-	-DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
-	-DLV_CONF_SKIP
-	-DLV_COLOR_DEPTH=16
-	-DLV_USE_LOG=0
-	-DLV_USE_BAR=1
-	-DLV_USE_LABEL=1
-	-DLV_USE_ARC=1
-	-DLV_USE_BTN=1
-	-DLV_USE_LINE=1
-	-DLV_USE_OBJ=1
-	-DLV_USE_IMG=1
-	-DLV_USE_IMAGE=1
-	-DLV_USE_ANIMIMG=0
-	-DLV_TICK_CUSTOM=1
-	-DLV_USE_SNAPSHOT=1
+
+build_flags =
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    -DTARGET_SENSECAP
+    ; TouchLib chip model selection (required by TouchLib headers)
+    -DTOUCH_MODULES_FT5x06
+    ; NimBLE config — peripheral-only, single connection
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+    ; LVGL config via build flags
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+; Exclude Waveshare-only drivers from SenseCAP build
 build_src_filter = +<*> -<power.cpp> -<imu.cpp>
-lib_deps = 
-	moononournation/GFX Library for Arduino@^1.5.6
-	https://github.com/mmMicky/TouchLib
-	hideakitai/PCA95x5@^0.1.3
-	lvgl/lvgl@^9.2.0
-	bblanchon/ArduinoJson@^7.0.0
-	h2zero/NimBLE-Arduino@^2.1.1
+
+lib_deps =
+    moononournation/GFX Library for Arduino@^1.5.6
+    https://github.com/mmMicky/TouchLib
+    hideakitai/PCA95x5@^0.1.3
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -50,7 +50,10 @@ upload_speed = 921600
 monitor_speed = 115200
 
 build_flags =
-    -DARDUINO_USB_CDC_ON_BOOT=1
+    ; ARDUINO_USB_CDC_ON_BOOT intentionally absent: on SenseCAP the ESP32-S3
+    ; USB D+/D- pins are not wired to the USB-C port (RP2040 owns USB).
+    ; With the flag set, Serial maps to the unconnected USB CDC and all
+    ; debug output silently disappears.  Without it, Serial = UART0 → CH340.
     -DBOARD_HAS_PSRAM
     -DTARGET_SENSECAP
     ; TouchLib chip model selection (required by TouchLib headers)

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,3 +1,13 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
 [env:waveshare_amoled_216]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
 board = esp32-s3-devkitc-1
@@ -5,41 +15,36 @@ framework = arduino
 board_build.arduino.memory_type = qio_opi
 upload_speed = 921600
 monitor_speed = 115200
-
-build_flags =
-    -DARDUINO_USB_CDC_ON_BOOT=1
-    -DBOARD_HAS_PSRAM
-    ; AXP2101 PMU
-    -DXPOWERS_CHIP_AXP2101
-    ; NimBLE config — peripheral-only, single connection
-    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
-    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
-    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
-    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
-    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
-    ; LVGL config via build flags
-    -DLV_CONF_SKIP
-    -DLV_COLOR_DEPTH=16
-    -DLV_USE_LOG=0
-    -DLV_USE_BAR=1
-    -DLV_USE_LABEL=1
-    -DLV_USE_ARC=1
-    -DLV_USE_BTN=1
-    -DLV_USE_LINE=1
-    -DLV_USE_OBJ=1
-    -DLV_USE_IMG=1
-    -DLV_USE_IMAGE=1
-    -DLV_USE_ANIMIMG=0
-    -DLV_TICK_CUSTOM=1
-    -DLV_USE_SNAPSHOT=1
-
-lib_deps =
-    moononournation/GFX Library for Arduino@^1.5.6
-    lewisxhe/SensorLib@^0.2.6
-    lewisxhe/XPowersLib@^0.2.7
-    lvgl/lvgl@^9.2.0
-    bblanchon/ArduinoJson@^7.0.0
-    h2zero/NimBLE-Arduino@^2.1.1
+build_flags = 
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-DBOARD_HAS_PSRAM
+	-DXPOWERS_CHIP_AXP2101
+	-DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+	-DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+	-DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+	-DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+	-DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+	-DLV_CONF_SKIP
+	-DLV_COLOR_DEPTH=16
+	-DLV_USE_LOG=0
+	-DLV_USE_BAR=1
+	-DLV_USE_LABEL=1
+	-DLV_USE_ARC=1
+	-DLV_USE_BTN=1
+	-DLV_USE_LINE=1
+	-DLV_USE_OBJ=1
+	-DLV_USE_IMG=1
+	-DLV_USE_IMAGE=1
+	-DLV_USE_ANIMIMG=0
+	-DLV_TICK_CUSTOM=1
+	-DLV_USE_SNAPSHOT=1
+lib_deps = 
+	moononournation/GFX Library for Arduino@^1.5.6
+	lewisxhe/SensorLib@^0.2.6
+	lewisxhe/XPowersLib@^0.2.7
+	lvgl/lvgl@^9.2.0
+	bblanchon/ArduinoJson@^7.0.0
+	h2zero/NimBLE-Arduino@^2.1.1
 
 [env:sensecap_indicator_d1l]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
@@ -48,40 +53,35 @@ framework = arduino
 board_build.arduino.memory_type = qio_opi
 upload_speed = 921600
 monitor_speed = 115200
-
-build_flags =
-    -DARDUINO_USB_CDC_ON_BOOT=1
-    -DBOARD_HAS_PSRAM
-    -DTARGET_SENSECAP
-    ; NimBLE config — peripheral-only, single connection
-    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
-    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
-    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
-    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
-    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
-    ; LVGL config via build flags
-    -DLV_CONF_SKIP
-    -DLV_COLOR_DEPTH=16
-    -DLV_USE_LOG=0
-    -DLV_USE_BAR=1
-    -DLV_USE_LABEL=1
-    -DLV_USE_ARC=1
-    -DLV_USE_BTN=1
-    -DLV_USE_LINE=1
-    -DLV_USE_OBJ=1
-    -DLV_USE_IMG=1
-    -DLV_USE_IMAGE=1
-    -DLV_USE_ANIMIMG=0
-    -DLV_TICK_CUSTOM=1
-    -DLV_USE_SNAPSHOT=1
-
-; Exclude Waveshare-only drivers from SenseCAP build
+build_flags = 
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-DBOARD_HAS_PSRAM
+	-DTARGET_SENSECAP
+	-DTOUCH_MODULES_FT5x06
+	-DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+	-DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+	-DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+	-DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+	-DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+	-DLV_CONF_SKIP
+	-DLV_COLOR_DEPTH=16
+	-DLV_USE_LOG=0
+	-DLV_USE_BAR=1
+	-DLV_USE_LABEL=1
+	-DLV_USE_ARC=1
+	-DLV_USE_BTN=1
+	-DLV_USE_LINE=1
+	-DLV_USE_OBJ=1
+	-DLV_USE_IMG=1
+	-DLV_USE_IMAGE=1
+	-DLV_USE_ANIMIMG=0
+	-DLV_TICK_CUSTOM=1
+	-DLV_USE_SNAPSHOT=1
 build_src_filter = +<*> -<power.cpp> -<imu.cpp>
-
-lib_deps =
-    moononournation/GFX Library for Arduino@^1.5.6
-    https://github.com/mmMicky/TouchLib
-    Anitracks_PCA95x5@^0.1.3
-    lvgl/lvgl@^9.2.0
-    bblanchon/ArduinoJson@^7.0.0
-    h2zero/NimBLE-Arduino@^2.1.1
+lib_deps = 
+	moononournation/GFX Library for Arduino@^1.5.6
+	https://github.com/mmMicky/TouchLib
+	hideakitai/PCA95x5@^0.1.3
+	lvgl/lvgl@^9.2.0
+	bblanchon/ArduinoJson@^7.0.0
+	h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -40,3 +40,48 @@ lib_deps =
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+[env:sensecap_indicator_d1l]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+upload_speed = 921600
+monitor_speed = 115200
+
+build_flags =
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    -DTARGET_SENSECAP
+    ; NimBLE config — peripheral-only, single connection
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+    ; LVGL config via build flags
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+; Exclude Waveshare-only drivers from SenseCAP build
+build_src_filter = +<*> -<power.cpp> -<imu.cpp>
+
+lib_deps =
+    moononournation/GFX Library for Arduino@^1.5.6
+    https://github.com/mmMicky/TouchLib
+    Anitracks_PCA95x5@^0.1.3
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/src/display_cfg_sensecap.h
+++ b/firmware/src/display_cfg_sensecap.h
@@ -14,38 +14,48 @@
 #define SENSECAP_LCD_VSYNC  17
 #define SENSECAP_LCD_HSYNC  16
 #define SENSECAP_LCD_PCLK   21
-// Bit order is reversed within each channel — verified against Meshtastic LGFX_INDICATOR.h
-#define SENSECAP_LCD_R0      4
-#define SENSECAP_LCD_R1      3
-#define SENSECAP_LCD_R2      2
-#define SENSECAP_LCD_R3      1
-#define SENSECAP_LCD_R4      0
-#define SENSECAP_LCD_G0     10
-#define SENSECAP_LCD_G1      9
-#define SENSECAP_LCD_G2      8
-#define SENSECAP_LCD_G3      7
-#define SENSECAP_LCD_G4      6
+// The SenseCAP Indicator PCB routes ESP32-S3 GPIO_n to LCD data bus pin D[(n+5) mod 16].
+// Standard RGB565 maps D[4:0]=B, D[10:5]=G, D[15:11]=R.
+// To compensate: Arduino_GFX R parameter must use GPIOs 6-10 (→ D[11-15] = LCD R),
+//                G parameter must use GPIOs 0-5  (→ D[5-10]  = LCD G),
+//                B parameter must use GPIOs 11-15 (→ D[0-4]   = LCD B).
+// Empirically confirmed: 0xF800→blue, 0x001F→green with any other assignment.
+#define SENSECAP_LCD_R0      6
+#define SENSECAP_LCD_R1      7
+#define SENSECAP_LCD_R2      8
+#define SENSECAP_LCD_R3      9
+#define SENSECAP_LCD_R4     10
+#define SENSECAP_LCD_G0      0
+#define SENSECAP_LCD_G1      1
+#define SENSECAP_LCD_G2      2
+#define SENSECAP_LCD_G3      3
+#define SENSECAP_LCD_G4      4
 #define SENSECAP_LCD_G5      5
-#define SENSECAP_LCD_B0     15
-#define SENSECAP_LCD_B1     14
+#define SENSECAP_LCD_B0     11
+#define SENSECAP_LCD_B1     12
 #define SENSECAP_LCD_B2     13
-#define SENSECAP_LCD_B3     12
-#define SENSECAP_LCD_B4     11
+#define SENSECAP_LCD_B3     14
+#define SENSECAP_LCD_B4     15
 #define SENSECAP_LCD_SPI_SCK  41
 #define SENSECAP_LCD_SPI_MOSI 48
 #define SENSECAP_BACKLIGHT    45
 
 // ---- I2C bus (touch + PCA9535 expander) ----
-#define SENSECAP_IIC_SDA  40
-#define SENSECAP_IIC_SCL  39
+// Confirmed from Seeed ESP-IDF reference: SCL=40, SDA=39.
+#define SENSECAP_IIC_SDA  39
+#define SENSECAP_IIC_SCL  40
+
+// FT6x36 touch I2C address on this board.
+// Note: standard FT6336 address is 0x38, but the D1L board has it at 0x48.
+// Confirmed by I2C scan + FT5x06 register probe (CHIP_ID=0x64, DEVICE_MODE=0x00).
+#define SENSECAP_TOUCH_ADDR  0x48
 
 // ---- PCA9535 I2C expander ----
 // Controls touch RST and other GPIOs not wired directly to ESP32-S3.
 // Address confirmed from Seeed schematic (A0=A1=A2=GND → 0x20).
 #define SENSECAP_PCA9535_ADDR  0x20
-// P06 = touch RST output. Verify pin number against the SenseCAP Indicator
-// schematic before flashing if touch does not initialise.
-#define SENSECAP_TP_RST_PIN    6
+// P07 = touch RST output (EXPANDER_IO_TP_RESET = 7 per Seeed ESP-IDF source).
+#define SENSECAP_TP_RST_PIN    7
 
 // ---- User button ----
 // Single physical button on the front panel. Verify GPIO against schematic.
@@ -162,6 +172,7 @@ static const uint8_t st7701_sensecap_init_operations[] = {
     DELAY, 120,
 
     BEGIN_WRITE,
+    WRITE_COMMAND_8, 0x21, // Display Inversion ON (IPS panel — must follow Sleep Out)
     WRITE_COMMAND_8, 0x29, // Display On
     END_WRITE,
 };

--- a/firmware/src/display_cfg_sensecap.h
+++ b/firmware/src/display_cfg_sensecap.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <Arduino_GFX_Library.h>
+#include <TouchLib.h>
+#include <PCA9535.h>
+#include <Wire.h>
+
+// ---- Display resolution (same as Waveshare) ----
+#define LCD_WIDTH   480
+#define LCD_HEIGHT  480
+
+// ---- RGB parallel display pins (ST7701S) ----
+#define SENSECAP_LCD_DE     18
+#define SENSECAP_LCD_VSYNC  17
+#define SENSECAP_LCD_HSYNC  16
+#define SENSECAP_LCD_PCLK   21
+#define SENSECAP_LCD_R0      0
+#define SENSECAP_LCD_R1      1
+#define SENSECAP_LCD_R2      2
+#define SENSECAP_LCD_R3      3
+#define SENSECAP_LCD_R4      4
+#define SENSECAP_LCD_G0      5
+#define SENSECAP_LCD_G1      6
+#define SENSECAP_LCD_G2      7
+#define SENSECAP_LCD_G3      8
+#define SENSECAP_LCD_G4      9
+#define SENSECAP_LCD_G5     10
+#define SENSECAP_LCD_B0     11
+#define SENSECAP_LCD_B1     12
+#define SENSECAP_LCD_B2     13
+#define SENSECAP_LCD_B3     14
+#define SENSECAP_LCD_B4     15
+#define SENSECAP_LCD_SPI_SCK  41
+#define SENSECAP_LCD_SPI_MOSI 48
+#define SENSECAP_BACKLIGHT    45
+
+// ---- I2C bus (touch + PCA9535 expander) ----
+#define SENSECAP_IIC_SDA  40
+#define SENSECAP_IIC_SCL  39
+
+// ---- PCA9535 I2C expander ----
+// Controls touch RST and other GPIOs not wired directly to ESP32-S3.
+// Address confirmed from Seeed schematic (A0=A1=A2=GND → 0x20).
+#define SENSECAP_PCA9535_ADDR  0x20
+// P06 = touch RST output. Verify pin number against the SenseCAP Indicator
+// schematic before flashing if touch does not initialise.
+#define SENSECAP_TP_RST_PIN    6
+
+// ---- User button ----
+// Single physical button on the front panel. Verify GPIO against schematic.
+#define SENSECAP_BTN  38
+
+// ---- Global hardware objects (defined in main.cpp) ----
+extern Arduino_GFX *gfx;
+extern TouchLib touch_sc;
+extern PCA9535  pca;

--- a/firmware/src/display_cfg_sensecap.h
+++ b/firmware/src/display_cfg_sensecap.h
@@ -2,7 +2,7 @@
 
 #include <Arduino_GFX_Library.h>
 #include <TouchLib.h>
-#include <PCA9535.h>
+#include <PCA95x5.h>
 #include <Wire.h>
 
 // ---- Display resolution (same as Waveshare) ----

--- a/firmware/src/display_cfg_sensecap.h
+++ b/firmware/src/display_cfg_sensecap.h
@@ -14,22 +14,23 @@
 #define SENSECAP_LCD_VSYNC  17
 #define SENSECAP_LCD_HSYNC  16
 #define SENSECAP_LCD_PCLK   21
-#define SENSECAP_LCD_R0      0
-#define SENSECAP_LCD_R1      1
+// Bit order is reversed within each channel — verified against Meshtastic LGFX_INDICATOR.h
+#define SENSECAP_LCD_R0      4
+#define SENSECAP_LCD_R1      3
 #define SENSECAP_LCD_R2      2
-#define SENSECAP_LCD_R3      3
-#define SENSECAP_LCD_R4      4
-#define SENSECAP_LCD_G0      5
-#define SENSECAP_LCD_G1      6
-#define SENSECAP_LCD_G2      7
-#define SENSECAP_LCD_G3      8
-#define SENSECAP_LCD_G4      9
-#define SENSECAP_LCD_G5     10
-#define SENSECAP_LCD_B0     11
-#define SENSECAP_LCD_B1     12
+#define SENSECAP_LCD_R3      1
+#define SENSECAP_LCD_R4      0
+#define SENSECAP_LCD_G0     10
+#define SENSECAP_LCD_G1      9
+#define SENSECAP_LCD_G2      8
+#define SENSECAP_LCD_G3      7
+#define SENSECAP_LCD_G4      6
+#define SENSECAP_LCD_G5      5
+#define SENSECAP_LCD_B0     15
+#define SENSECAP_LCD_B1     14
 #define SENSECAP_LCD_B2     13
-#define SENSECAP_LCD_B3     14
-#define SENSECAP_LCD_B4     15
+#define SENSECAP_LCD_B3     12
+#define SENSECAP_LCD_B4     11
 #define SENSECAP_LCD_SPI_SCK  41
 #define SENSECAP_LCD_SPI_MOSI 48
 #define SENSECAP_BACKLIGHT    45
@@ -49,6 +50,121 @@
 // ---- User button ----
 // Single physical button on the front panel. Verify GPIO against schematic.
 #define SENSECAP_BTN  38
+
+// ---- ST7701S init sequence: type9 + COLMOD=0x50 (RGB565) ----
+// type9 from Arduino_GFX uses COLMOD=0x60 (RGB666), which misaligns the
+// R/G/B channels on a 16-bit parallel bus and produces a green tint.
+// This array is byte-for-byte identical to st7701_type9_init_operations
+// except the single COLMOD byte is changed from 0x60 to 0x50.
+static const uint8_t st7701_sensecap_init_operations[] = {
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x10,
+
+    WRITE_C8_D16, 0xC0, 0x3B, 0x00,
+    WRITE_C8_D16, 0xC1, 0x0D, 0x02,
+    WRITE_C8_D16, 0xC2, 0x31, 0x05,
+    WRITE_C8_D8, 0xCD, 0x00,
+
+    WRITE_COMMAND_8, 0xB0, // Positive Voltage Gamma Control
+    WRITE_BYTES, 16,
+    0x00, 0x11, 0x18, 0x0E,
+    0x11, 0x06, 0x07, 0x08,
+    0x07, 0x22, 0x04, 0x12,
+    0x0F, 0xAA, 0x31, 0x18,
+
+    WRITE_COMMAND_8, 0xB1, // Negative Voltage Gamma Control
+    WRITE_BYTES, 16,
+    0x00, 0x11, 0x19, 0x0E,
+    0x12, 0x07, 0x08, 0x08,
+    0x08, 0x22, 0x04, 0x11,
+    0x11, 0xA9, 0x32, 0x18,
+
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x11,
+
+    WRITE_C8_D8, 0xB0, 0x60,
+    WRITE_C8_D8, 0xB1, 0x32,
+    WRITE_C8_D8, 0xB2, 0x07,
+    WRITE_C8_D8, 0xB3, 0x80,
+    WRITE_C8_D8, 0xB5, 0x49,
+    WRITE_C8_D8, 0xB7, 0x85,
+    WRITE_C8_D8, 0xB8, 0x21,
+    WRITE_C8_D8, 0xC1, 0x78,
+    WRITE_C8_D8, 0xC2, 0x78,
+
+    WRITE_COMMAND_8, 0xE0,
+    WRITE_BYTES, 3, 0x00, 0x1B, 0x02,
+
+    WRITE_COMMAND_8, 0xE1,
+    WRITE_BYTES, 11,
+    0x08, 0xA0, 0x00, 0x00,
+    0x07, 0xA0, 0x00, 0x00,
+    0x00, 0x44, 0x44,
+
+    WRITE_COMMAND_8, 0xE2,
+    WRITE_BYTES, 12,
+    0x11, 0x11, 0x44, 0x44,
+    0xED, 0xA0, 0x00, 0x00,
+    0xEC, 0xA0, 0x00, 0x00,
+
+    WRITE_COMMAND_8, 0xE3,
+    WRITE_BYTES, 4, 0x00, 0x00, 0x11, 0x11,
+
+    WRITE_C8_D16, 0xE4, 0x44, 0x44,
+
+    WRITE_COMMAND_8, 0xE5,
+    WRITE_BYTES, 16,
+    0x0A, 0xE9, 0xD8, 0xA0,
+    0x0C, 0xEB, 0xD8, 0xA0,
+    0x0E, 0xED, 0xD8, 0xA0,
+    0x10, 0xEF, 0xD8, 0xA0,
+
+    WRITE_COMMAND_8, 0xE6,
+    WRITE_BYTES, 4, 0x00, 0x00, 0x11, 0x11,
+
+    WRITE_C8_D16, 0xE7, 0x44, 0x44,
+
+    WRITE_COMMAND_8, 0xE8,
+    WRITE_BYTES, 16,
+    0x09, 0xE8, 0xD8, 0xA0,
+    0x0B, 0xEA, 0xD8, 0xA0,
+    0x0D, 0xEC, 0xD8, 0xA0,
+    0x0F, 0xEE, 0xD8, 0xA0,
+
+    WRITE_COMMAND_8, 0xEB,
+    WRITE_BYTES, 7,
+    0x02, 0x00, 0xE4, 0xE4,
+    0x88, 0x00, 0x40,
+
+    WRITE_C8_D16, 0xEC, 0x3C, 0x00,
+
+    WRITE_COMMAND_8, 0xED,
+    WRITE_BYTES, 16,
+    0xAB, 0x89, 0x76, 0x54,
+    0x02, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0x20,
+    0x45, 0x67, 0x98, 0xBA,
+
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x13,
+
+    WRITE_C8_D8, 0xE5, 0xE4,
+
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x00,
+
+    WRITE_C8_D8, 0x3A, 0x50, // RGB565 (type9 uses 0x60 RGB666 which green-shifts on 16-bit bus)
+
+    WRITE_COMMAND_8, 0x11, // Sleep Out
+    END_WRITE,
+
+    DELAY, 120,
+
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, 0x29, // Display On
+    END_WRITE,
+};
 
 // ---- Global hardware objects (defined in main.cpp) ----
 extern Arduino_GFX *gfx;

--- a/firmware/src/display_cfg_sensecap.h
+++ b/firmware/src/display_cfg_sensecap.h
@@ -14,28 +14,30 @@
 #define SENSECAP_LCD_VSYNC  17
 #define SENSECAP_LCD_HSYNC  16
 #define SENSECAP_LCD_PCLK   21
-// The SenseCAP Indicator PCB routes ESP32-S3 GPIO_n to LCD data bus pin D[(n+5) mod 16].
-// Standard RGB565 maps D[4:0]=B, D[10:5]=G, D[15:11]=R.
-// To compensate: Arduino_GFX R parameter must use GPIOs 6-10 (→ D[11-15] = LCD R),
-//                G parameter must use GPIOs 0-5  (→ D[5-10]  = LCD G),
-//                B parameter must use GPIOs 11-15 (→ D[0-4]   = LCD B).
-// Empirically confirmed: 0xF800→blue, 0x001F→green with any other assignment.
-#define SENSECAP_LCD_R0      6
-#define SENSECAP_LCD_R1      7
-#define SENSECAP_LCD_R2      8
-#define SENSECAP_LCD_R3      9
-#define SENSECAP_LCD_R4     10
-#define SENSECAP_LCD_G0      0
-#define SENSECAP_LCD_G1      1
-#define SENSECAP_LCD_G2      2
-#define SENSECAP_LCD_G3      3
-#define SENSECAP_LCD_G4      4
+// The SenseCAP Indicator PCB routes ESP32-S3 GPIO_n to LCD data bus pin D[15-n]
+// (bit-reversal, confirmed against Seeed's reference ESP-IDF source).
+// Standard RGB565 maps data bit i → data_gpio_nums[i].  With the reversal,
+// bit i must use GPIO (15-i) so it reaches LCD_D[15-(15-i)] = LCD_D[i]:
+//   B[4:0]  = bits  4:0  → GPIOs 11-15  (B4=GPIO11 … B0=GPIO15)
+//   G[5:0]  = bits 10:5  → GPIOs  5-10  (G5=GPIO5  … G0=GPIO10)
+//   R[4:0]  = bits 15:11 → GPIOs  0-4   (R4=GPIO0  … R0=GPIO4)
+// (Previous cyclic-shift-of-+5 theory was wrong; it put R bits on G pins.)
+#define SENSECAP_LCD_R0      4
+#define SENSECAP_LCD_R1      3
+#define SENSECAP_LCD_R2      2
+#define SENSECAP_LCD_R3      1
+#define SENSECAP_LCD_R4      0
+#define SENSECAP_LCD_G0     10
+#define SENSECAP_LCD_G1      9
+#define SENSECAP_LCD_G2      8
+#define SENSECAP_LCD_G3      7
+#define SENSECAP_LCD_G4      6
 #define SENSECAP_LCD_G5      5
-#define SENSECAP_LCD_B0     11
-#define SENSECAP_LCD_B1     12
+#define SENSECAP_LCD_B0     15
+#define SENSECAP_LCD_B1     14
 #define SENSECAP_LCD_B2     13
-#define SENSECAP_LCD_B3     14
-#define SENSECAP_LCD_B4     15
+#define SENSECAP_LCD_B3     12
+#define SENSECAP_LCD_B4     11
 #define SENSECAP_LCD_SPI_SCK  41
 #define SENSECAP_LCD_SPI_MOSI 48
 #define SENSECAP_BACKLIGHT    45

--- a/firmware/src/display_cfg_sensecap.h
+++ b/firmware/src/display_cfg_sensecap.h
@@ -53,9 +53,13 @@
 #define SENSECAP_TOUCH_ADDR  0x48
 
 // ---- PCA9535 I2C expander ----
-// Controls touch RST and other GPIOs not wired directly to ESP32-S3.
+// Controls touch RST and ST7701S SPI CS — must be initialised BEFORE gfx->begin().
 // Address confirmed from Seeed schematic (A0=A1=A2=GND → 0x20).
 #define SENSECAP_PCA9535_ADDR  0x20
+// P04 = ST7701S SPI CS (active LOW).  PCA9535 output register defaults to
+// 0xFFFF at power-on, so P04 starts HIGH (deasserted).  Assert LOW before
+// the gfx->begin() init sequence, release HIGH after.
+#define SENSECAP_LCD_CS_PORT   4   // PCA9535 P04
 // P07 = touch RST output (EXPANDER_IO_TP_RESET = 7 per Seeed ESP-IDF source).
 #define SENSECAP_TP_RST_PIN    7
 

--- a/firmware/src/display_cfg_sensecap.h
+++ b/firmware/src/display_cfg_sensecap.h
@@ -67,20 +67,26 @@
 // Single physical button on the front panel. Verify GPIO against schematic.
 #define SENSECAP_BTN  38
 
-// ---- ST7701S init sequence: type9 + COLMOD=0x50 (RGB565) ----
-// type9 from Arduino_GFX uses COLMOD=0x60 (RGB666), which misaligns the
-// R/G/B channels on a 16-bit parallel bus and produces a green tint.
-// This array is byte-for-byte identical to st7701_type9_init_operations
-// except the single COLMOD byte is changed from 0x60 to 0x50.
+// ---- ST7701S init sequence ----
+// Based on Arduino_GFX type9 with two corrections verified against LovyanGFX
+// Panel_ST7701 (Meshtastic LGFX_INDICATOR, known-working on this board):
+//   1. Register 0xCD: 0x00 → 0x08  (type9 had 0x00; 0x08 is required for correct
+//      RGB colour output — wrong value produces a green tint on all content)
+//   2. Register 0xC0 omitted entirely (type9 set 0x3B,0x00; LovyanGFX leaves it
+//      at default — removing it caused no regressions)
+//   3. COLMOD 0x3A: kept at 0x60 (RGB666) to match RP2040 boot config
+//      (0x50 was also tried; 0xCD was the real root cause, not COLMOD)
+//
+// P04 (PCA9535) is asserted LOW before gfx->begin() so this sequence reaches
+// the ST7701S; see setup() in main.cpp.
 static const uint8_t st7701_sensecap_init_operations[] = {
     BEGIN_WRITE,
     WRITE_COMMAND_8, 0xFF,
     WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x10,
 
-    WRITE_C8_D16, 0xC0, 0x3B, 0x00,
     WRITE_C8_D16, 0xC1, 0x0D, 0x02,
     WRITE_C8_D16, 0xC2, 0x31, 0x05,
-    WRITE_C8_D8, 0xCD, 0x00,
+    WRITE_C8_D8, 0xCD, 0x08,
 
     WRITE_COMMAND_8, 0xB0, // Positive Voltage Gamma Control
     WRITE_BYTES, 16,
@@ -170,7 +176,7 @@ static const uint8_t st7701_sensecap_init_operations[] = {
     WRITE_COMMAND_8, 0xFF,
     WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x00,
 
-    WRITE_C8_D8, 0x3A, 0x50, // RGB565 (type9 uses 0x60 RGB666 which green-shifts on 16-bit bus)
+    WRITE_C8_D8, 0x3A, 0x60, // COLMOD=0x60 (RGB666, matches RP2040 boot config)
 
     WRITE_COMMAND_8, 0x11, // Sleep Out
     END_WRITE,
@@ -178,7 +184,7 @@ static const uint8_t st7701_sensecap_init_operations[] = {
     DELAY, 120,
 
     BEGIN_WRITE,
-    WRITE_COMMAND_8, 0x21, // Display Inversion ON (IPS panel — must follow Sleep Out)
+    WRITE_COMMAND_8, 0x21, // Display Inversion ON (IPS panel)
     WRITE_COMMAND_8, 0x29, // Display On
     END_WRITE,
 };

--- a/firmware/src/display_cfg_target.h
+++ b/firmware/src/display_cfg_target.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef TARGET_SENSECAP
+#include "display_cfg_sensecap.h"
+#else
+#include "display_cfg.h"
+#endif

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -380,24 +380,33 @@ void setup() {
     // ---- SenseCAP: I2C for PCA9535 expander + FT6336 touch ----
     Wire.begin(SENSECAP_IIC_SDA, SENSECAP_IIC_SCL);
 
-    // Init display (ST7701S over RGB parallel + SPI config).
-    // Requires a full power cycle after flashing: the RP2040 co-processor
-    // initialises the ST7701S at boot and must complete before ESP32-S3
-    // touches the SPI bus.  A USB-only reset (esptool RTS) does not reset
-    // the RP2040, so the SPI bus may be in a contested state.
-    gfx->begin();
+    // PCA9535 must be initialised BEFORE gfx->begin().
+    // P04 is the SPI CS for the ST7701S init bus (SCK=GPIO41, MOSI=GPIO48).
+    // The PCA9535 output register defaults to 0xFFFF at power-on (all HIGH),
+    // so P04 starts deasserted.  If we call gfx->begin() without first
+    // asserting P04 LOW, every SPI init command is ignored by the ST7701S
+    // and the display keeps the RP2040's boot-time settings (COLMOD=0x60
+    // RGB666, wrong for our RGB565 pixel pipeline → wrong colours).
+    // P07 = touch RST; configure both outputs here in one pass.
+    pca.attach(Wire, SENSECAP_PCA9535_ADDR);
+    pca.direction(PCA95x5::Port::P04, PCA95x5::Direction::OUT);
+    pca.direction(PCA95x5::Port::P07, PCA95x5::Direction::OUT);
 
-    // Turn on backlight via GPIO (ST7701S has no brightness register)
+    // Give the RP2040 SPI activity time to complete before we assert CS.
+    // A USB-only reset (esptool RTS) does not reset the RP2040, so after
+    // flashing the RP2040 may still be driving the SPI bus.
+    delay(200);
+
+    // Assert LCD SPI CS and send the init sequence (includes COLMOD=0x50).
+    pca.write(PCA95x5::Port::P04, PCA95x5::Level::L);
+    gfx->begin();
+    pca.write(PCA95x5::Port::P04, PCA95x5::Level::H);
+
+    // Turn on backlight
     pinMode(SENSECAP_BACKLIGHT, OUTPUT);
     digitalWrite(SENSECAP_BACKLIGHT, HIGH);
 
-    delay(200);
-
-    // FT6336 touch init via PCA9535 expander.
-    // PCA9535 P07 = touch RST (EXPANDER_IO_TP_RESET=7 per Seeed ESP-IDF source).
-    // Touch IC is at I2C address 0x48 on this board (not the standard 0x38).
-    pca.attach(Wire, SENSECAP_PCA9535_ADDR);
-    pca.direction(PCA95x5::Port::P07, PCA95x5::Direction::OUT);
+    // Touch RST via P07
     pca.write(PCA95x5::Port::P07, PCA95x5::Level::L);
     delay(50);
     pca.write(PCA95x5::Port::P07, PCA95x5::Level::H);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,7 +1,7 @@
 #include <Arduino.h>
 #include <lvgl.h>
 #include <ArduinoJson.h>
-#include "display_cfg.h"
+#include "display_cfg_target.h"
 #include "data.h"
 #include "ui.h"
 #include "ble.h"

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -57,6 +57,7 @@ static volatile uint16_t touch_x = 0;
 static volatile uint16_t touch_y = 0;
 static volatile bool     touch_data_ready = false;
 
+#ifndef TARGET_SENSECAP
 static void IRAM_ATTR touch_isr(void) {
     touch_data_ready = true;
 }
@@ -75,6 +76,18 @@ static void touch_read() {
         touch_pressed = false;
     }
 }
+#else
+static void touch_read() {
+    if (touch_sc.read()) {
+        TP_Point p = touch_sc.getPoint(0);
+        touch_pressed = true;
+        touch_x = (uint16_t)p.x;
+        touch_y = (uint16_t)p.y;
+    } else {
+        touch_pressed = false;
+    }
+}
+#endif
 
 // ---- LVGL draw buffers (PSRAM-backed, partial render) ----
 #define BUF_LINES 40
@@ -250,12 +263,17 @@ static void check_serial_cmd() {
     }
 }
 
+#ifdef TARGET_SENSECAP
+static void sensecap_gesture_cb(lv_event_t* e);
+#endif
+
 void setup() {
     Serial.begin(115200);
     delay(300);
     Serial.println("{\"ready\":true}");
 
-    // Init I2C (shared by touch + PMU)
+#ifndef TARGET_SENSECAP
+    // ---- Waveshare: I2C for touch + PMU ----
     Wire.begin(IIC_SDA, IIC_SCL);
 
     // Init display
@@ -280,17 +298,45 @@ void setup() {
         attachInterrupt(TP_INT, touch_isr, FALLING);
         Serial.println("Touch init OK");
     }
+#else
+    // ---- SenseCAP: I2C for touch + PCA9535 expander ----
+    Wire.begin(SENSECAP_IIC_SDA, SENSECAP_IIC_SCL);
 
-    // Init LVGL
+    // Reset the FT6336 touch controller via PCA9535 expander
+    pca.attach(Wire, SENSECAP_PCA9535_ADDR);
+    pca.direction(static_cast<PCA95x5::Port::Port>(SENSECAP_TP_RST_PIN), PCA95x5::Direction::OUT);
+    pca.write(static_cast<PCA95x5::Port::Port>(SENSECAP_TP_RST_PIN), PCA95x5::Level::L);
+    delay(10);
+    pca.write(static_cast<PCA95x5::Port::Port>(SENSECAP_TP_RST_PIN), PCA95x5::Level::H);
+    delay(100);
+
+    // Init display (ST7701S over RGB parallel)
+    gfx->begin();
+    gfx->fillScreen(0x0000);
+
+    // Turn on backlight via GPIO (ST7701S has no brightness register)
+    pinMode(SENSECAP_BACKLIGHT, OUTPUT);
+    digitalWrite(SENSECAP_BACKLIGHT, HIGH);
+
+    // Init FT6336 touch
+    if (!touch_sc.init()) {
+        Serial.println("Touch init failed");
+    } else {
+        Serial.println("Touch init OK");
+    }
+#endif
+
+    // ---- LVGL init (common) ----
     lv_init();
     lv_tick_set_cb(my_tick);
 
     // Allocate PSRAM-backed partial render buffers
     buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
     buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-    // rot_buf needs to hold the largest possible strip after rotation
-    // A 480×40 strip rotated 90° becomes 40×480, same pixel count
+#ifndef TARGET_SENSECAP
+    // rot_buf only needed for IMU-driven rotation (Waveshare only)
     rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+#endif
 
     lv_display_t* disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
     lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
@@ -298,8 +344,10 @@ void setup() {
     lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
                            LV_DISPLAY_RENDER_MODE_PARTIAL);
 
-    // CO5300 even-alignment rounder
+#ifndef TARGET_SENSECAP
+    // CO5300 requires even-aligned flush regions; ST7701S does not
     lv_display_add_event_cb(disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, NULL);
+#endif
 
     lv_indev_t* indev = lv_indev_create();
     lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
@@ -308,9 +356,18 @@ void setup() {
     // Init BLE data channel
     ble_init();
 
-    // Physical buttons: back (GPIO 0) and forward (GPIO 18)
+    // Physical buttons
+#ifndef TARGET_SENSECAP
+    // Waveshare: back (GPIO 0) and forward (GPIO 18) — BLE HID keystrokes
     pinMode(BTN_BACK, INPUT_PULLUP);
     pinMode(BTN_FWD,  INPUT_PULLUP);
+#else
+    // SenseCAP: single button toggles backlight
+    pinMode(SENSECAP_BTN, INPUT_PULLUP);
+
+    // Swipe gestures drive screen navigation
+    lv_obj_add_event_cb(lv_screen_active(), sensecap_gesture_cb, LV_EVENT_GESTURE, NULL);
+#endif
 
     // Build dashboard
     ui_init();
@@ -318,8 +375,10 @@ void setup() {
     // Show initial BLE status on Bluetooth screen
     ui_update_ble_status(ble_get_state(), ble_get_device_name(), ble_get_mac_address());
 
-    // Show initial battery status
+#ifndef TARGET_SENSECAP
+    // Show initial battery status (Waveshare only — SenseCAP hides the widget)
     ui_update_battery(power_battery_pct(), power_is_charging());
+#endif
 
     ui_show_screen(SCREEN_SPLASH);
 
@@ -332,6 +391,8 @@ static ble_state_t last_ble_state = BLE_STATE_INIT;
 // On rotation change we blank the panel, force a full LVGL redraw at the
 // new orientation, then ramp brightness back up over ~125ms so the
 // transition reads as deliberate instead of as a glitch.
+// Waveshare only — SenseCAP has no IMU and backlight is a plain GPIO.
+#ifndef TARGET_SENSECAP
 static void handle_rotation_change(void) {
     static uint8_t last_rotation = 0;
     static uint8_t  ramp_step = 0;  // 0=idle, 1-4=ramping
@@ -356,6 +417,7 @@ static void handle_rotation_change(void) {
     if (ramp_step >= 4) ramp_step = 0;
     else                ramp_step++;
 }
+#endif
 
 void loop() {
     touch_read();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -38,8 +38,8 @@ static Arduino_ESP32RGBPanel *rgb_panel = new Arduino_ESP32RGBPanel(
     SENSECAP_LCD_R0, SENSECAP_LCD_R1, SENSECAP_LCD_R2, SENSECAP_LCD_R3, SENSECAP_LCD_R4,
     SENSECAP_LCD_G0, SENSECAP_LCD_G1, SENSECAP_LCD_G2, SENSECAP_LCD_G3, SENSECAP_LCD_G4, SENSECAP_LCD_G5,
     SENSECAP_LCD_B0, SENSECAP_LCD_B1, SENSECAP_LCD_B2, SENSECAP_LCD_B3, SENSECAP_LCD_B4,
-    0 /* hsync_polarity */, 8 /* hsync_front_porch */, 4 /* hsync_pulse_width */, 8 /* hsync_back_porch */,
-    0 /* vsync_polarity */, 8 /* vsync_front_porch */, 4 /* vsync_pulse_width */, 8 /* vsync_back_porch */,
+    0 /* hsync_polarity */, 10 /* hsync_front_porch */, 8 /* hsync_pulse_width */, 50 /* hsync_back_porch */,
+    0 /* vsync_polarity */, 10 /* vsync_front_porch */, 8 /* vsync_pulse_width */, 20 /* vsync_back_porch */,
     1 /* pclk_active_neg */);
 Arduino_GFX *gfx = new Arduino_RGB_Display(
     LCD_WIDTH, LCD_HEIGHT, rgb_panel, 0 /* rotation */, true /* auto_flush */,

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -43,13 +43,12 @@ static Arduino_ESP32RGBPanel *rgb_panel = new Arduino_ESP32RGBPanel(
     0 /* pclk_active_neg */, 12000000 /* prefer_speed */,
     false /* useBigEndian */, 0 /* de_idle_high */, 0 /* pclk_idle_high */,
     480 * 10 /* bounce_buffer_size_px — SRAM relay cuts PSRAM bus contention */);
-// Typed pointer kept so setup() can call getFramebuffer() without re-init.
 static Arduino_RGB_Display *gfx_rgb = new Arduino_RGB_Display(
-    LCD_WIDTH, LCD_HEIGHT, rgb_panel, 0 /* rotation */, true /* auto_flush */,
+    LCD_WIDTH, LCD_HEIGHT, rgb_panel, 2 /* rotation: panel mounted 180° */, true /* auto_flush */,
     spi_bus_init, GFX_NOT_DEFINED /* RST */,
     st7701_sensecap_init_operations, sizeof(st7701_sensecap_init_operations));
 Arduino_GFX *gfx = gfx_rgb;
-TouchLib touch_sc(Wire, SENSECAP_IIC_SDA, SENSECAP_IIC_SCL, FT3267_SLAVE_ADDRESS);
+TouchLib touch_sc(Wire, SENSECAP_IIC_SDA, SENSECAP_IIC_SCL, SENSECAP_TOUCH_ADDR);
 PCA9535 pca;
 #endif
 
@@ -94,8 +93,10 @@ static void touch_read() {
     if (touch_sc.read()) {
         TP_Point p = touch_sc.getPoint(0);
         touch_pressed = true;
-        touch_x = (uint16_t)p.x;
-        touch_y = (uint16_t)p.y;
+        // Panel is mounted 180° rotated; flip both axes so LVGL logical (0,0)
+        // matches the top-left corner as seen by the user.
+        touch_x = (LCD_WIDTH  - 1) - (uint16_t)p.x;
+        touch_y = (LCD_HEIGHT - 1) - (uint16_t)p.y;
     } else {
         touch_pressed = false;
     }
@@ -170,9 +171,6 @@ static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_m
 #ifdef TARGET_SENSECAP
     int32_t w = area->x2 - area->x1 + 1;
     int32_t h = area->y2 - area->y1 + 1;
-    // draw16bitRGBBitmap handles the DMA cache writeback internally.
-    // A raw memcpy to getFramebuffer() leaves data in the CPU write-back
-    // cache; the LCD DMA reads PSRAM directly and would see stale zeros.
     gfx->draw16bitRGBBitmap(area->x1, area->y1, (uint16_t*)px_map, w, h);
     lv_display_flush_ready(disp);
 #else
@@ -273,6 +271,67 @@ static void check_serial_cmd() {
             cmd_buf[cmd_pos] = '\0';
             if (strcmp(cmd_buf, "screenshot") == 0) {
                 send_screenshot();
+#ifdef TARGET_SENSECAP
+            } else if (strcmp(cmd_buf, "diag") == 0) {
+                Serial.printf("touch_init_ok=%d screen=%d touch_pressed=%d x=%d y=%d\n",
+                    (int)touch_init_ok, (int)ui_get_current_screen(),
+                    (int)touch_pressed, (int)touch_x, (int)touch_y);
+                Serial.println("I2C scan:");
+                for (uint8_t a = 1; a < 127; a++) {
+                    Wire.beginTransmission(a);
+                    if (Wire.endTransmission() == 0) {
+                        Serial.printf("  found 0x%02X\n", a);
+                    }
+                }
+                Serial.println("I2C scan done");
+            } else if (strcmp(cmd_buf, "touch_reset") == 0) {
+                // Manually re-run the PCA9535 RST sequence and re-probe.
+                touch_init_ok = false;
+                Serial.println("Asserting RST low...");
+                pca.write(PCA95x5::Port::P07, PCA95x5::Level::L);
+                delay(50);
+                Serial.println("Releasing RST high...");
+                pca.write(PCA95x5::Port::P07, PCA95x5::Level::H);
+                delay(500);
+                Serial.println("I2C scan after RST release:");
+                for (uint8_t a = 1; a < 127; a++) {
+                    Wire.beginTransmission(a);
+                    if (Wire.endTransmission() == 0) {
+                        Serial.printf("  found 0x%02X\n", a);
+                    }
+                }
+                Serial.println("I2C scan done");
+                bool ft_found = false;
+                // Check for touch IC at expected address
+                Wire.beginTransmission(SENSECAP_TOUCH_ADDR);
+                ft_found = (Wire.endTransmission() == 0);
+                if (ft_found) {
+                    touch_init_ok = true;
+                    Serial.printf("Touch IC found at 0x%02X — OK\n", SENSECAP_TOUCH_ADDR);
+                } else {
+                    touch_init_ok = false;
+                    Serial.printf("Touch IC not found at 0x%02X\n", SENSECAP_TOUCH_ADDR);
+                }
+            } else if (strcmp(cmd_buf, "probe48") == 0) {
+                // Read a few registers from 0x48 to identify what device it is.
+                Serial.println("Probing 0x48:");
+                for (uint8_t reg : {0x00u, 0x01u, 0x02u, 0x3Au, 0xA3u, 0xA6u, 0xA8u}) {
+                    Wire.beginTransmission(0x48);
+                    Wire.write(reg);
+                    if (Wire.endTransmission(false) == 0) {
+                        Wire.requestFrom((uint8_t)0x48, (uint8_t)1);
+                        if (Wire.available()) {
+                            uint8_t val = Wire.read();
+                            Serial.printf("  reg 0x%02X = 0x%02X (%d)\n", reg, val, val);
+                        } else {
+                            Serial.printf("  reg 0x%02X = no data\n", reg);
+                        }
+                    } else {
+                        Serial.printf("  reg 0x%02X = nack\n", reg);
+                    }
+                }
+                Serial.println("probe done");
+#endif
             }
             cmd_pos = 0;
         } else if (cmd_pos < CMD_BUF_SIZE - 1) {
@@ -287,6 +346,7 @@ static void sensecap_gesture_cb(lv_event_t* e);
 
 void setup() {
     Serial.begin(115200);
+    // Print for 3 s so the serial monitor can be opened before boot messages scroll past.
     delay(300);
     Serial.println("{\"ready\":true}");
 
@@ -317,22 +377,32 @@ void setup() {
         Serial.println("Touch init OK");
     }
 #else
-    // ---- SenseCAP: I2C for FT6336 touch ----
-    // The PCA9535 expander is owned by the RP2040 co-processor on SenseCAP;
-    // attempting I2C to it from ESP32 produces NACK errors that corrupt
-    // the ESP-IDF 5.x I2C state machine for all subsequent transactions.
-    // Touch RST is managed by the RP2040 at boot — no reset needed here.
+    // ---- SenseCAP: I2C for PCA9535 expander + FT6336 touch ----
     Wire.begin(SENSECAP_IIC_SDA, SENSECAP_IIC_SCL);
 
-    // Init display (ST7701S over RGB parallel)
+    // Init display (ST7701S over RGB parallel + SPI config).
+    // Requires a full power cycle after flashing: the RP2040 co-processor
+    // initialises the ST7701S at boot and must complete before ESP32-S3
+    // touches the SPI bus.  A USB-only reset (esptool RTS) does not reset
+    // the RP2040, so the SPI bus may be in a contested state.
     gfx->begin();
-    gfx->fillScreen(0x0000);
 
     // Turn on backlight via GPIO (ST7701S has no brightness register)
     pinMode(SENSECAP_BACKLIGHT, OUTPUT);
     digitalWrite(SENSECAP_BACKLIGHT, HIGH);
 
-    // Init FT6336 touch
+    delay(200);
+
+    // FT6336 touch init via PCA9535 expander.
+    // PCA9535 P07 = touch RST (EXPANDER_IO_TP_RESET=7 per Seeed ESP-IDF source).
+    // Touch IC is at I2C address 0x48 on this board (not the standard 0x38).
+    pca.attach(Wire, SENSECAP_PCA9535_ADDR);
+    pca.direction(PCA95x5::Port::P07, PCA95x5::Direction::OUT);
+    pca.write(PCA95x5::Port::P07, PCA95x5::Level::L);
+    delay(50);
+    pca.write(PCA95x5::Port::P07, PCA95x5::Level::H);
+    delay(300);
+
     touch_init_ok = touch_sc.init();
     Serial.println(touch_init_ok ? "Touch init OK" : "Touch init failed");
 #endif
@@ -499,14 +569,13 @@ void loop() {
         ui_update_battery(pct, charging);
     }
 #else
-    // ---- SenseCAP: single button toggles backlight ----
+    // ---- SenseCAP: physical button cycles screens (same as Waveshare middle) ----
     {
         static bool btn_was = false;
-        static bool backlight_on = true;
         bool btn_now = (digitalRead(SENSECAP_BTN) == LOW);
         if (btn_now && !btn_was) {
-            backlight_on = !backlight_on;
-            digitalWrite(SENSECAP_BACKLIGHT, backlight_on ? HIGH : LOW);
+            if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
+            else                                          ui_cycle_screen();
         }
         btn_was = btn_now;
     }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -340,10 +340,6 @@ static void check_serial_cmd() {
     }
 }
 
-#ifdef TARGET_SENSECAP
-static void sensecap_gesture_cb(lv_event_t* e);
-#endif
-
 void setup() {
     Serial.begin(115200);
     // Print for 3 s so the serial monitor can be opened before boot messages scroll past.
@@ -469,7 +465,7 @@ void setup() {
     // lv_layer_top() is not in the parent chain of screen objects, so gesture events from
     // usage_container/ble_container never reach it.  ui_register_sensecap_gesture_cb()
     // sets GESTURE_BUBBLE on each container and attaches the callback to lv_screen_active().
-    ui_register_sensecap_gesture_cb(sensecap_gesture_cb);
+    ui_register_sensecap_gesture_cb();
 #endif
 
     // Show initial BLE status on Bluetooth screen
@@ -516,22 +512,6 @@ static void handle_rotation_change(void) {
     gfx->setBrightness(levels[ramp_step - 1]);
     if (ramp_step >= 4) ramp_step = 0;
     else                ramp_step++;
-}
-#endif
-
-#ifdef TARGET_SENSECAP
-// Swipe left → advance screen, swipe right → go back.
-// With two main screens (Usage ↔ Bluetooth) either direction cycles identically,
-// but directional intent is preserved for if screens are added later.
-static void sensecap_gesture_cb(lv_event_t* e) {
-    (void)e;
-    lv_indev_t* indev = lv_indev_active();
-    if (!indev) return;
-    lv_dir_t dir = lv_indev_get_gesture_dir(indev);
-    if (dir == LV_DIR_LEFT || dir == LV_DIR_RIGHT) {
-        if (ui_get_current_screen() == SCREEN_SPLASH) ui_show_screen(SCREEN_USAGE);
-        else ui_cycle_screen();
-    }
 }
 #endif
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -412,11 +412,7 @@ void setup() {
     lv_tick_set_cb(my_tick);
 
     lv_display_t* disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
-#ifdef TARGET_SENSECAP
-    lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565_SWAPPED);
-#else
     lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
-#endif
     lv_display_set_flush_cb(disp, my_flush_cb);
 
 #ifdef TARGET_SENSECAP
@@ -578,13 +574,14 @@ void loop() {
         ui_update_battery(pct, charging);
     }
 #else
-    // ---- SenseCAP: physical button cycles screens (same as Waveshare middle) ----
+    // ---- SenseCAP: physical button toggles backlight on/off ----
     {
-        static bool btn_was = false;
+        static bool btn_was      = false;
+        static bool backlight_on = true;
         bool btn_now = (digitalRead(SENSECAP_BTN) == LOW);
         if (btn_now && !btn_was) {
-            if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
-            else                                          ui_cycle_screen();
+            backlight_on = !backlight_on;
+            digitalWrite(SENSECAP_BACKLIGHT, backlight_on ? HIGH : LOW);
         }
         btn_was = btn_now;
     }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -419,19 +419,34 @@ static void handle_rotation_change(void) {
 }
 #endif
 
+#ifdef TARGET_SENSECAP
+// Swipe left → advance screen, swipe right → go back.
+// With two main screens (Usage ↔ Bluetooth) either direction cycles identically,
+// but directional intent is preserved for if screens are added later.
+static void sensecap_gesture_cb(lv_event_t* e) {
+    (void)e;
+    if (ui_get_current_screen() == SCREEN_SPLASH) return;
+    lv_indev_t* indev = lv_indev_active();
+    lv_dir_t dir = lv_indev_get_gesture_dir(indev);
+    if (dir == LV_DIR_LEFT || dir == LV_DIR_RIGHT) {
+        ui_cycle_screen();
+    }
+}
+#endif
+
 void loop() {
     touch_read();
     lv_timer_handler();
     ui_tick_anim();
     ble_tick();
+#ifndef TARGET_SENSECAP
     power_tick();
     imu_tick();
+#endif
     splash_tick();
 
-    // Three-button input (global, screen-independent):
-    //   LEFT  (GPIO 0)  → Space (voice-mode push-to-talk; press & release tracked)
-    //   RIGHT (GPIO 18) → Shift+Tab (Claude Code mode toggle)
-    //   PWR   (AXP)     → cycle screens; on splash, cycle animations
+#ifndef TARGET_SENSECAP
+    // ---- Waveshare: two buttons + PMU power button ----
     {
         static bool back_was = false, fwd_was = false;
         bool back_now = (digitalRead(BTN_BACK) == LOW);
@@ -456,13 +471,6 @@ void loop() {
 
     handle_rotation_change();
 
-    // Update BLE status on screen when state changes
-    ble_state_t bs = ble_get_state();
-    if (bs != last_ble_state) {
-        last_ble_state = bs;
-        ui_update_ble_status(bs, ble_get_device_name(), ble_get_mac_address());
-    }
-
     // Update battery indicator
     static int last_pct = -2;
     static bool last_charging = false;
@@ -472,6 +480,26 @@ void loop() {
         last_pct = pct;
         last_charging = charging;
         ui_update_battery(pct, charging);
+    }
+#else
+    // ---- SenseCAP: single button toggles backlight ----
+    {
+        static bool btn_was = false;
+        static bool backlight_on = true;
+        bool btn_now = (digitalRead(SENSECAP_BTN) == LOW);
+        if (btn_now && !btn_was) {
+            backlight_on = !backlight_on;
+            digitalWrite(SENSECAP_BACKLIGHT, backlight_on ? HIGH : LOW);
+        }
+        btn_was = btn_now;
+    }
+#endif
+
+    // Update BLE status on screen when state changes
+    ble_state_t bs = ble_get_state();
+    if (bs != last_ble_state) {
+        last_ble_state = bs;
+        ui_update_ble_status(bs, ble_get_device_name(), ble_get_mac_address());
     }
 
     // Check for serial commands (screenshot, etc.)

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -144,8 +144,9 @@ static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_m
     int32_t w = area->x2 - area->x1 + 1;
     int32_t h = area->y2 - area->y1 + 1;
     uint16_t *src = (uint16_t*)px_map;
-    uint8_t r = imu_get_rotation();
 
+#ifndef TARGET_SENSECAP
+    uint8_t r = imu_get_rotation();
     if (r == 0) {
         gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
     } else {
@@ -153,6 +154,10 @@ static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_m
         rotate_strip(src, w, h, area->x1, area->y1, r, &dx, &dy, &dw, &dh);
         gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
     }
+#else
+    gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
+#endif
+
     lv_display_flush_ready(disp);
 }
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -412,7 +412,11 @@ void setup() {
     lv_tick_set_cb(my_tick);
 
     lv_display_t* disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
+#ifdef TARGET_SENSECAP
+    lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565_SWAPPED);
+#else
     lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
+#endif
     lv_display_set_flush_cb(disp, my_flush_cb);
 
 #ifdef TARGET_SENSECAP
@@ -448,15 +452,20 @@ void setup() {
     pinMode(BTN_BACK, INPUT_PULLUP);
     pinMode(BTN_FWD,  INPUT_PULLUP);
 #else
-    // SenseCAP: single button toggles backlight
+    // SenseCAP: single button cycles screens
     pinMode(SENSECAP_BTN, INPUT_PULLUP);
-
-    // Swipe gestures drive screen navigation — lv_layer_top() persists across screen switches
-    lv_obj_add_event_cb(lv_layer_top(), sensecap_gesture_cb, LV_EVENT_GESTURE, NULL);
 #endif
 
     // Build dashboard
     ui_init();
+
+#ifdef TARGET_SENSECAP
+    // Register swipe-gesture handler on containers (must be after ui_init so objects exist).
+    // lv_layer_top() is not in the parent chain of screen objects, so gesture events from
+    // usage_container/ble_container never reach it.  ui_register_sensecap_gesture_cb()
+    // sets GESTURE_BUBBLE on each container and attaches the callback to lv_screen_active().
+    ui_register_sensecap_gesture_cb(sensecap_gesture_cb);
+#endif
 
     // Show initial BLE status on Bluetooth screen
     ui_update_ble_status(ble_get_state(), ble_get_device_name(), ble_get_mac_address());

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -365,8 +365,8 @@ void setup() {
     // SenseCAP: single button toggles backlight
     pinMode(SENSECAP_BTN, INPUT_PULLUP);
 
-    // Swipe gestures drive screen navigation
-    lv_obj_add_event_cb(lv_screen_active(), sensecap_gesture_cb, LV_EVENT_GESTURE, NULL);
+    // Swipe gestures drive screen navigation — lv_layer_top() persists across screen switches
+    lv_obj_add_event_cb(lv_layer_top(), sensecap_gesture_cb, LV_EVENT_GESTURE, NULL);
 #endif
 
     // Build dashboard
@@ -427,6 +427,7 @@ static void sensecap_gesture_cb(lv_event_t* e) {
     (void)e;
     if (ui_get_current_screen() == SCREEN_SPLASH) return;
     lv_indev_t* indev = lv_indev_active();
+    if (!indev) return;
     lv_dir_t dir = lv_indev_get_gesture_dir(indev);
     if (dir == LV_DIR_LEFT || dir == LV_DIR_RIGHT) {
         ui_cycle_screen();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -38,13 +38,13 @@ static Arduino_ESP32RGBPanel *rgb_panel = new Arduino_ESP32RGBPanel(
     SENSECAP_LCD_R0, SENSECAP_LCD_R1, SENSECAP_LCD_R2, SENSECAP_LCD_R3, SENSECAP_LCD_R4,
     SENSECAP_LCD_G0, SENSECAP_LCD_G1, SENSECAP_LCD_G2, SENSECAP_LCD_G3, SENSECAP_LCD_G4, SENSECAP_LCD_G5,
     SENSECAP_LCD_B0, SENSECAP_LCD_B1, SENSECAP_LCD_B2, SENSECAP_LCD_B3, SENSECAP_LCD_B4,
-    0 /* hsync_polarity */, 10 /* hsync_front_porch */, 8 /* hsync_pulse_width */, 50 /* hsync_back_porch */,
-    0 /* vsync_polarity */, 10 /* vsync_front_porch */, 8 /* vsync_pulse_width */, 20 /* vsync_back_porch */,
-    1 /* pclk_active_neg */);
+    1 /* hsync_polarity */, 10 /* hsync_front_porch */, 8 /* hsync_pulse_width */, 50 /* hsync_back_porch */,
+    1 /* vsync_polarity */, 10 /* vsync_front_porch */, 8 /* vsync_pulse_width */, 20 /* vsync_back_porch */,
+    0 /* pclk_active_neg */, 12000000 /* prefer_speed */);
 Arduino_GFX *gfx = new Arduino_RGB_Display(
     LCD_WIDTH, LCD_HEIGHT, rgb_panel, 0 /* rotation */, true /* auto_flush */,
     spi_bus_init, GFX_NOT_DEFINED /* RST */,
-    st7701_type6_init_operations, sizeof(st7701_type6_init_operations));
+    st7701_type9_init_operations, sizeof(st7701_type9_init_operations));
 TouchLib touch_sc(Wire, SENSECAP_IIC_SDA, SENSECAP_IIC_SCL, FT3267_SLAVE_ADDRESS);
 PCA9535 pca;
 #endif

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -40,11 +40,15 @@ static Arduino_ESP32RGBPanel *rgb_panel = new Arduino_ESP32RGBPanel(
     SENSECAP_LCD_B0, SENSECAP_LCD_B1, SENSECAP_LCD_B2, SENSECAP_LCD_B3, SENSECAP_LCD_B4,
     1 /* hsync_polarity */, 10 /* hsync_front_porch */, 8 /* hsync_pulse_width */, 50 /* hsync_back_porch */,
     1 /* vsync_polarity */, 10 /* vsync_front_porch */, 8 /* vsync_pulse_width */, 20 /* vsync_back_porch */,
-    0 /* pclk_active_neg */, 12000000 /* prefer_speed */);
-Arduino_GFX *gfx = new Arduino_RGB_Display(
+    0 /* pclk_active_neg */, 12000000 /* prefer_speed */,
+    false /* useBigEndian */, 0 /* de_idle_high */, 0 /* pclk_idle_high */,
+    480 * 10 /* bounce_buffer_size_px — SRAM relay cuts PSRAM bus contention */);
+// Typed pointer kept so setup() can call getFramebuffer() without re-init.
+static Arduino_RGB_Display *gfx_rgb = new Arduino_RGB_Display(
     LCD_WIDTH, LCD_HEIGHT, rgb_panel, 0 /* rotation */, true /* auto_flush */,
     spi_bus_init, GFX_NOT_DEFINED /* RST */,
-    st7701_type9_init_operations, sizeof(st7701_type9_init_operations));
+    st7701_sensecap_init_operations, sizeof(st7701_sensecap_init_operations));
+Arduino_GFX *gfx = gfx_rgb;
 TouchLib touch_sc(Wire, SENSECAP_IIC_SDA, SENSECAP_IIC_SCL, FT3267_SLAVE_ADDRESS);
 PCA9535 pca;
 #endif
@@ -56,6 +60,9 @@ static volatile bool     touch_pressed = false;
 static volatile uint16_t touch_x = 0;
 static volatile uint16_t touch_y = 0;
 static volatile bool     touch_data_ready = false;
+#ifdef TARGET_SENSECAP
+static bool touch_init_ok = false;
+#endif
 
 #ifndef TARGET_SENSECAP
 static void IRAM_ATTR touch_isr(void) {
@@ -78,6 +85,12 @@ static void touch_read() {
 }
 #else
 static void touch_read() {
+    if (!touch_init_ok) return;
+    static uint32_t last_ms = 0;
+    uint32_t now = millis();
+    if (now - last_ms < 20) return;  // poll FT6336 at 50 Hz
+    last_ms = now;
+
     if (touch_sc.read()) {
         TP_Point p = touch_sc.getPoint(0);
         touch_pressed = true;
@@ -152,13 +165,21 @@ static void rotate_strip(const uint16_t *src, int32_t w, int32_t h,
     }
 }
 
-// LVGL flush callback — rotates partial strips and writes to display
+// LVGL flush callback
 static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
+#ifdef TARGET_SENSECAP
+    int32_t w = area->x2 - area->x1 + 1;
+    int32_t h = area->y2 - area->y1 + 1;
+    // draw16bitRGBBitmap handles the DMA cache writeback internally.
+    // A raw memcpy to getFramebuffer() leaves data in the CPU write-back
+    // cache; the LCD DMA reads PSRAM directly and would see stale zeros.
+    gfx->draw16bitRGBBitmap(area->x1, area->y1, (uint16_t*)px_map, w, h);
+    lv_display_flush_ready(disp);
+#else
+    // Waveshare: partial strip mode with optional IMU rotation.
     int32_t w = area->x2 - area->x1 + 1;
     int32_t h = area->y2 - area->y1 + 1;
     uint16_t *src = (uint16_t*)px_map;
-
-#ifndef TARGET_SENSECAP
     uint8_t r = imu_get_rotation();
     if (r == 0) {
         gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
@@ -167,11 +188,8 @@ static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_m
         rotate_strip(src, w, h, area->x1, area->y1, r, &dx, &dy, &dw, &dh);
         gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
     }
-#else
-    gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
-#endif
-
     lv_display_flush_ready(disp);
+#endif
 }
 
 // CO5300 requires even-aligned flush regions
@@ -299,16 +317,12 @@ void setup() {
         Serial.println("Touch init OK");
     }
 #else
-    // ---- SenseCAP: I2C for touch + PCA9535 expander ----
+    // ---- SenseCAP: I2C for FT6336 touch ----
+    // The PCA9535 expander is owned by the RP2040 co-processor on SenseCAP;
+    // attempting I2C to it from ESP32 produces NACK errors that corrupt
+    // the ESP-IDF 5.x I2C state machine for all subsequent transactions.
+    // Touch RST is managed by the RP2040 at boot — no reset needed here.
     Wire.begin(SENSECAP_IIC_SDA, SENSECAP_IIC_SCL);
-
-    // Reset the FT6336 touch controller via PCA9535 expander
-    pca.attach(Wire, SENSECAP_PCA9535_ADDR);
-    pca.direction(static_cast<PCA95x5::Port::Port>(SENSECAP_TP_RST_PIN), PCA95x5::Direction::OUT);
-    pca.write(static_cast<PCA95x5::Port::Port>(SENSECAP_TP_RST_PIN), PCA95x5::Level::L);
-    delay(10);
-    pca.write(static_cast<PCA95x5::Port::Port>(SENSECAP_TP_RST_PIN), PCA95x5::Level::H);
-    delay(100);
 
     // Init display (ST7701S over RGB parallel)
     gfx->begin();
@@ -319,32 +333,34 @@ void setup() {
     digitalWrite(SENSECAP_BACKLIGHT, HIGH);
 
     // Init FT6336 touch
-    if (!touch_sc.init()) {
-        Serial.println("Touch init failed");
-    } else {
-        Serial.println("Touch init OK");
-    }
+    touch_init_ok = touch_sc.init();
+    Serial.println(touch_init_ok ? "Touch init OK" : "Touch init failed");
 #endif
 
     // ---- LVGL init (common) ----
     lv_init();
     lv_tick_set_cb(my_tick);
 
-    // Allocate PSRAM-backed partial render buffers
-    buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-    buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-#ifndef TARGET_SENSECAP
-    // rot_buf only needed for IMU-driven rotation (Waveshare only)
-    rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-#endif
-
     lv_display_t* disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
     lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
     lv_display_set_flush_cb(disp, my_flush_cb);
+
+#ifdef TARGET_SENSECAP
+    // Full-screen off-screen draw buffer: LCD_WIDTH × LCD_HEIGHT fits the
+    // entire frame, so LVGL renders all dirty regions in one pass and calls
+    // flush once with the completed composite (background + canvas).
+    // The flush callback then copies the finished frame to the display
+    // framebuffer in one memcpy — no intermediate states hit the live buffer.
+    buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * LCD_HEIGHT * 2, MALLOC_CAP_SPIRAM);
+    lv_display_set_buffers(disp, buf1, NULL, LCD_WIDTH * LCD_HEIGHT * 2,
+                           LV_DISPLAY_RENDER_MODE_PARTIAL);
+#else
+    // Waveshare: two PSRAM-backed partial render buffers + rotation buffer.
+    buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
     lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
                            LV_DISPLAY_RENDER_MODE_PARTIAL);
-
-#ifndef TARGET_SENSECAP
     // CO5300 requires even-aligned flush regions; ST7701S does not
     lv_display_add_event_cb(disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, NULL);
 #endif
@@ -425,12 +441,12 @@ static void handle_rotation_change(void) {
 // but directional intent is preserved for if screens are added later.
 static void sensecap_gesture_cb(lv_event_t* e) {
     (void)e;
-    if (ui_get_current_screen() == SCREEN_SPLASH) return;
     lv_indev_t* indev = lv_indev_active();
     if (!indev) return;
     lv_dir_t dir = lv_indev_get_gesture_dir(indev);
     if (dir == LV_DIR_LEFT || dir == LV_DIR_RIGHT) {
-        ui_cycle_screen();
+        if (ui_get_current_screen() == SCREEN_SPLASH) ui_show_screen(SCREEN_USAGE);
+        else ui_cycle_screen();
     }
 }
 #endif
@@ -518,6 +534,9 @@ void loop() {
                 if (splash_is_active()) splash_pick_for_current_rate();
             }
             ui_update(&usage);
+#ifdef TARGET_SENSECAP
+            if (ui_get_current_screen() == SCREEN_SPLASH) ui_show_screen(SCREEN_USAGE);
+#endif
             ble_send_ack();
         } else {
             ble_send_nack();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -18,6 +18,8 @@
 #define BTN_FWD  18
 
 // ---- Hardware objects ----
+#ifndef TARGET_SENSECAP
+// Waveshare ESP32-S3-Touch-AMOLED-2.16
 Arduino_DataBus *bus = new Arduino_ESP32QSPI(
     LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
 Arduino_CO5300 *gfx = new Arduino_CO5300(
@@ -26,6 +28,26 @@ Arduino_CO5300 *gfx = new Arduino_CO5300(
 TouchDrvCST92xx touch;
 XPowersPMU pmu;
 SensorQMI8658 imu;
+#else
+// SenseCAP Indicator D1L
+static Arduino_DataBus *spi_bus_init = new Arduino_ESP32SPI(
+    GFX_NOT_DEFINED, GFX_NOT_DEFINED,
+    SENSECAP_LCD_SPI_SCK, SENSECAP_LCD_SPI_MOSI, GFX_NOT_DEFINED);
+static Arduino_ESP32RGBPanel *rgb_panel = new Arduino_ESP32RGBPanel(
+    SENSECAP_LCD_DE, SENSECAP_LCD_VSYNC, SENSECAP_LCD_HSYNC, SENSECAP_LCD_PCLK,
+    SENSECAP_LCD_R0, SENSECAP_LCD_R1, SENSECAP_LCD_R2, SENSECAP_LCD_R3, SENSECAP_LCD_R4,
+    SENSECAP_LCD_G0, SENSECAP_LCD_G1, SENSECAP_LCD_G2, SENSECAP_LCD_G3, SENSECAP_LCD_G4, SENSECAP_LCD_G5,
+    SENSECAP_LCD_B0, SENSECAP_LCD_B1, SENSECAP_LCD_B2, SENSECAP_LCD_B3, SENSECAP_LCD_B4,
+    0 /* hsync_polarity */, 8 /* hsync_front_porch */, 4 /* hsync_pulse_width */, 8 /* hsync_back_porch */,
+    0 /* vsync_polarity */, 8 /* vsync_front_porch */, 4 /* vsync_pulse_width */, 8 /* vsync_back_porch */,
+    1 /* pclk_active_neg */);
+Arduino_GFX *gfx = new Arduino_RGB_Display(
+    LCD_WIDTH, LCD_HEIGHT, rgb_panel, 0 /* rotation */, true /* auto_flush */,
+    spi_bus_init, GFX_NOT_DEFINED /* RST */,
+    st7701_type6_init_operations, sizeof(st7701_type6_init_operations));
+TouchLib touch_sc(Wire, SENSECAP_IIC_SDA, SENSECAP_IIC_SCL, FT3267_SLAVE_ADDRESS);
+PCA9535 pca;
+#endif
 
 static UsageData usage = {};
 

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -401,6 +401,9 @@ void ui_init(void) {
     battery_img = lv_image_create(scr);
     lv_image_set_src(battery_img, &battery_dscs[0]);
     lv_obj_set_pos(battery_img, SCR_W - 48 - MARGIN, TITLE_Y);
+#ifdef TARGET_SENSECAP
+    lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+#endif
 }
 
 void ui_update(const UsageData* data) {

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -3,7 +3,7 @@
 #include <lvgl.h>
 #include "logo.h"
 #include "icons.h"
-#include "display_cfg.h"
+#include "display_cfg_target.h"
 
 // Custom fonts (scaled for 314 PPI, ~1.9x from original 165 PPI)
 LV_FONT_DECLARE(font_tiempos_56);

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -476,7 +476,9 @@ static void apply_battery_visibility(void) {
 static void global_click_cb(lv_event_t* e) {
     (void)e;
 #ifdef TARGET_SENSECAP
-    // SenseCAP has a single button; tapping any screen cycles SPLASH→USAGE→BT→USAGE…
+    // Suppress the spurious LV_EVENT_CLICKED that fires at the end of a swipe gesture.
+    extern uint32_t sensecap_last_gesture_ms;
+    if ((lv_tick_get() - sensecap_last_gesture_ms) < 400) return;
     ui_cycle_screen();
 #else
     if (ui_get_current_screen() == SCREEN_BLUETOOTH) return;
@@ -485,7 +487,7 @@ static void global_click_cb(lv_event_t* e) {
 }
 
 static void ble_reset_click_cb(lv_event_t* e) {
-    (void)e;
+    lv_event_stop_bubbling(e);
     ble_clear_bonds();
 }
 
@@ -578,7 +580,32 @@ void ui_update_battery(int percent, bool charging) {
 }
 
 #ifdef TARGET_SENSECAP
-void ui_register_sensecap_gesture_cb(lv_event_cb_t cb) {
+uint32_t sensecap_last_gesture_ms = 0;
+
+static void sensecap_gesture_cb(lv_event_t* e) {
+    (void)e;
+    lv_indev_t* indev = lv_indev_active();
+    if (!indev) return;
+    lv_dir_t dir = lv_indev_get_gesture_dir(indev);
+    if (dir != LV_DIR_LEFT && dir != LV_DIR_RIGHT) return;
+    sensecap_last_gesture_ms = lv_tick_get();
+    screen_t cur = current_screen;
+    screen_t next;
+    if (dir == LV_DIR_LEFT) {
+        // Forward: SPLASH → USAGE → BLUETOOTH → SPLASH
+        if (cur == SCREEN_SPLASH)         next = SCREEN_USAGE;
+        else if (cur == SCREEN_USAGE)     next = SCREEN_BLUETOOTH;
+        else                              next = SCREEN_SPLASH;
+    } else {
+        // Back: SPLASH → BLUETOOTH → USAGE → SPLASH
+        if (cur == SCREEN_SPLASH)         next = SCREEN_BLUETOOTH;
+        else if (cur == SCREEN_BLUETOOTH) next = SCREEN_USAGE;
+        else                              next = SCREEN_SPLASH;
+    }
+    ui_show_screen(next);
+}
+
+void ui_register_sensecap_gesture_cb(void) {
     // Gesture events bubble from the pressed child object up the parent chain.
     // usage_container / ble_container / splash root are direct children of the
     // single LVGL screen; they need GESTURE_BUBBLE so the event reaches the
@@ -587,6 +614,6 @@ void ui_register_sensecap_gesture_cb(lv_event_cb_t cb) {
     lv_obj_add_flag(ble_container,   LV_OBJ_FLAG_GESTURE_BUBBLE);
     lv_obj_t* splash_root = splash_get_root();
     if (splash_root) lv_obj_add_flag(splash_root, LV_OBJ_FLAG_GESTURE_BUBBLE);
-    lv_obj_add_event_cb(lv_screen_active(), cb, LV_EVENT_GESTURE, NULL);
+    lv_obj_add_event_cb(lv_screen_active(), sensecap_gesture_cb, LV_EVENT_GESTURE, NULL);
 }
 #endif

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -289,6 +289,9 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_style_border_width(ble_container, 0, 0);
     lv_obj_set_style_pad_all(ble_container, 0, 0);
     lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_SCROLLABLE);
+#ifdef TARGET_SENSECAP
+    lv_obj_add_event_cb(ble_container, global_click_cb, LV_EVENT_CLICKED, NULL);
+#endif
 
     // Title
     lv_obj_t* lbl_ble_title = lv_label_create(ble_container);
@@ -458,8 +461,12 @@ static screen_t prev_non_splash_screen = SCREEN_USAGE;
 // noisy over the pixel-art creature animations.
 static void apply_battery_visibility(void) {
     if (!battery_img) return;
+#ifdef TARGET_SENSECAP
+    lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+#else
     if (current_screen == SCREEN_SPLASH) lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
     else                                  lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+#endif
 }
 
 // LVGL handles click debouncing internally. Screen-level handler fires when
@@ -468,8 +475,13 @@ static void apply_battery_visibility(void) {
 // splash toggle so only the reset zone is interactive there.
 static void global_click_cb(lv_event_t* e) {
     (void)e;
+#ifdef TARGET_SENSECAP
+    // SenseCAP has a single button; tapping any screen cycles SPLASH→USAGE→BT→USAGE…
+    ui_cycle_screen();
+#else
     if (ui_get_current_screen() == SCREEN_BLUETOOTH) return;
     ui_toggle_splash();
+#endif
 }
 
 static void ble_reset_click_cb(lv_event_t* e) {
@@ -564,3 +576,17 @@ void ui_update_battery(int percent, bool charging) {
     lv_image_set_src(battery_img, &battery_dscs[idx]);
     apply_battery_visibility();
 }
+
+#ifdef TARGET_SENSECAP
+void ui_register_sensecap_gesture_cb(lv_event_cb_t cb) {
+    // Gesture events bubble from the pressed child object up the parent chain.
+    // usage_container / ble_container / splash root are direct children of the
+    // single LVGL screen; they need GESTURE_BUBBLE so the event reaches the
+    // screen root where we register the callback.
+    lv_obj_add_flag(usage_container, LV_OBJ_FLAG_GESTURE_BUBBLE);
+    lv_obj_add_flag(ble_container,   LV_OBJ_FLAG_GESTURE_BUBBLE);
+    lv_obj_t* splash_root = splash_get_root();
+    if (splash_root) lv_obj_add_flag(splash_root, LV_OBJ_FLAG_GESTURE_BUBBLE);
+    lv_obj_add_event_cb(lv_screen_active(), cb, LV_EVENT_GESTURE, NULL);
+}
+#endif

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -257,8 +257,6 @@ static void init_usage_screen(lv_obj_t* scr) {
     lv_obj_set_style_border_width(usage_container, 0, 0);
     lv_obj_set_style_pad_all(usage_container, 0, 0);
     lv_obj_clear_flag(usage_container, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_add_event_cb(usage_container, global_click_cb, LV_EVENT_CLICKED, NULL);
-
     lbl_title = lv_label_create(usage_container);
     lv_label_set_text(lbl_title, "Usage");
     lv_obj_set_style_text_font(lbl_title, &font_tiempos_56, 0);

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -479,7 +479,7 @@ static void global_click_cb(lv_event_t* e) {
     // Suppress the spurious LV_EVENT_CLICKED that fires at the end of a swipe gesture.
     extern uint32_t sensecap_last_gesture_ms;
     if ((lv_tick_get() - sensecap_last_gesture_ms) < 400) return;
-    ui_cycle_screen();
+    if (current_screen == SCREEN_SPLASH) splash_next();
 #else
     if (ui_get_current_screen() == SCREEN_BLUETOOTH) return;
     ui_toggle_splash();

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -287,10 +287,6 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_style_border_width(ble_container, 0, 0);
     lv_obj_set_style_pad_all(ble_container, 0, 0);
     lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_SCROLLABLE);
-#ifdef TARGET_SENSECAP
-    lv_obj_add_event_cb(ble_container, global_click_cb, LV_EVENT_CLICKED, NULL);
-#endif
-
     // Title
     lv_obj_t* lbl_ble_title = lv_label_create(ble_container);
     lv_label_set_text(lbl_ble_title, "Bluetooth");

--- a/firmware/src/ui.h
+++ b/firmware/src/ui.h
@@ -20,5 +20,5 @@ screen_t ui_get_current_screen(void);
 void ui_update_ble_status(ble_state_t state, const char* name, const char* mac);
 void ui_update_battery(int percent, bool charging);
 #ifdef TARGET_SENSECAP
-void ui_register_sensecap_gesture_cb(lv_event_cb_t cb);
+void ui_register_sensecap_gesture_cb(void);
 #endif

--- a/firmware/src/ui.h
+++ b/firmware/src/ui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <lvgl.h>
 #include "data.h"
 #include "ble.h"
 
@@ -18,3 +19,6 @@ void ui_toggle_splash(void);
 screen_t ui_get_current_screen(void);
 void ui_update_ble_status(ble_state_t state, const char* name, const char* mac);
 void ui_update_battery(int percent, bool charging);
+#ifdef TARGET_SENSECAP
+void ui_register_sensecap_gesture_cb(lv_event_cb_t cb);
+#endif


### PR DESCRIPTION
Added the Seeed Studio SenseCap Indicator D1L model as a target.
Since this device only has one physical button at the top, that one is used to turn the screen on/off.
The rest is touch screen driven.
No internal battery -> hide the battery icon.

<img width="3025" height="3072" alt="IMG20260516161533" src="https://github.com/user-attachments/assets/be974daa-1320-4416-91b8-09d13b4674cf" />
