### PR TITLE
Add support for xingzhi-cube 1.83 ESP32-S3 board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # PlatformIO build artifacts
 firmware/.pio/
 firmware/.vscode/
+firmware/monitor_output.txt
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ While the splash is up, the middle button cycles animations instead of screens. 
 - USB-C cable for flashing firmware and charging
 - 3.7V Li-Po battery (MX1.25 2-pin connector, optional)
 
+## Board support
+
+This repository now supports two ESP32-S3 board targets:
+
+- Waveshare ESP32-S3-Touch-AMOLED-2.16 (default, 480x480, touch + PMU + IMU)
+- xingzhi-cube 1.83" 2mic ESP32-S3 (284x240 ST7789 SPI panel)
+
+Build/flash commands:
+
+```bash
+# Waveshare (default)
+pio run -d firmware -e waveshare_amoled_216
+
+# xingzhi-cube 1.83
+pio run -d firmware -e xingzhi_cube_183
+pio run -d firmware -e xingzhi_cube_183 -t upload --upload-port <PORT>
+```
+
+Detailed bring-up notes, root causes, and fixes for the xingzhi board are documented in [docs/xingzhi-bringup-issues.md](docs/xingzhi-bringup-issues.md).
+
 ## Prerequisites
 
 - Linux (tested on Ubuntu) or macOS

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -231,9 +231,9 @@ class Session:
 async def connect_and_run(address: str, stop_event: asyncio.Event) -> bool:
     """Connect to a known address and poll until disconnected or stopped.
 
-    Returns True if the connection was used successfully (so the caller
-    keeps the cached address), False if the connection failed and the
-    cache should be invalidated.
+    Returns True if the address connected successfully (so the caller
+    keeps the cached address), False only when the address itself appears
+    invalid/unreachable and should be invalidated.
     """
     log(f"Connecting to {address}...")
     client = BleakClient(address)
@@ -252,7 +252,7 @@ async def connect_and_run(address: str, stop_event: asyncio.Event) -> bool:
     await session.setup_refresh_subscription()
 
     last_poll = 0.0
-    used_successfully = False
+    keep_cached_address = True
     try:
         while client.is_connected and not stop_event.is_set():
             now = time.time()
@@ -267,7 +267,6 @@ async def connect_and_run(address: str, stop_event: asyncio.Event) -> bool:
                     if payload is not None:
                         if await session.write_payload(payload):
                             last_poll = time.time()
-                            used_successfully = True
 
             try:
                 await asyncio.wait_for(session.refresh_requested.wait(), timeout=TICK)
@@ -280,7 +279,7 @@ async def connect_and_run(address: str, stop_event: asyncio.Event) -> bool:
             pass
 
     log("Device disconnected" if not stop_event.is_set() else "Stopping")
-    return used_successfully
+    return keep_cached_address
 
 
 async def main() -> None:

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -149,11 +149,16 @@ def save_address(addr: str) -> None:
 
 async def scan_for_device() -> str | None:
     log(f"Scanning for '{DEVICE_NAME}' ({SCAN_TIMEOUT}s)...")
-    devices = await BleakScanner.discover(timeout=SCAN_TIMEOUT)
-    for d in devices:
-        if d.name == DEVICE_NAME:
-            log(f"Found: {d.address}")
-            return d.address
+    # Windows often omits local name in passive scans; match by either
+    # advertised local name/device name OR our custom service UUID.
+    devices = await BleakScanner.discover(timeout=SCAN_TIMEOUT, return_adv=True)
+    for addr, (dev, adv) in devices.items():
+        uuids = [u.lower() for u in (adv.service_uuids or [])]
+        name = dev.name
+        local_name = adv.local_name
+        if name == DEVICE_NAME or local_name == DEVICE_NAME or SERVICE_UUID.lower() in uuids:
+            log(f"Found: {addr} (name={name!r}, local_name={local_name!r}, uuids={uuids})")
+            return addr
     return None
 
 
@@ -292,7 +297,7 @@ async def main() -> None:
         except NotImplementedError:
             signal.signal(sig, _stop)
 
-    log("=== Claude Usage Tracker Daemon (BLE, macOS) ===")
+    log("=== Claude Usage Tracker Daemon (BLE) ===")
     log(f"Poll interval: {POLL_INTERVAL}s")
 
     backoff = 1
@@ -310,6 +315,8 @@ async def main() -> None:
                     pass
                 backoff = min(backoff * 2, 60)
                 continue
+        else:
+            log(f"Using cached address: {address}")
 
         ok = await connect_and_run(address, stop_event)
         if not ok:

--- a/docs/xingzhi-bringup-issues.md
+++ b/docs/xingzhi-bringup-issues.md
@@ -1,74 +1,12 @@
-# Xingzhi Cube 1.83 Bring-Up Issues
+# Xingzhi Cube 1.83 Compatibility Notes
 
-This file tracks issues found while adding support for the xingzhi-cube 1.83" 2mic ESP32-S3 board.
+Support for the xingzhi-cube board was implemented with board-gated changes (`BOARD_XINGZHI_CUBE`) so existing Waveshare behavior stays intact.
 
-## Scope
-- Repository: Clawdmeter
-- Branch: generic-board-support
-- Target env: xingzhi_cube_183
+Key requirements and fixes:
+- ST7789 panel needs a vendor init table; base `Arduino_ST7789::tftInit()` was overridden to avoid SWRESET wiping vendor registers.
+- Board config added for 284x240 SPI display, no touch/PMU/IMU, and 3 physical buttons.
+- UI and splash renderer were made size-aware for 284x240 (layout constants, font scaling, dynamic splash canvas/cell sizing).
+- BLE path hardened for cross-platform daemon compatibility (advertising retry/state handling and Windows-friendly daemon discovery matching).
+- Splash color path updated for xingzhi with orange tinting, SPI byte-order handling, and black eye/detail preservation.
 
-## Issue Log
-
-### 1) Display stayed blank (sometimes only a white line)
-- Symptom: backlight on, panel mostly blank, occasional white line at top.
-- Root cause: panel requires a vendor-specific init command table before standard ST7789 use.
-- Evidence: board YAML and ORC board notes.
-- Fix: injected vendor init sequence in custom ST7789 subclass.
-- Status: fixed.
-
-### 2) Vendor init got wiped after injection
-- Symptom: panel still unstable after adding vendor commands.
-- Root cause: Arduino_ST7789::tftInit() always sends SWRESET (0x01), which clears vendor register programming.
-- Fix: override tftInit() and do full init without calling base tftInit().
-- Status: fixed.
-
-### 3) Wrong colors (expected orange, looked white-ish)
-- Symptom: accent colors looked wrong/washed.
-- Root cause candidates: panel color mode/order and init sequencing.
-- Fixes applied:
-  - set COLMOD to RGB565 in vendor path.
-  - preserve vendor sequence ordering.
-  - keep known-good invert setting for this panel.
-  - apply xingzhi-only orange tint mapping in splash render path.
-- Status: fixed.
-
-### 4) Initial suspicion of offset issue
-- Symptom: possible clipping/partial render looked like offset problem.
-- Root cause: mostly initialization mismatch, not pure offset.
-- Fix: temporary offset probe mode was used and then removed.
-- Status: closed (probe tooling removed).
-
-### 5) UI built for 480x480 only
-- Symptom: layout/typography too large or clipped on 284x240 xingzhi panel.
-- Root cause: hardcoded 480x480 constants and large-font assumptions in UI code.
-- Fix: added xingzhi-specific responsive layout constants and smaller font mapping.
-- Status: fixed.
-
-### 6) Splash renderer hardcoded to 480x480
-- Symptom: splash assets/layout not appropriate for 284x240 panel.
-- Root cause: fixed CELL and canvas dimensions.
-- Fix: splash cell/canvas now derived from panel size.
-- Status: fixed.
-
-### 7) Temporary boot-only debug mode
-- Symptom addressed: needed a clean rendering baseline to separate panel issues from asset/layout issues.
-- Fix: black screen + centered green "Booting up" screen (xingzhi only).
-- Outcome: confirmed display path, centering, and basic rendering were sane.
-- Status: removed after full UI path validation.
-
-### 8) Flash/port instability during iteration
-- Symptom: COM port busy/missing intermittently during upload attempts.
-- Root cause: USB serial contention/device reconnect timing.
-- Fix: detect active COM port before upload and retry with explicit port.
-- Status: operational workaround.
-
-## Validation Result
-1. Full xingzhi UI runtime path restored.
-2. Usage and Bluetooth screens verified on 284x240 layout.
-3. Splash animation renders at panel-sized scaling.
-4. Accent colors corrected with orange-tinted splash path.
-5. Build + flash validation passed for `xingzhi_cube_183`.
-
-## Notes
-- Asset conversion (icon/logo/splash preprocessing) should only proceed after panel init + layout are stable.
-- On xingzhi, oversized decorative icons are disabled pending a dedicated small-asset pack.
+Validation: `xingzhi_cube_183` builds and flashes successfully; Usage, Bluetooth, and Splash screens render correctly on device.

--- a/docs/xingzhi-bringup-issues.md
+++ b/docs/xingzhi-bringup-issues.md
@@ -1,0 +1,74 @@
+# Xingzhi Cube 1.83 Bring-Up Issues
+
+This file tracks issues found while adding support for the xingzhi-cube 1.83" 2mic ESP32-S3 board.
+
+## Scope
+- Repository: Clawdmeter
+- Branch: generic-board-support
+- Target env: xingzhi_cube_183
+
+## Issue Log
+
+### 1) Display stayed blank (sometimes only a white line)
+- Symptom: backlight on, panel mostly blank, occasional white line at top.
+- Root cause: panel requires a vendor-specific init command table before standard ST7789 use.
+- Evidence: board YAML and ORC board notes.
+- Fix: injected vendor init sequence in custom ST7789 subclass.
+- Status: fixed.
+
+### 2) Vendor init got wiped after injection
+- Symptom: panel still unstable after adding vendor commands.
+- Root cause: Arduino_ST7789::tftInit() always sends SWRESET (0x01), which clears vendor register programming.
+- Fix: override tftInit() and do full init without calling base tftInit().
+- Status: fixed.
+
+### 3) Wrong colors (expected orange, looked white-ish)
+- Symptom: accent colors looked wrong/washed.
+- Root cause candidates: panel color mode/order and init sequencing.
+- Fixes applied:
+  - set COLMOD to RGB565 in vendor path.
+  - preserve vendor sequence ordering.
+  - keep known-good invert setting for this panel.
+  - apply xingzhi-only orange tint mapping in splash render path.
+- Status: fixed.
+
+### 4) Initial suspicion of offset issue
+- Symptom: possible clipping/partial render looked like offset problem.
+- Root cause: mostly initialization mismatch, not pure offset.
+- Fix: temporary offset probe mode was used and then removed.
+- Status: closed (probe tooling removed).
+
+### 5) UI built for 480x480 only
+- Symptom: layout/typography too large or clipped on 284x240 xingzhi panel.
+- Root cause: hardcoded 480x480 constants and large-font assumptions in UI code.
+- Fix: added xingzhi-specific responsive layout constants and smaller font mapping.
+- Status: fixed.
+
+### 6) Splash renderer hardcoded to 480x480
+- Symptom: splash assets/layout not appropriate for 284x240 panel.
+- Root cause: fixed CELL and canvas dimensions.
+- Fix: splash cell/canvas now derived from panel size.
+- Status: fixed.
+
+### 7) Temporary boot-only debug mode
+- Symptom addressed: needed a clean rendering baseline to separate panel issues from asset/layout issues.
+- Fix: black screen + centered green "Booting up" screen (xingzhi only).
+- Outcome: confirmed display path, centering, and basic rendering were sane.
+- Status: removed after full UI path validation.
+
+### 8) Flash/port instability during iteration
+- Symptom: COM port busy/missing intermittently during upload attempts.
+- Root cause: USB serial contention/device reconnect timing.
+- Fix: detect active COM port before upload and retry with explicit port.
+- Status: operational workaround.
+
+## Validation Result
+1. Full xingzhi UI runtime path restored.
+2. Usage and Bluetooth screens verified on 284x240 layout.
+3. Splash animation renders at panel-sized scaling.
+4. Accent colors corrected with orange-tinted splash path.
+5. Build + flash validation passed for `xingzhi_cube_183`.
+
+## Notes
+- Asset conversion (icon/logo/splash preprocessing) should only proceed after panel init + layout are stable.
+- On xingzhi, oversized decorative icons are disabled pending a dedicated small-asset pack.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -40,3 +40,47 @@ lib_deps =
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+; ---- xingzhi-cube 1.83" 2mic (ESP32-S3) ----
+; ST7789 SPI LCD 284×240, 3 buttons, WS2812 LED, ES8311+ES7210 audio
+; No touch, no PMU, no IMU — audio subsystem not used by Clawdmeter firmware
+[env:xingzhi_cube_183]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+board_upload.flash_size = 16MB
+upload_speed = 921600
+monitor_speed = 115200
+
+build_flags =
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    -DBOARD_XINGZHI_CUBE
+    ; NimBLE config — peripheral-only, single connection
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+    ; LVGL config via build flags
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    moononournation/GFX Library for Arduino@^1.5.6
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/src/ble.cpp
+++ b/firmware/src/ble.cpp
@@ -74,10 +74,12 @@ static NimBLECharacteristic *req_char = nullptr;
 static ble_state_t state = BLE_STATE_INIT;
 static bool need_advertise = false;
 static char rx_buf[BLE_BUF_SIZE];
+static char rx_snapshot[BLE_BUF_SIZE];
 static volatile bool data_ready = false;
 static volatile bool has_received_data = false;
 static char mac_str[18];
 static uint32_t last_adv_attempt_ms = 0;
+static portMUX_TYPE rx_mux = portMUX_INITIALIZER_UNLOCKED;
 
 static void start_advertising()
 {
@@ -120,10 +122,12 @@ class RxCallbacks : public NimBLECharacteristicCallbacks
         size_t len = val.length();
         if (len >= BLE_BUF_SIZE)
             len = BLE_BUF_SIZE - 1;
+        taskENTER_CRITICAL(&rx_mux);
         memcpy(rx_buf, val.c_str(), len);
         rx_buf[len] = '\0';
         data_ready = true;
         has_received_data = true;
+        taskEXIT_CRITICAL(&rx_mux);
     }
 };
 
@@ -239,13 +243,20 @@ void ble_clear_bonds(void)
 
 bool ble_has_data(void)
 {
-    return data_ready;
+    bool ready;
+    taskENTER_CRITICAL(&rx_mux);
+    ready = data_ready;
+    taskEXIT_CRITICAL(&rx_mux);
+    return ready;
 }
 
 const char *ble_get_data(void)
 {
+    taskENTER_CRITICAL(&rx_mux);
+    memcpy(rx_snapshot, rx_buf, BLE_BUF_SIZE);
     data_ready = false;
-    return rx_buf;
+    taskEXIT_CRITICAL(&rx_mux);
+    return rx_snapshot;
 }
 
 void ble_send_ack(void)

--- a/firmware/src/ble.cpp
+++ b/firmware/src/ble.cpp
@@ -6,47 +6,70 @@
 #define DEVICE_NAME "Claude Controller"
 
 // Custom GATT UUIDs for data channel
-#define SERVICE_UUID        "4c41555a-4465-7669-6365-000000000001"
-#define RX_CHAR_UUID        "4c41555a-4465-7669-6365-000000000002"  // host writes here
-#define TX_CHAR_UUID        "4c41555a-4465-7669-6365-000000000003"  // device ack/nack notifies
-#define REQ_CHAR_UUID       "4c41555a-4465-7669-6365-000000000004"  // device-initiated refresh request
+#define SERVICE_UUID "4c41555a-4465-7669-6365-000000000001"
+#define RX_CHAR_UUID "4c41555a-4465-7669-6365-000000000002"  // host writes here
+#define TX_CHAR_UUID "4c41555a-4465-7669-6365-000000000003"  // device ack/nack notifies
+#define REQ_CHAR_UUID "4c41555a-4465-7669-6365-000000000004" // device-initiated refresh request
 
 #define BLE_BUF_SIZE 512
 
 // HID keyboard report descriptor
 static const uint8_t HID_REPORT_MAP[] = {
-    0x05, 0x01,  // Usage Page (Generic Desktop)
-    0x09, 0x06,  // Usage (Keyboard)
-    0xA1, 0x01,  // Collection (Application)
-    0x85, 0x01,  //   Report ID (1)
-    0x05, 0x07,  //   Usage Page (Key Codes)
-    0x19, 0xE0,  //   Usage Minimum (224) - Left Control
-    0x29, 0xE7,  //   Usage Maximum (231) - Right GUI
-    0x15, 0x00,  //   Logical Minimum (0)
-    0x25, 0x01,  //   Logical Maximum (1)
-    0x75, 0x01,  //   Report Size (1)
-    0x95, 0x08,  //   Report Count (8)
-    0x81, 0x02,  //   Input (Data, Variable, Absolute) - Modifier byte
-    0x95, 0x01,  //   Report Count (1)
-    0x75, 0x08,  //   Report Size (8)
-    0x81, 0x01,  //   Input (Constant) - Reserved byte
-    0x95, 0x06,  //   Report Count (6)
-    0x75, 0x08,  //   Report Size (8)
-    0x15, 0x00,  //   Logical Minimum (0)
-    0x25, 0x65,  //   Logical Maximum (101)
-    0x05, 0x07,  //   Usage Page (Key Codes)
-    0x19, 0x00,  //   Usage Minimum (0)
-    0x29, 0x65,  //   Usage Maximum (101)
-    0x81, 0x00,  //   Input (Data, Array) - Key array (6 keys)
-    0xC0,        // End Collection
+    0x05,
+    0x01, // Usage Page (Generic Desktop)
+    0x09,
+    0x06, // Usage (Keyboard)
+    0xA1,
+    0x01, // Collection (Application)
+    0x85,
+    0x01, //   Report ID (1)
+    0x05,
+    0x07, //   Usage Page (Key Codes)
+    0x19,
+    0xE0, //   Usage Minimum (224) - Left Control
+    0x29,
+    0xE7, //   Usage Maximum (231) - Right GUI
+    0x15,
+    0x00, //   Logical Minimum (0)
+    0x25,
+    0x01, //   Logical Maximum (1)
+    0x75,
+    0x01, //   Report Size (1)
+    0x95,
+    0x08, //   Report Count (8)
+    0x81,
+    0x02, //   Input (Data, Variable, Absolute) - Modifier byte
+    0x95,
+    0x01, //   Report Count (1)
+    0x75,
+    0x08, //   Report Size (8)
+    0x81,
+    0x01, //   Input (Constant) - Reserved byte
+    0x95,
+    0x06, //   Report Count (6)
+    0x75,
+    0x08, //   Report Size (8)
+    0x15,
+    0x00, //   Logical Minimum (0)
+    0x25,
+    0x65, //   Logical Maximum (101)
+    0x05,
+    0x07, //   Usage Page (Key Codes)
+    0x19,
+    0x00, //   Usage Minimum (0)
+    0x29,
+    0x65, //   Usage Maximum (101)
+    0x81,
+    0x00, //   Input (Data, Array) - Key array (6 keys)
+    0xC0, // End Collection
 };
 
-static NimBLEServer* server = nullptr;
-static NimBLEHIDDevice* hid_dev = nullptr;
-static NimBLECharacteristic* input_kbd = nullptr;
-static NimBLECharacteristic* tx_char = nullptr;
-static NimBLECharacteristic* rx_char = nullptr;
-static NimBLECharacteristic* req_char = nullptr;
+static NimBLEServer *server = nullptr;
+static NimBLEHIDDevice *hid_dev = nullptr;
+static NimBLECharacteristic *input_kbd = nullptr;
+static NimBLECharacteristic *tx_char = nullptr;
+static NimBLECharacteristic *rx_char = nullptr;
+static NimBLECharacteristic *req_char = nullptr;
 
 static ble_state_t state = BLE_STATE_INIT;
 static bool need_advertise = false;
@@ -54,38 +77,49 @@ static char rx_buf[BLE_BUF_SIZE];
 static volatile bool data_ready = false;
 static volatile bool has_received_data = false;
 static char mac_str[18];
+static uint32_t last_adv_attempt_ms = 0;
 
-static void start_advertising() {
-    NimBLEAdvertising* adv = NimBLEDevice::getAdvertising();
+static void start_advertising()
+{
+    NimBLEAdvertising *adv = NimBLEDevice::getAdvertising();
     adv->reset();
     adv->addServiceUUID(SERVICE_UUID);
+    // Include HID service too so hosts can classify keyboard capability.
+    adv->addServiceUUID((uint16_t)0x1812);
     adv->setAppearance(HID_KEYBOARD);
     adv->enableScanResponse(true);
     adv->setName(DEVICE_NAME);
     bool ok = adv->start();
-    state = BLE_STATE_ADVERTISING;
+    state = ok ? BLE_STATE_ADVERTISING : BLE_STATE_DISCONNECTED;
+    need_advertise = !ok;
+    last_adv_attempt_ms = millis();
     Serial.printf("BLE: advertising start=%s\n", ok ? "OK" : "FAILED");
 }
 
-class ServerCallbacks : public NimBLEServerCallbacks {
-    void onConnect(NimBLEServer* s, NimBLEConnInfo& info) override {
+class ServerCallbacks : public NimBLEServerCallbacks
+{
+    void onConnect(NimBLEServer *s, NimBLEConnInfo &info) override
+    {
         state = BLE_STATE_CONNECTED;
         Serial.printf("BLE: connected from %s\n", info.getAddress().toString().c_str());
     }
 
-    void onDisconnect(NimBLEServer* s, NimBLEConnInfo& info, int reason) override {
+    void onDisconnect(NimBLEServer *s, NimBLEConnInfo &info, int reason) override
+    {
         state = BLE_STATE_DISCONNECTED;
         need_advertise = true;
         Serial.printf("BLE: disconnected (reason=%d)\n", reason);
     }
-
 };
 
-class RxCallbacks : public NimBLECharacteristicCallbacks {
-    void onWrite(NimBLECharacteristic* chr, NimBLEConnInfo& info) override {
+class RxCallbacks : public NimBLECharacteristicCallbacks
+{
+    void onWrite(NimBLECharacteristic *chr, NimBLEConnInfo &info) override
+    {
         std::string val = chr->getValue();
         size_t len = val.length();
-        if (len >= BLE_BUF_SIZE) len = BLE_BUF_SIZE - 1;
+        if (len >= BLE_BUF_SIZE)
+            len = BLE_BUF_SIZE - 1;
         memcpy(rx_buf, val.c_str(), len);
         rx_buf[len] = '\0';
         data_ready = true;
@@ -96,24 +130,32 @@ class RxCallbacks : public NimBLECharacteristicCallbacks {
 // When the daemon enables notifications on the refresh char, ask for data
 // if we have none yet. Firing on subscribe (not on connect) ensures the
 // notification isn't dropped before the daemon's CCCD write completes.
-class ReqCallbacks : public NimBLECharacteristicCallbacks {
-    void onSubscribe(NimBLECharacteristic* chr, NimBLEConnInfo& info, uint16_t subValue) override {
+class ReqCallbacks : public NimBLECharacteristicCallbacks
+{
+    void onSubscribe(NimBLECharacteristic *chr, NimBLEConnInfo &info, uint16_t subValue) override
+    {
         Serial.printf("BLE: req_char onSubscribe subValue=%u has_data=%d\n", subValue, has_received_data ? 1 : 0);
-        if (subValue != 0 && !has_received_data) {
+        if (subValue != 0 && !has_received_data)
+        {
             ble_request_refresh();
         }
     }
 };
 
-void ble_init(void) {
+void ble_init(void)
+{
     NimBLEDevice::init(DEVICE_NAME);
-    NimBLEDevice::setSecurityAuth(true, false, true);  // bonding, no MITM, SC
+    // Cross-platform compatibility: keep bonding, but avoid Secure Connections
+    // requirement which can fail on some Windows/macOS Bluetooth stacks.
+    NimBLEDevice::setSecurityAuth(true, false, false); // bonding, no MITM, no SC required
 
     // Format MAC address
     NimBLEAddress addr = NimBLEDevice::getAddress();
     snprintf(mac_str, sizeof(mac_str), "%s", addr.toString().c_str());
-    for (int i = 0; mac_str[i]; i++) {
-        if (mac_str[i] >= 'a' && mac_str[i] <= 'f') mac_str[i] -= 32;
+    for (int i = 0; mac_str[i]; i++)
+    {
+        if (mac_str[i] >= 'a' && mac_str[i] <= 'f')
+            mac_str[i] -= 32;
     }
 
     server = NimBLEDevice::createServer();
@@ -122,32 +164,29 @@ void ble_init(void) {
 
     // --- HID keyboard service ---
     hid_dev = new NimBLEHIDDevice(server);
-    hid_dev->setReportMap((uint8_t*)HID_REPORT_MAP, sizeof(HID_REPORT_MAP));
+    hid_dev->setReportMap((uint8_t *)HID_REPORT_MAP, sizeof(HID_REPORT_MAP));
     hid_dev->setManufacturer("Anthropic");
-    hid_dev->setPnp(0x02, 0x05AC, 0x820A, 0x0210);  // BT SIG, generic keyboard
-    hid_dev->setHidInfo(0x00, 0x02);  // country=0, flags=normally connectable
+    hid_dev->setPnp(0x02, 0x05AC, 0x820A, 0x0210); // BT SIG, generic keyboard
+    hid_dev->setHidInfo(0x00, 0x02);               // country=0, flags=normally connectable
     hid_dev->setBatteryLevel(100);
-    input_kbd = hid_dev->getInputReport(1);  // report ID 1
+    input_kbd = hid_dev->getInputReport(1); // report ID 1
 
     // --- Custom data service ---
-    NimBLEService* svc = server->createService(SERVICE_UUID);
+    NimBLEService *svc = server->createService(SERVICE_UUID);
 
     rx_char = svc->createCharacteristic(
         RX_CHAR_UUID,
-        NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR
-    );
+        NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR);
     static RxCallbacks rxCb;
     rx_char->setCallbacks(&rxCb);
 
     tx_char = svc->createCharacteristic(
         TX_CHAR_UUID,
-        NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY
-    );
+        NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
 
     req_char = svc->createCharacteristic(
         REQ_CHAR_UUID,
-        NIMBLE_PROPERTY::NOTIFY
-    );
+        NIMBLE_PROPERTY::NOTIFY);
     static ReqCallbacks reqCb;
     req_char->setCallbacks(&reqCb);
 
@@ -158,59 +197,79 @@ void ble_init(void) {
     Serial.printf("BLE: init complete, MAC=%s\n", mac_str);
 }
 
-void ble_tick(void) {
-    if (need_advertise) {
-        need_advertise = false;
-        start_advertising();
+void ble_tick(void)
+{
+    if (need_advertise)
+    {
+        // Throttle retries; some stacks need a short cool-down after failure.
+        uint32_t now = millis();
+        if (now - last_adv_attempt_ms >= 2000)
+        {
+            need_advertise = false;
+            start_advertising();
+        }
     }
 }
 
-ble_state_t ble_get_state(void) {
+ble_state_t ble_get_state(void)
+{
     return state;
 }
 
-const char* ble_get_device_name(void) {
+const char *ble_get_device_name(void)
+{
     return DEVICE_NAME;
 }
 
-const char* ble_get_mac_address(void) {
+const char *ble_get_mac_address(void)
+{
     return mac_str;
 }
 
-void ble_clear_bonds(void) {
+void ble_clear_bonds(void)
+{
     NimBLEDevice::deleteAllBonds();
     Serial.println("BLE: bonds cleared");
-    if (state == BLE_STATE_CONNECTED) {
+    if (state == BLE_STATE_CONNECTED)
+    {
         server->disconnect(server->getPeerInfo(0).getConnHandle());
     }
     need_advertise = true;
 }
 
-bool ble_has_data(void) {
+bool ble_has_data(void)
+{
     return data_ready;
 }
 
-const char* ble_get_data(void) {
+const char *ble_get_data(void)
+{
     data_ready = false;
     return rx_buf;
 }
 
-void ble_send_ack(void) {
-    if (state == BLE_STATE_CONNECTED && tx_char) {
+void ble_send_ack(void)
+{
+    if (state == BLE_STATE_CONNECTED && tx_char)
+    {
         tx_char->setValue("{\"ack\":true}");
         tx_char->notify();
     }
 }
 
-void ble_send_nack(void) {
-    if (state == BLE_STATE_CONNECTED && tx_char) {
+void ble_send_nack(void)
+{
+    if (state == BLE_STATE_CONNECTED && tx_char)
+    {
         tx_char->setValue("{\"err\":true}");
         tx_char->notify();
     }
 }
 
-void ble_request_refresh(void) {
-    if (state == BLE_STATE_CONNECTED && req_char) {
+void ble_request_refresh(void)
+{
+    if (state == BLE_STATE_CONNECTED && req_char)
+    {
         uint8_t v = 0x01;
         req_char->setValue(&v, 1);
         req_char->notify();
@@ -218,16 +277,20 @@ void ble_request_refresh(void) {
     }
 }
 
-void ble_keyboard_press(uint8_t key, uint8_t modifier) {
-    if (state != BLE_STATE_CONNECTED || !input_kbd) return;
+void ble_keyboard_press(uint8_t key, uint8_t modifier)
+{
+    if (state != BLE_STATE_CONNECTED || !input_kbd)
+        return;
     // HID report: [modifier, reserved, key1, key2, key3, key4, key5, key6]
     uint8_t report[8] = {modifier, 0, key, 0, 0, 0, 0, 0};
     input_kbd->setValue(report, sizeof(report));
     input_kbd->notify();
 }
 
-void ble_keyboard_release(void) {
-    if (state != BLE_STATE_CONNECTED || !input_kbd) return;
+void ble_keyboard_release(void)
+{
+    if (state != BLE_STATE_CONNECTED || !input_kbd)
+        return;
     uint8_t report[8] = {0};
     input_kbd->setValue(report, sizeof(report));
     input_kbd->notify();

--- a/firmware/src/display_cfg.h
+++ b/firmware/src/display_cfg.h
@@ -1,16 +1,49 @@
 #pragma once
 
 #include <Arduino_GFX_Library.h>
+#include <Wire.h>
+
+#ifdef BOARD_XINGZHI_CUBE
+// ---- xingzhi-cube 1.83" 2mic (ESP32-S3) ----
+// Display: ST7789 SPI LCD, 284×240 landscape
+// No touch, no PMU, no IMU on this board.
+
+#define LCD_WIDTH    284
+#define LCD_HEIGHT   240
+
+// SPI LCD pins
+#define LCD_SPI_CLK  9
+#define LCD_SPI_MOSI 10
+#define LCD_CS       14
+#define LCD_DC       8
+#define LCD_RST      18
+#define LCD_BL       13    // LEDC PWM backlight (TIMER_0, CH_0)
+
+// Buttons (all active LOW with internal pull-ups)
+//   BTN_WAKE (GPIO  0) — Space / voice push-to-talk (press + release tracked)
+//   BTN_VOL  (GPIO 40) — Shift+Tab / mode toggle
+//   BTN_MID  (GPIO 39) — cycle screens / cycle splash animations
+#define BTN_WAKE     0
+#define BTN_VOL      40
+#define BTN_MID      39
+
+// WS2812 RGB LED — reserved, not used by Clawdmeter firmware
+#define LED_WS2812   48
+
+// Global display object (base-class pointer; concrete type is Arduino_ST7789)
+extern Arduino_GFX *gfx;
+
+#else  // ---- Waveshare ESP32-S3-Touch-AMOLED-2.16 (default) ----
+// Display: CO5300 QSPI AMOLED 480×480
+
 #include <TouchDrvCSTXXX.hpp>
 #include <XPowersLib.h>
 #include <SensorQMI8658.hpp>
-#include <Wire.h>
 
-// ---- Display resolution ----
 #define LCD_WIDTH   480
 #define LCD_HEIGHT  480
 
-// ---- QSPI display pins (CO5300) ----
+// QSPI display pins (CO5300)
 #define LCD_CS      12
 #define LCD_SCLK    38
 #define LCD_SDIO0   4
@@ -19,19 +52,22 @@
 #define LCD_SDIO3   7
 #define LCD_RESET   2
 
-// ---- Touch pins (CST9220 via I2C) ----
+// I2C bus (touch + PMU + IMU share one bus)
 #define IIC_SDA     15
 #define IIC_SCL     14
 #define TP_INT      11
 #define TP_RST      2    // shared with LCD_RESET
 #define CST9220_ADDR 0x5A
-
-// ---- PMU (AXP2101 via same I2C) ----
 #define AXP2101_ADDR 0x34
 
-// ---- Global hardware objects (defined in main.cpp) ----
-extern Arduino_DataBus *bus;
-extern Arduino_CO5300 *gfx;
-extern TouchDrvCST92xx touch;
-extern XPowersPMU pmu;
-extern SensorQMI8658 imu;
+// Physical buttons
+#define BTN_BACK 0
+#define BTN_FWD  18
+
+// Global hardware objects (defined in main.cpp)
+extern Arduino_GFX     *gfx;
+extern TouchDrvCST92xx  touch;
+extern XPowersPMU       pmu;
+extern SensorQMI8658    imu;
+
+#endif // BOARD_XINGZHI_CUBE

--- a/firmware/src/imu.cpp
+++ b/firmware/src/imu.cpp
@@ -2,6 +2,8 @@
 #include "display_cfg.h"
 #include <Arduino.h>
 
+#ifndef BOARD_XINGZHI_CUBE
+
 // Poll and hysteresis timing
 #define IMU_POLL_MS       100    // read accel at ~10 Hz
 #define STABLE_TIME_MS    300    // orientation must be stable this long before rotating
@@ -74,3 +76,11 @@ void imu_tick(void) {
 uint8_t imu_get_rotation(void) {
     return current_rotation;
 }
+
+#else  // BOARD_XINGZHI_CUBE — no IMU; rotation is always 0
+
+void    imu_init(void)          {}
+void    imu_tick(void)          {}
+uint8_t imu_get_rotation(void)  { return 0; }
+
+#endif // BOARD_XINGZHI_CUBE

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -10,26 +10,126 @@
 #include "splash.h"
 #include "usage_rate.h"
 
+#ifdef BOARD_XINGZHI_CUBE
+// ---- xingzhi-cube hardware objects ----
+// Buttons: BTN_WAKE/BTN_VOL/BTN_MID defined in display_cfg.h
+// Unified names for shared button logic:
+#define BTN_LEFT   BTN_WAKE  // GPIO  0 — Space / voice push-to-talk
+#define BTN_RIGHT  BTN_VOL   // GPIO 40 — Shift+Tab / mode toggle
+// BTN_MID (GPIO 39) replaces AXP PWR button for screen cycling
+
+
+// Vendor-specific init sequence for the xingzhi-cube 1.83" ST7789V-like panel.
+// Recovered from the board's ESPHome YAML. Without this the screen stays blank.
+// Includes SLPOUT at the end, followed by the minimal standard setup.
+// NOTE: Arduino_ST7789::tftInit() always sends SWRESET which would wipe these
+// vendor registers, so we do NOT call super — we handle the full init here.
+static const uint8_t xingzhi_vendor_init[] = {
+    BEGIN_WRITE,
+    WRITE_C8_BYTES, 0xFD, 2, 0x06, 0x08,
+    WRITE_C8_BYTES, 0x61, 2, 0x07, 0x04,
+    WRITE_C8_BYTES, 0x62, 3, 0x00, 0x44, 0x45,
+    WRITE_C8_BYTES, 0x63, 4, 0x41, 0x07, 0x12, 0x12,
+    WRITE_C8_D8,    0x64, 0x37,
+    WRITE_C8_BYTES, 0x65, 3, 0x09, 0x10, 0x21,
+    WRITE_C8_BYTES, 0x66, 3, 0x09, 0x10, 0x21,
+    WRITE_C8_BYTES, 0x67, 2, 0x20, 0x40,
+    WRITE_C8_BYTES, 0x68, 4, 0x90, 0x4C, 0x7C, 0x66,
+    WRITE_C8_BYTES, 0xB1, 3, 0x0F, 0x02, 0x01,
+    WRITE_C8_D8,    0xB4, 0x01,
+    WRITE_C8_BYTES, 0xB5, 4, 0x02, 0x02, 0x0A, 0x14,
+    WRITE_C8_BYTES, 0xB6, 5, 0x04, 0x01, 0x9F, 0x00, 0x02,
+    WRITE_C8_D8,    0xDF, 0x11,
+    WRITE_C8_BYTES, 0xE2, 6, 0x13, 0x00, 0x00, 0x30, 0x33, 0x3F,
+    WRITE_C8_BYTES, 0xE5, 6, 0x3F, 0x33, 0x30, 0x00, 0x00, 0x13,
+    WRITE_C8_BYTES, 0xE1, 2, 0x00, 0x57,
+    WRITE_C8_BYTES, 0xE4, 2, 0x58, 0x00,
+    WRITE_C8_BYTES, 0xE0, 8, 0x01, 0x03, 0x0D, 0x0E, 0x0E, 0x0C, 0x15, 0x19,
+    WRITE_C8_BYTES, 0xE3, 8, 0x1A, 0x16, 0x0C, 0x0F, 0x0E, 0x0D, 0x02, 0x01,
+    WRITE_C8_BYTES, 0xE6, 2, 0x00, 0xFF,
+    WRITE_C8_BYTES, 0xE7, 6, 0x01, 0x04, 0x03, 0x03, 0x00, 0x12,
+    WRITE_C8_BYTES, 0xE8, 3, 0x00, 0x70, 0x00,
+    WRITE_C8_D8,    0xEC, 0x52,
+    WRITE_C8_BYTES, 0xF1, 3, 0x01, 0x01, 0x02,
+    WRITE_C8_BYTES, 0xF6, 4, 0x09, 0x10, 0x00, 0x00,
+    WRITE_C8_BYTES, 0xFD, 2, 0xFA, 0xFC,
+    WRITE_C8_D8,    0x35, 0x00,     // TEON  — tearing effect line on
+    WRITE_COMMAND_8, 0x11,          // SLPOUT
+    DELAY, 120,                     // 120 ms for SLPOUT to settle
+    WRITE_C8_D8,    0x3A, 0x55,     // COLMOD — RGB565
+    WRITE_COMMAND_8, 0x13,          // NORON
+    WRITE_COMMAND_8, 0x29,          // DISPON
+    END_WRITE,
+};
+
+class CalibratedST7789 : public Arduino_ST7789 {
+public:
+    using Arduino_ST7789::Arduino_ST7789;
+
+    void setPanelOffsets(uint8_t c1, uint8_t r1, uint8_t c2, uint8_t r2, uint8_t rot) {
+        COL_OFFSET1 = c1;
+        ROW_OFFSET1 = r1;
+        COL_OFFSET2 = c2;
+        ROW_OFFSET2 = r2;
+        setRotation(rot);
+    }
+
+protected:
+    void tftInit() override {
+        // Hardware reset — Arduino_ST7789::tftInit() would SWRESET after this,
+        // wiping our vendor registers, so we handle the full init ourselves.
+        if (_rst != GFX_NOT_DEFINED) {
+            pinMode(_rst, OUTPUT);
+            digitalWrite(_rst, HIGH);
+            delay(10);
+            digitalWrite(_rst, LOW);
+            delay(20);
+            digitalWrite(_rst, HIGH);
+            delay(120);
+        }
+        // Vendor init + COLMOD + NORON + DISPON — no SWRESET
+        _bus->batchOperation(xingzhi_vendor_init, sizeof(xingzhi_vendor_init));
+        // invertDisplay() is called by the caller (main.cpp) after begin()
+    }
+};
+
+static Arduino_DataBus *bus = new Arduino_ESP32SPI(
+    LCD_DC, LCD_CS, LCD_SPI_CLK, LCD_SPI_MOSI);
+// rotation=3 -> MADCTL MY+MV, which matches swap_xy + mirror_y.
+// Arduino_TFT maps rotation=3 offsets as: xStart=ROW_OFFSET2, yStart=COL_OFFSET1.
+// We need gap_x=36, gap_y=0 -> ROW_OFFSET2=36 and COL_OFFSET1=0.
+static CalibratedST7789 *st7789_gfx = new CalibratedST7789(
+    bus, LCD_RST,
+    3,           // rotation: swap_xy + mirror_y -> landscape
+    false,       // IPS = false
+    240, 284,    // native W×H (portrait); rotation=1 yields 284×240 logical
+    0, 0,        // col_offset1, row_offset1
+    0, 36);      // col_offset2, row_offset2
+Arduino_GFX *gfx = st7789_gfx;
+
+
+#else  // Waveshare ESP32-S3-Touch-AMOLED-2.16
 // Physical buttons (global, screen-independent):
 //   BTN_BACK   (GPIO 0)  — left,  send Space (Claude Code voice mode push-to-talk)
 //   BTN_FWD    (GPIO 18) — right, send Shift+Tab (Claude Code mode toggle)
 //   AXP PWR    (PMU)     — middle, cycle screens; on splash, cycle animations
-#define BTN_BACK 0
-#define BTN_FWD  18
+#define BTN_LEFT   BTN_BACK
+#define BTN_RIGHT  BTN_FWD
 
-// ---- Hardware objects ----
-Arduino_DataBus *bus = new Arduino_ESP32QSPI(
+static Arduino_DataBus *bus = new Arduino_ESP32QSPI(
     LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
-Arduino_CO5300 *gfx = new Arduino_CO5300(
+Arduino_GFX *gfx = new Arduino_CO5300(
     bus, LCD_RESET, 0 /* rotation */,
     LCD_WIDTH, LCD_HEIGHT, 0, 0, 0, 0);
 TouchDrvCST92xx touch;
 XPowersPMU pmu;
 SensorQMI8658 imu;
+#endif
 
 static UsageData usage = {};
 
-// ---- Touch interrupt + shared state ----
+#ifndef BOARD_XINGZHI_CUBE
+// ---- Touch interrupt + shared state (Waveshare only) ----
 static volatile bool     touch_pressed = false;
 static volatile uint16_t touch_x = 0;
 static volatile uint16_t touch_y = 0;
@@ -53,20 +153,23 @@ static void touch_read() {
         touch_pressed = false;
     }
 }
+#endif // BOARD_XINGZHI_CUBE
 
 // ---- LVGL draw buffers (PSRAM-backed, partial render) ----
 #define BUF_LINES 40
 static uint16_t *buf1 = nullptr;
 static uint16_t *buf2 = nullptr;
+#ifndef BOARD_XINGZHI_CUBE
 // rot_buf for strip rotation — max size is 480×480 (full invalidation case)
-// but typical partial strips are much smaller
 static uint16_t *rot_buf = nullptr;
+#endif
 
 // LVGL tick callback
 static uint32_t my_tick(void) {
     return millis();
 }
 
+#ifndef BOARD_XINGZHI_CUBE
 // Rotate a w×h strip and compute destination coordinates on the 480×480 display.
 // src pixels are in row-major order for the rectangle (sx, sy, w, h).
 // Output goes to rot_buf in row-major order for the destination rectangle.
@@ -116,14 +219,34 @@ static void rotate_strip(const uint16_t *src, int32_t w, int32_t h,
         break;
     }
 }
+#endif // BOARD_XINGZHI_CUBE
 
-// LVGL flush callback — rotates partial strips and writes to display
+// ---- Backlight control (board-specific) ----
+#ifdef BOARD_XINGZHI_CUBE
+// LEDC PWM backlight on GPIO LCD_BL (0–255)
+static void lcd_backlight_init(void) {
+    ledcAttach(LCD_BL, 5000, 8);  // 5kHz, 8-bit resolution
+    ledcWrite(LCD_BL, 0);
+}
+static void lcd_set_brightness(uint8_t val) {
+    ledcWrite(LCD_BL, val);
+}
+#else
+// CO5300 has on-chip brightness register (0–255)
+static void lcd_backlight_init(void) {}  // nothing extra needed
+static void lcd_set_brightness(uint8_t val) {
+    gfx->setBrightness(val);
+}
+#endif
+
+// LVGL flush callback
 static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
     int32_t w = area->x2 - area->x1 + 1;
     int32_t h = area->y2 - area->y1 + 1;
     uint16_t *src = (uint16_t*)px_map;
+#ifndef BOARD_XINGZHI_CUBE
+    // Waveshare: CPU-side strip rotation for auto-rotate via IMU
     uint8_t r = imu_get_rotation();
-
     if (r == 0) {
         gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
     } else {
@@ -131,9 +254,14 @@ static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_m
         rotate_strip(src, w, h, area->x1, area->y1, r, &dx, &dy, &dw, &dh);
         gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
     }
+#else
+    // xingzhi-cube: fixed orientation, direct blit
+    gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
+#endif
     lv_display_flush_ready(disp);
 }
 
+#ifndef BOARD_XINGZHI_CUBE
 // CO5300 requires even-aligned flush regions
 static void rounder_cb(lv_event_t* e) {
     lv_area_t *area = (lv_area_t*)lv_event_get_param(e);
@@ -143,7 +271,7 @@ static void rounder_cb(lv_event_t* e) {
     area->y2 = area->y2 | 1;
 }
 
-// LVGL touch callback
+// LVGL touch callback (Waveshare only)
 static void my_touch_cb(lv_indev_t* indev, lv_indev_data_t* data) {
     if (touch_pressed) {
         data->point.x = touch_x;
@@ -153,6 +281,7 @@ static void my_touch_cb(lv_indev_t* indev, lv_indev_data_t* data) {
         data->state = LV_INDEV_STATE_RELEASED;
     }
 }
+#endif // BOARD_XINGZHI_CUBE
 
 // Parse a JSON line into UsageData
 static bool parse_json(const char* json, UsageData* out) {
@@ -228,21 +357,29 @@ void setup() {
     delay(300);
     Serial.println("{\"ready\":true}");
 
-    // Init I2C (shared by touch + PMU)
+#ifndef BOARD_XINGZHI_CUBE
+    // Init I2C (shared by touch + PMU + IMU on Waveshare)
     Wire.begin(IIC_SDA, IIC_SCL);
+#endif
 
     // Init display
+    lcd_backlight_init();
     gfx->begin();
+#ifdef BOARD_XINGZHI_CUBE
+    // This panel's known-good setup uses inverted colors.
+    gfx->invertDisplay(true);
+#endif
     gfx->fillScreen(0x0000);
-    gfx->setBrightness(200);
+    lcd_set_brightness(200);
 
-    // Init PMU
+    // Init PMU (stubbed on xingzhi)
     power_init();
 
-    // Init IMU (accelerometer for auto-rotation)
+    // Init IMU for auto-rotation (stubbed on xingzhi — always returns 0)
     imu_init();
 
-    // Init touch
+#ifndef BOARD_XINGZHI_CUBE
+    // Init touch (Waveshare only)
     touch.setPins(TP_RST, TP_INT);
     if (!touch.begin(Wire, CST9220_ADDR, IIC_SDA, IIC_SCL)) {
         Serial.println("Touch init failed");
@@ -253,6 +390,7 @@ void setup() {
         attachInterrupt(TP_INT, touch_isr, FALLING);
         Serial.println("Touch init OK");
     }
+#endif
 
     // Init LVGL
     lv_init();
@@ -261,9 +399,10 @@ void setup() {
     // Allocate PSRAM-backed partial render buffers
     buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
     buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-    // rot_buf needs to hold the largest possible strip after rotation
-    // A 480×40 strip rotated 90° becomes 40×480, same pixel count
+#ifndef BOARD_XINGZHI_CUBE
+    // rot_buf for IMU-driven strip rotation (Waveshare only)
     rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+#endif
 
     lv_display_t* disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
     lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
@@ -271,19 +410,27 @@ void setup() {
     lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
                            LV_DISPLAY_RENDER_MODE_PARTIAL);
 
-    // CO5300 even-alignment rounder
+#ifndef BOARD_XINGZHI_CUBE
+    // CO5300 requires even-aligned flush regions
     lv_display_add_event_cb(disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, NULL);
 
     lv_indev_t* indev = lv_indev_create();
     lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
     lv_indev_set_read_cb(indev, my_touch_cb);
+#endif
 
     // Init BLE data channel
     ble_init();
 
-    // Physical buttons: back (GPIO 0) and forward (GPIO 18)
+    // Physical buttons
+#ifdef BOARD_XINGZHI_CUBE
+    pinMode(BTN_WAKE, INPUT_PULLUP);
+    pinMode(BTN_VOL,  INPUT_PULLUP);
+    pinMode(BTN_MID,  INPUT_PULLUP);
+#else
     pinMode(BTN_BACK, INPUT_PULLUP);
     pinMode(BTN_FWD,  INPUT_PULLUP);
+#endif
 
     // Build dashboard
     ui_init();
@@ -294,17 +441,21 @@ void setup() {
     // Show initial battery status
     ui_update_battery(power_battery_pct(), power_is_charging());
 
+#ifdef BOARD_XINGZHI_CUBE
+    // Start on Usage for xingzhi so a dark splash palette can't look like a blank panel.
+    ui_show_screen(SCREEN_USAGE);
+#else
     ui_show_screen(SCREEN_SPLASH);
+#endif
 
     Serial.println("Dashboard ready, waiting for data on BLE...");
 }
 
 static ble_state_t last_ble_state = BLE_STATE_INIT;
 
-// Brightness ramp state for rotation transition
-// On rotation change we blank the panel, force a full LVGL redraw at the
-// new orientation, then ramp brightness back up over ~125ms so the
-// transition reads as deliberate instead of as a glitch.
+// Brightness ramp for rotation transition (Waveshare/CO5300 only)
+// On rotation change: blank panel, force full LVGL redraw, ramp brightness back.
+#ifndef BOARD_XINGZHI_CUBE
 static void handle_rotation_change(void) {
     static uint8_t last_rotation = 0;
     static uint8_t  ramp_step = 0;  // 0=idle, 1-4=ramping
@@ -312,7 +463,7 @@ static void handle_rotation_change(void) {
 
     uint8_t rot = imu_get_rotation();
     if (rot != last_rotation) {
-        gfx->setBrightness(0);
+        lcd_set_brightness(0);
         last_rotation = rot;
         lv_obj_invalidate(lv_screen_active());
         ramp_step = 1;
@@ -325,13 +476,16 @@ static void handle_rotation_change(void) {
     ramp_last = now;
 
     static const uint8_t levels[] = {60, 120, 170, 200};
-    gfx->setBrightness(levels[ramp_step - 1]);
+    lcd_set_brightness(levels[ramp_step - 1]);
     if (ramp_step >= 4) ramp_step = 0;
     else                ramp_step++;
 }
+#endif // BOARD_XINGZHI_CUBE
 
 void loop() {
+#ifndef BOARD_XINGZHI_CUBE
     touch_read();
+#endif
     lv_timer_handler();
     ui_tick_anim();
     ble_tick();
@@ -340,13 +494,14 @@ void loop() {
     splash_tick();
 
     // Three-button input (global, screen-independent):
-    //   LEFT  (GPIO 0)  → Space (voice-mode push-to-talk; press & release tracked)
-    //   RIGHT (GPIO 18) → Shift+Tab (Claude Code mode toggle)
-    //   PWR   (AXP)     → cycle screens; on splash, cycle animations
+    //   LEFT   — Space (voice-mode push-to-talk; press & release tracked)
+    //   RIGHT  — Shift+Tab (Claude Code mode toggle)
+    //   MIDDLE — cycle screens; on splash, cycle animations
+    //           (xingzhi: GPIO39 / Waveshare: AXP PMU short-press)
     {
         static bool back_was = false, fwd_was = false;
-        bool back_now = (digitalRead(BTN_BACK) == LOW);
-        bool fwd_now  = (digitalRead(BTN_FWD)  == LOW);
+        bool back_now = (digitalRead(BTN_LEFT)  == LOW);
+        bool fwd_now  = (digitalRead(BTN_RIGHT) == LOW);
 
         if (back_now != back_was) {
             if (back_now) ble_keyboard_press(0x2C, 0);  // HID Space, no mods
@@ -359,13 +514,30 @@ void loop() {
             fwd_was = fwd_now;
         }
 
+#ifdef BOARD_XINGZHI_CUBE
+        // xingzhi: GPIO39 (BTN_MID) always cycles screens so we can
+        // recover even if splash content appears too dark.
+        static bool mid_was = false;
+        bool mid_now = (digitalRead(BTN_MID) == LOW);
+        if (!mid_now && mid_was) {  // trigger on release
+            screen_t s = ui_get_current_screen();
+            if (s == SCREEN_USAGE)          ui_show_screen(SCREEN_BLUETOOTH);
+            else if (s == SCREEN_BLUETOOTH) ui_show_screen(SCREEN_SPLASH);
+            else                            ui_show_screen(SCREEN_USAGE);
+        }
+        mid_was = mid_now;
+#else
+        // Waveshare: AXP PWR short-press is the cycle button
         if (power_pwr_pressed()) {
             if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
             else                                          ui_cycle_screen();
         }
+#endif  // BOARD_XINGZHI_CUBE
     }
 
+#ifndef BOARD_XINGZHI_CUBE
     handle_rotation_change();
+#endif
 
     // Update BLE status on screen when state changes
     ble_state_t bs = ble_get_state();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -269,9 +269,10 @@ Arduino_GFX *gfx = st7789_gfx;
 
 static Arduino_DataBus *bus = new Arduino_ESP32QSPI(
     LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
-Arduino_GFX *gfx = new Arduino_CO5300(
+static Arduino_CO5300 *co5300_gfx = new Arduino_CO5300(
     bus, LCD_RESET, 0 /* rotation */,
     LCD_WIDTH, LCD_HEIGHT, 0, 0, 0, 0);
+Arduino_GFX *gfx = co5300_gfx;
 TouchDrvCST92xx touch;
 XPowersPMU pmu;
 SensorQMI8658 imu;
@@ -431,7 +432,7 @@ static void lcd_set_brightness(uint8_t val)
 static void lcd_backlight_init(void) {} // nothing extra needed
 static void lcd_set_brightness(uint8_t val)
 {
-    gfx->setBrightness(val);
+    co5300_gfx->setBrightness(val);
 }
 #endif
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -14,10 +14,9 @@
 // ---- xingzhi-cube hardware objects ----
 // Buttons: BTN_WAKE/BTN_VOL/BTN_MID defined in display_cfg.h
 // Unified names for shared button logic:
-#define BTN_LEFT   BTN_WAKE  // GPIO  0 — Space / voice push-to-talk
-#define BTN_RIGHT  BTN_VOL   // GPIO 40 — Shift+Tab / mode toggle
+#define BTN_LEFT BTN_WAKE // GPIO  0 — Space / voice push-to-talk
+#define BTN_RIGHT BTN_VOL // GPIO 40 — Shift+Tab / mode toggle
 // BTN_MID (GPIO 39) replaces AXP PWR button for screen cycling
-
 
 // Vendor-specific init sequence for the xingzhi-cube 1.83" ST7789V-like panel.
 // Recovered from the board's ESPHome YAML. Without this the screen stays blank.
@@ -26,47 +25,198 @@
 // vendor registers, so we do NOT call super — we handle the full init here.
 static const uint8_t xingzhi_vendor_init[] = {
     BEGIN_WRITE,
-    WRITE_C8_BYTES, 0xFD, 2, 0x06, 0x08,
-    WRITE_C8_BYTES, 0x61, 2, 0x07, 0x04,
-    WRITE_C8_BYTES, 0x62, 3, 0x00, 0x44, 0x45,
-    WRITE_C8_BYTES, 0x63, 4, 0x41, 0x07, 0x12, 0x12,
-    WRITE_C8_D8,    0x64, 0x37,
-    WRITE_C8_BYTES, 0x65, 3, 0x09, 0x10, 0x21,
-    WRITE_C8_BYTES, 0x66, 3, 0x09, 0x10, 0x21,
-    WRITE_C8_BYTES, 0x67, 2, 0x20, 0x40,
-    WRITE_C8_BYTES, 0x68, 4, 0x90, 0x4C, 0x7C, 0x66,
-    WRITE_C8_BYTES, 0xB1, 3, 0x0F, 0x02, 0x01,
-    WRITE_C8_D8,    0xB4, 0x01,
-    WRITE_C8_BYTES, 0xB5, 4, 0x02, 0x02, 0x0A, 0x14,
-    WRITE_C8_BYTES, 0xB6, 5, 0x04, 0x01, 0x9F, 0x00, 0x02,
-    WRITE_C8_D8,    0xDF, 0x11,
-    WRITE_C8_BYTES, 0xE2, 6, 0x13, 0x00, 0x00, 0x30, 0x33, 0x3F,
-    WRITE_C8_BYTES, 0xE5, 6, 0x3F, 0x33, 0x30, 0x00, 0x00, 0x13,
-    WRITE_C8_BYTES, 0xE1, 2, 0x00, 0x57,
-    WRITE_C8_BYTES, 0xE4, 2, 0x58, 0x00,
-    WRITE_C8_BYTES, 0xE0, 8, 0x01, 0x03, 0x0D, 0x0E, 0x0E, 0x0C, 0x15, 0x19,
-    WRITE_C8_BYTES, 0xE3, 8, 0x1A, 0x16, 0x0C, 0x0F, 0x0E, 0x0D, 0x02, 0x01,
-    WRITE_C8_BYTES, 0xE6, 2, 0x00, 0xFF,
-    WRITE_C8_BYTES, 0xE7, 6, 0x01, 0x04, 0x03, 0x03, 0x00, 0x12,
-    WRITE_C8_BYTES, 0xE8, 3, 0x00, 0x70, 0x00,
-    WRITE_C8_D8,    0xEC, 0x52,
-    WRITE_C8_BYTES, 0xF1, 3, 0x01, 0x01, 0x02,
-    WRITE_C8_BYTES, 0xF6, 4, 0x09, 0x10, 0x00, 0x00,
-    WRITE_C8_BYTES, 0xFD, 2, 0xFA, 0xFC,
-    WRITE_C8_D8,    0x35, 0x00,     // TEON  — tearing effect line on
-    WRITE_COMMAND_8, 0x11,          // SLPOUT
-    DELAY, 120,                     // 120 ms for SLPOUT to settle
-    WRITE_C8_D8,    0x3A, 0x55,     // COLMOD — RGB565
-    WRITE_COMMAND_8, 0x13,          // NORON
-    WRITE_COMMAND_8, 0x29,          // DISPON
+    WRITE_C8_BYTES,
+    0xFD,
+    2,
+    0x06,
+    0x08,
+    WRITE_C8_BYTES,
+    0x61,
+    2,
+    0x07,
+    0x04,
+    WRITE_C8_BYTES,
+    0x62,
+    3,
+    0x00,
+    0x44,
+    0x45,
+    WRITE_C8_BYTES,
+    0x63,
+    4,
+    0x41,
+    0x07,
+    0x12,
+    0x12,
+    WRITE_C8_D8,
+    0x64,
+    0x37,
+    WRITE_C8_BYTES,
+    0x65,
+    3,
+    0x09,
+    0x10,
+    0x21,
+    WRITE_C8_BYTES,
+    0x66,
+    3,
+    0x09,
+    0x10,
+    0x21,
+    WRITE_C8_BYTES,
+    0x67,
+    2,
+    0x20,
+    0x40,
+    WRITE_C8_BYTES,
+    0x68,
+    4,
+    0x90,
+    0x4C,
+    0x7C,
+    0x66,
+    WRITE_C8_BYTES,
+    0xB1,
+    3,
+    0x0F,
+    0x02,
+    0x01,
+    WRITE_C8_D8,
+    0xB4,
+    0x01,
+    WRITE_C8_BYTES,
+    0xB5,
+    4,
+    0x02,
+    0x02,
+    0x0A,
+    0x14,
+    WRITE_C8_BYTES,
+    0xB6,
+    5,
+    0x04,
+    0x01,
+    0x9F,
+    0x00,
+    0x02,
+    WRITE_C8_D8,
+    0xDF,
+    0x11,
+    WRITE_C8_BYTES,
+    0xE2,
+    6,
+    0x13,
+    0x00,
+    0x00,
+    0x30,
+    0x33,
+    0x3F,
+    WRITE_C8_BYTES,
+    0xE5,
+    6,
+    0x3F,
+    0x33,
+    0x30,
+    0x00,
+    0x00,
+    0x13,
+    WRITE_C8_BYTES,
+    0xE1,
+    2,
+    0x00,
+    0x57,
+    WRITE_C8_BYTES,
+    0xE4,
+    2,
+    0x58,
+    0x00,
+    WRITE_C8_BYTES,
+    0xE0,
+    8,
+    0x01,
+    0x03,
+    0x0D,
+    0x0E,
+    0x0E,
+    0x0C,
+    0x15,
+    0x19,
+    WRITE_C8_BYTES,
+    0xE3,
+    8,
+    0x1A,
+    0x16,
+    0x0C,
+    0x0F,
+    0x0E,
+    0x0D,
+    0x02,
+    0x01,
+    WRITE_C8_BYTES,
+    0xE6,
+    2,
+    0x00,
+    0xFF,
+    WRITE_C8_BYTES,
+    0xE7,
+    6,
+    0x01,
+    0x04,
+    0x03,
+    0x03,
+    0x00,
+    0x12,
+    WRITE_C8_BYTES,
+    0xE8,
+    3,
+    0x00,
+    0x70,
+    0x00,
+    WRITE_C8_D8,
+    0xEC,
+    0x52,
+    WRITE_C8_BYTES,
+    0xF1,
+    3,
+    0x01,
+    0x01,
+    0x02,
+    WRITE_C8_BYTES,
+    0xF6,
+    4,
+    0x09,
+    0x10,
+    0x00,
+    0x00,
+    WRITE_C8_BYTES,
+    0xFD,
+    2,
+    0xFA,
+    0xFC,
+    WRITE_C8_D8,
+    0x35,
+    0x00, // TEON  — tearing effect line on
+    WRITE_COMMAND_8,
+    0x11, // SLPOUT
+    DELAY,
+    120, // 120 ms for SLPOUT to settle
+    WRITE_C8_D8,
+    0x3A,
+    0x55, // COLMOD — RGB565
+    WRITE_COMMAND_8,
+    0x13, // NORON
+    WRITE_COMMAND_8,
+    0x29, // DISPON
     END_WRITE,
 };
 
-class CalibratedST7789 : public Arduino_ST7789 {
+class CalibratedST7789 : public Arduino_ST7789
+{
 public:
     using Arduino_ST7789::Arduino_ST7789;
 
-    void setPanelOffsets(uint8_t c1, uint8_t r1, uint8_t c2, uint8_t r2, uint8_t rot) {
+    void setPanelOffsets(uint8_t c1, uint8_t r1, uint8_t c2, uint8_t r2, uint8_t rot)
+    {
         COL_OFFSET1 = c1;
         ROW_OFFSET1 = r1;
         COL_OFFSET2 = c2;
@@ -75,10 +225,12 @@ public:
     }
 
 protected:
-    void tftInit() override {
+    void tftInit() override
+    {
         // Hardware reset — Arduino_ST7789::tftInit() would SWRESET after this,
         // wiping our vendor registers, so we handle the full init ourselves.
-        if (_rst != GFX_NOT_DEFINED) {
+        if (_rst != GFX_NOT_DEFINED)
+        {
             pinMode(_rst, OUTPUT);
             digitalWrite(_rst, HIGH);
             delay(10);
@@ -100,21 +252,20 @@ static Arduino_DataBus *bus = new Arduino_ESP32SPI(
 // We need gap_x=36, gap_y=0 -> ROW_OFFSET2=36 and COL_OFFSET1=0.
 static CalibratedST7789 *st7789_gfx = new CalibratedST7789(
     bus, LCD_RST,
-    3,           // rotation: swap_xy + mirror_y -> landscape
-    false,       // IPS = false
-    240, 284,    // native W×H (portrait); rotation=1 yields 284×240 logical
-    0, 0,        // col_offset1, row_offset1
-    0, 36);      // col_offset2, row_offset2
+    3,        // rotation: swap_xy + mirror_y -> landscape
+    false,    // IPS = false
+    240, 284, // native W×H (portrait); rotation=1 yields 284×240 logical
+    0, 0,     // col_offset1, row_offset1
+    0, 36);   // col_offset2, row_offset2
 Arduino_GFX *gfx = st7789_gfx;
 
-
-#else  // Waveshare ESP32-S3-Touch-AMOLED-2.16
+#else // Waveshare ESP32-S3-Touch-AMOLED-2.16
 // Physical buttons (global, screen-independent):
 //   BTN_BACK   (GPIO 0)  — left,  send Space (Claude Code voice mode push-to-talk)
 //   BTN_FWD    (GPIO 18) — right, send Shift+Tab (Claude Code mode toggle)
 //   AXP PWR    (PMU)     — middle, cycle screens; on splash, cycle animations
-#define BTN_LEFT   BTN_BACK
-#define BTN_RIGHT  BTN_FWD
+#define BTN_LEFT BTN_BACK
+#define BTN_RIGHT BTN_FWD
 
 static Arduino_DataBus *bus = new Arduino_ESP32QSPI(
     LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
@@ -128,28 +279,51 @@ SensorQMI8658 imu;
 
 static UsageData usage = {};
 
+static const char *ble_state_name(ble_state_t s)
+{
+    switch (s)
+    {
+    case BLE_STATE_INIT:
+        return "INIT";
+    case BLE_STATE_ADVERTISING:
+        return "ADVERTISING";
+    case BLE_STATE_CONNECTED:
+        return "CONNECTED";
+    case BLE_STATE_DISCONNECTED:
+        return "DISCONNECTED";
+    default:
+        return "UNKNOWN";
+    }
+}
+
 #ifndef BOARD_XINGZHI_CUBE
 // ---- Touch interrupt + shared state (Waveshare only) ----
-static volatile bool     touch_pressed = false;
+static volatile bool touch_pressed = false;
 static volatile uint16_t touch_x = 0;
 static volatile uint16_t touch_y = 0;
-static volatile bool     touch_data_ready = false;
+static volatile bool touch_data_ready = false;
 
-static void IRAM_ATTR touch_isr(void) {
+static void IRAM_ATTR touch_isr(void)
+{
     touch_data_ready = true;
 }
 
-static void touch_read() {
-    if (!touch_data_ready) return;
+static void touch_read()
+{
+    if (!touch_data_ready)
+        return;
     touch_data_ready = false;
 
     int16_t tx[5], ty[5];
     uint8_t n = touch.getPoint(tx, ty, touch.getSupportTouchPoint());
-    if (n > 0) {
+    if (n > 0)
+    {
         touch_pressed = true;
         touch_x = (uint16_t)tx[0];
         touch_y = (uint16_t)ty[0];
-    } else {
+    }
+    else
+    {
         touch_pressed = false;
     }
 }
@@ -163,9 +337,11 @@ static uint16_t *buf2 = nullptr;
 // rot_buf for strip rotation — max size is 480×480 (full invalidation case)
 static uint16_t *rot_buf = nullptr;
 #endif
+static bool lvgl_ready = false;
 
 // LVGL tick callback
-static uint32_t my_tick(void) {
+static uint32_t my_tick(void)
+{
     return millis();
 }
 
@@ -175,39 +351,53 @@ static uint32_t my_tick(void) {
 // Output goes to rot_buf in row-major order for the destination rectangle.
 static void rotate_strip(const uint16_t *src, int32_t w, int32_t h,
                          int32_t sx, int32_t sy, uint8_t r,
-                         int32_t *dx, int32_t *dy, int32_t *dw, int32_t *dh) {
-    const int S = LCD_WIDTH;  // 480
+                         int32_t *dx, int32_t *dy, int32_t *dw, int32_t *dh)
+{
+    const int S = LCD_WIDTH; // 480
 
-    switch (r) {
-    case 1: { // 90° CW: (x,y) -> (S-1-y, x)
-        *dw = h; *dh = w;
+    switch (r)
+    {
+    case 1:
+    { // 90° CW: (x,y) -> (S-1-y, x)
+        *dw = h;
+        *dh = w;
         *dx = S - sy - h;
         *dy = sx;
-        for (int32_t y = 0; y < h; y++) {
-            for (int32_t x = 0; x < w; x++) {
+        for (int32_t y = 0; y < h; y++)
+        {
+            for (int32_t x = 0; x < w; x++)
+            {
                 // src(x,y) -> dst(h-1-y, x)
                 rot_buf[x * h + (h - 1 - y)] = src[y * w + x];
             }
         }
         break;
     }
-    case 2: { // 180°: (x,y) -> (S-1-x, S-1-y)
-        *dw = w; *dh = h;
+    case 2:
+    { // 180°: (x,y) -> (S-1-x, S-1-y)
+        *dw = w;
+        *dh = h;
         *dx = S - sx - w;
         *dy = S - sy - h;
-        for (int32_t y = 0; y < h; y++) {
-            for (int32_t x = 0; x < w; x++) {
+        for (int32_t y = 0; y < h; y++)
+        {
+            for (int32_t x = 0; x < w; x++)
+            {
                 rot_buf[(h - 1 - y) * w + (w - 1 - x)] = src[y * w + x];
             }
         }
         break;
     }
-    case 3: { // 270° CW: (x,y) -> (y, S-1-x)
-        *dw = h; *dh = w;
+    case 3:
+    { // 270° CW: (x,y) -> (y, S-1-x)
+        *dw = h;
+        *dh = w;
         *dx = sy;
         *dy = S - sx - w;
-        for (int32_t y = 0; y < h; y++) {
-            for (int32_t x = 0; x < w; x++) {
+        for (int32_t y = 0; y < h; y++)
+        {
+            for (int32_t x = 0; x < w; x++)
+            {
                 // src(x,y) -> dst(y, w-1-x)
                 rot_buf[(w - 1 - x) * h + y] = src[y * w + x];
             }
@@ -215,7 +405,10 @@ static void rotate_strip(const uint16_t *src, int32_t w, int32_t h,
         break;
     }
     default:
-        *dx = sx; *dy = sy; *dw = w; *dh = h;
+        *dx = sx;
+        *dy = sy;
+        *dw = w;
+        *dh = h;
         break;
     }
 }
@@ -224,32 +417,39 @@ static void rotate_strip(const uint16_t *src, int32_t w, int32_t h,
 // ---- Backlight control (board-specific) ----
 #ifdef BOARD_XINGZHI_CUBE
 // LEDC PWM backlight on GPIO LCD_BL (0–255)
-static void lcd_backlight_init(void) {
-    ledcAttach(LCD_BL, 5000, 8);  // 5kHz, 8-bit resolution
+static void lcd_backlight_init(void)
+{
+    ledcAttach(LCD_BL, 5000, 8); // 5kHz, 8-bit resolution
     ledcWrite(LCD_BL, 0);
 }
-static void lcd_set_brightness(uint8_t val) {
+static void lcd_set_brightness(uint8_t val)
+{
     ledcWrite(LCD_BL, val);
 }
 #else
 // CO5300 has on-chip brightness register (0–255)
-static void lcd_backlight_init(void) {}  // nothing extra needed
-static void lcd_set_brightness(uint8_t val) {
+static void lcd_backlight_init(void) {} // nothing extra needed
+static void lcd_set_brightness(uint8_t val)
+{
     gfx->setBrightness(val);
 }
 #endif
 
 // LVGL flush callback
-static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
+static void my_flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map)
+{
     int32_t w = area->x2 - area->x1 + 1;
     int32_t h = area->y2 - area->y1 + 1;
-    uint16_t *src = (uint16_t*)px_map;
+    uint16_t *src = (uint16_t *)px_map;
 #ifndef BOARD_XINGZHI_CUBE
     // Waveshare: CPU-side strip rotation for auto-rotate via IMU
     uint8_t r = imu_get_rotation();
-    if (r == 0) {
+    if (r == 0)
+    {
         gfx->draw16bitRGBBitmap(area->x1, area->y1, src, w, h);
-    } else {
+    }
+    else
+    {
         int32_t dx, dy, dw, dh;
         rotate_strip(src, w, h, area->x1, area->y1, r, &dx, &dy, &dw, &dh);
         gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
@@ -263,8 +463,9 @@ static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_m
 
 #ifndef BOARD_XINGZHI_CUBE
 // CO5300 requires even-aligned flush regions
-static void rounder_cb(lv_event_t* e) {
-    lv_area_t *area = (lv_area_t*)lv_event_get_param(e);
+static void rounder_cb(lv_event_t *e)
+{
+    lv_area_t *area = (lv_area_t *)lv_event_get_param(e);
     area->x1 = area->x1 & ~1;
     area->y1 = area->y1 & ~1;
     area->x2 = area->x2 | 1;
@@ -272,22 +473,28 @@ static void rounder_cb(lv_event_t* e) {
 }
 
 // LVGL touch callback (Waveshare only)
-static void my_touch_cb(lv_indev_t* indev, lv_indev_data_t* data) {
-    if (touch_pressed) {
+static void my_touch_cb(lv_indev_t *indev, lv_indev_data_t *data)
+{
+    if (touch_pressed)
+    {
         data->point.x = touch_x;
         data->point.y = touch_y;
         data->state = LV_INDEV_STATE_PRESSED;
-    } else {
+    }
+    else
+    {
         data->state = LV_INDEV_STATE_RELEASED;
     }
 }
 #endif // BOARD_XINGZHI_CUBE
 
 // Parse a JSON line into UsageData
-static bool parse_json(const char* json, UsageData* out) {
+static bool parse_json(const char *json, UsageData *out)
+{
     JsonDocument doc;
     DeserializationError err = deserializeJson(doc, json);
-    if (err) {
+    if (err)
+    {
         Serial.printf("JSON parse error: %s\n", err.c_str());
         return false;
     }
@@ -307,12 +514,14 @@ static bool parse_json(const char* json, UsageData* out) {
 static char cmd_buf[CMD_BUF_SIZE];
 static int cmd_pos = 0;
 
-static void send_screenshot() {
+static void send_screenshot()
+{
     const uint32_t w = LCD_WIDTH, h = LCD_HEIGHT;
     const uint32_t row_bytes = w * 2;
     const uint32_t buf_size = row_bytes * h;
-    uint8_t* sbuf = (uint8_t*)heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
-    if (!sbuf) {
+    uint8_t *sbuf = (uint8_t *)heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
+    if (!sbuf)
+    {
         Serial.println("SCREENSHOT_ERR");
         return;
     }
@@ -321,7 +530,8 @@ static void send_screenshot() {
     lv_draw_buf_init(&draw_buf, w, h, LV_COLOR_FORMAT_RGB565, row_bytes, sbuf, buf_size);
 
     lv_result_t res = lv_snapshot_take_to_draw_buf(lv_screen_active(), LV_COLOR_FORMAT_RGB565, &draw_buf);
-    if (res != LV_RESULT_OK) {
+    if (res != LV_RESULT_OK)
+    {
         heap_caps_free(sbuf);
         Serial.println("SCREENSHOT_ERR");
         return;
@@ -337,22 +547,29 @@ static void send_screenshot() {
     heap_caps_free(sbuf);
 }
 
-static void check_serial_cmd() {
-    while (Serial.available()) {
+static void check_serial_cmd()
+{
+    while (Serial.available())
+    {
         char c = Serial.read();
-        if (c == '\n' || c == '\r') {
+        if (c == '\n' || c == '\r')
+        {
             cmd_buf[cmd_pos] = '\0';
-            if (strcmp(cmd_buf, "screenshot") == 0) {
+            if (strcmp(cmd_buf, "screenshot") == 0)
+            {
                 send_screenshot();
             }
             cmd_pos = 0;
-        } else if (cmd_pos < CMD_BUF_SIZE - 1) {
+        }
+        else if (cmd_pos < CMD_BUF_SIZE - 1)
+        {
             cmd_buf[cmd_pos++] = c;
         }
     }
 }
 
-void setup() {
+void setup()
+{
     Serial.begin(115200);
     delay(300);
     Serial.println("{\"ready\":true}");
@@ -381,9 +598,12 @@ void setup() {
 #ifndef BOARD_XINGZHI_CUBE
     // Init touch (Waveshare only)
     touch.setPins(TP_RST, TP_INT);
-    if (!touch.begin(Wire, CST9220_ADDR, IIC_SDA, IIC_SCL)) {
+    if (!touch.begin(Wire, CST9220_ADDR, IIC_SDA, IIC_SCL))
+    {
         Serial.println("Touch init failed");
-    } else {
+    }
+    else
+    {
         touch.setMaxCoordinates(LCD_WIDTH, LCD_HEIGHT);
         touch.setSwapXY(true);
         touch.setMirrorXY(true, false);
@@ -392,77 +612,107 @@ void setup() {
     }
 #endif
 
+    // Init BLE data channel
+    ble_init();
+    Serial.printf("BLEDBG: mac=%s state=%s name=%s\n",
+                  ble_get_mac_address(),
+                  ble_state_name(ble_get_state()),
+                  ble_get_device_name());
+
     // Init LVGL
     lv_init();
     lv_tick_set_cb(my_tick);
 
     // Allocate PSRAM-backed partial render buffers
-    buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-    buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    buf1 = (uint16_t *)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    buf2 = (uint16_t *)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
 #ifndef BOARD_XINGZHI_CUBE
     // rot_buf for IMU-driven strip rotation (Waveshare only)
-    rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    rot_buf = (uint16_t *)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
 #endif
 
-    lv_display_t* disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
-    lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
-    lv_display_set_flush_cb(disp, my_flush_cb);
-    lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
-                           LV_DISPLAY_RENDER_MODE_PARTIAL);
+    bool lvgl_buffers_ok = (buf1 && buf2);
+#ifndef BOARD_XINGZHI_CUBE
+    lvgl_buffers_ok = lvgl_buffers_ok && (rot_buf != nullptr);
+#endif
+    if (!lvgl_buffers_ok)
+    {
+        Serial.println("LVGL buffer alloc failed; entering BLE-only safe mode");
+        gfx->fillScreen(0x0000);
+        gfx->setTextColor(0x07E0);
+        gfx->setTextSize(2);
+        gfx->setCursor(8, 24);
+        gfx->print("BLE safe mode");
+        lvgl_ready = false;
+    }
+    else
+    {
+        lv_display_t *disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
+        lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
+        lv_display_set_flush_cb(disp, my_flush_cb);
+        lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
+                               LV_DISPLAY_RENDER_MODE_PARTIAL);
 
 #ifndef BOARD_XINGZHI_CUBE
-    // CO5300 requires even-aligned flush regions
-    lv_display_add_event_cb(disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, NULL);
+        // CO5300 requires even-aligned flush regions
+        lv_display_add_event_cb(disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, NULL);
 
-    lv_indev_t* indev = lv_indev_create();
-    lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
-    lv_indev_set_read_cb(indev, my_touch_cb);
+        lv_indev_t *indev = lv_indev_create();
+        lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
+        lv_indev_set_read_cb(indev, my_touch_cb);
 #endif
-
-    // Init BLE data channel
-    ble_init();
+        lvgl_ready = true;
+    }
 
     // Physical buttons
 #ifdef BOARD_XINGZHI_CUBE
     pinMode(BTN_WAKE, INPUT_PULLUP);
-    pinMode(BTN_VOL,  INPUT_PULLUP);
-    pinMode(BTN_MID,  INPUT_PULLUP);
+    pinMode(BTN_VOL, INPUT_PULLUP);
+    pinMode(BTN_MID, INPUT_PULLUP);
 #else
     pinMode(BTN_BACK, INPUT_PULLUP);
-    pinMode(BTN_FWD,  INPUT_PULLUP);
+    pinMode(BTN_FWD, INPUT_PULLUP);
 #endif
 
     // Build dashboard
-    ui_init();
+    if (lvgl_ready)
+    {
+        ui_init();
 
-    // Show initial BLE status on Bluetooth screen
-    ui_update_ble_status(ble_get_state(), ble_get_device_name(), ble_get_mac_address());
+        // Show initial BLE status on Bluetooth screen
+        ui_update_ble_status(ble_get_state(), ble_get_device_name(), ble_get_mac_address());
 
-    // Show initial battery status
-    ui_update_battery(power_battery_pct(), power_is_charging());
+        // Show initial battery status
+        ui_update_battery(power_battery_pct(), power_is_charging());
+    }
 
 #ifdef BOARD_XINGZHI_CUBE
     // Start on Usage for xingzhi so a dark splash palette can't look like a blank panel.
-    ui_show_screen(SCREEN_USAGE);
+    if (lvgl_ready)
+        ui_show_screen(SCREEN_USAGE);
 #else
-    ui_show_screen(SCREEN_SPLASH);
+    if (lvgl_ready)
+        ui_show_screen(SCREEN_SPLASH);
 #endif
 
     Serial.println("Dashboard ready, waiting for data on BLE...");
 }
 
 static ble_state_t last_ble_state = BLE_STATE_INIT;
+static uint32_t last_ble_dbg_ms = 0;
 
 // Brightness ramp for rotation transition (Waveshare/CO5300 only)
 // On rotation change: blank panel, force full LVGL redraw, ramp brightness back.
 #ifndef BOARD_XINGZHI_CUBE
-static void handle_rotation_change(void) {
+static void handle_rotation_change(void)
+{
     static uint8_t last_rotation = 0;
-    static uint8_t  ramp_step = 0;  // 0=idle, 1-4=ramping
+    static uint8_t ramp_step = 0; // 0=idle, 1-4=ramping
     static uint32_t ramp_last = 0;
 
     uint8_t rot = imu_get_rotation();
-    if (rot != last_rotation) {
+    if (rot != last_rotation)
+    {
         lcd_set_brightness(0);
         last_rotation = rot;
         lv_obj_invalidate(lv_screen_active());
@@ -470,28 +720,36 @@ static void handle_rotation_change(void) {
         return;
     }
 
-    if (ramp_step == 0) return;
+    if (ramp_step == 0)
+        return;
     uint32_t now = millis();
-    if (now - ramp_last < 25) return;
+    if (now - ramp_last < 25)
+        return;
     ramp_last = now;
 
     static const uint8_t levels[] = {60, 120, 170, 200};
     lcd_set_brightness(levels[ramp_step - 1]);
-    if (ramp_step >= 4) ramp_step = 0;
-    else                ramp_step++;
+    if (ramp_step >= 4)
+        ramp_step = 0;
+    else
+        ramp_step++;
 }
 #endif // BOARD_XINGZHI_CUBE
 
-void loop() {
+void loop()
+{
 #ifndef BOARD_XINGZHI_CUBE
     touch_read();
 #endif
-    lv_timer_handler();
-    ui_tick_anim();
+    if (lvgl_ready)
+        lv_timer_handler();
+    if (lvgl_ready)
+        ui_tick_anim();
     ble_tick();
     power_tick();
     imu_tick();
-    splash_tick();
+    if (lvgl_ready)
+        splash_tick();
 
     // Three-button input (global, screen-independent):
     //   LEFT   — Space (voice-mode push-to-talk; press & release tracked)
@@ -500,17 +758,23 @@ void loop() {
     //           (xingzhi: GPIO39 / Waveshare: AXP PMU short-press)
     {
         static bool back_was = false, fwd_was = false;
-        bool back_now = (digitalRead(BTN_LEFT)  == LOW);
-        bool fwd_now  = (digitalRead(BTN_RIGHT) == LOW);
+        bool back_now = (digitalRead(BTN_LEFT) == LOW);
+        bool fwd_now = (digitalRead(BTN_RIGHT) == LOW);
 
-        if (back_now != back_was) {
-            if (back_now) ble_keyboard_press(0x2C, 0);  // HID Space, no mods
-            else          ble_keyboard_release();
+        if (back_now != back_was)
+        {
+            if (back_now)
+                ble_keyboard_press(0x2C, 0); // HID Space, no mods
+            else
+                ble_keyboard_release();
             back_was = back_now;
         }
-        if (fwd_now != fwd_was) {
-            if (fwd_now) ble_keyboard_press(0x2B, 0x02);  // HID Tab + LEFT_SHIFT
-            else         ble_keyboard_release();
+        if (fwd_now != fwd_was)
+        {
+            if (fwd_now)
+                ble_keyboard_press(0x2B, 0x02); // HID Tab + LEFT_SHIFT
+            else
+                ble_keyboard_release();
             fwd_was = fwd_now;
         }
 
@@ -519,20 +783,27 @@ void loop() {
         // recover even if splash content appears too dark.
         static bool mid_was = false;
         bool mid_now = (digitalRead(BTN_MID) == LOW);
-        if (!mid_now && mid_was) {  // trigger on release
+        if (lvgl_ready && !mid_now && mid_was)
+        { // trigger on release
             screen_t s = ui_get_current_screen();
-            if (s == SCREEN_USAGE)          ui_show_screen(SCREEN_BLUETOOTH);
-            else if (s == SCREEN_BLUETOOTH) ui_show_screen(SCREEN_SPLASH);
-            else                            ui_show_screen(SCREEN_USAGE);
+            if (s == SCREEN_USAGE)
+                ui_show_screen(SCREEN_BLUETOOTH);
+            else if (s == SCREEN_BLUETOOTH)
+                ui_show_screen(SCREEN_SPLASH);
+            else
+                ui_show_screen(SCREEN_USAGE);
         }
         mid_was = mid_now;
 #else
         // Waveshare: AXP PWR short-press is the cycle button
-        if (power_pwr_pressed()) {
-            if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
-            else                                          ui_cycle_screen();
+        if (lvgl_ready && power_pwr_pressed())
+        {
+            if (ui_get_current_screen() == SCREEN_SPLASH)
+                splash_next();
+            else
+                ui_cycle_screen();
         }
-#endif  // BOARD_XINGZHI_CUBE
+#endif // BOARD_XINGZHI_CUBE
     }
 
 #ifndef BOARD_XINGZHI_CUBE
@@ -541,9 +812,24 @@ void loop() {
 
     // Update BLE status on screen when state changes
     ble_state_t bs = ble_get_state();
-    if (bs != last_ble_state) {
+    if (bs != last_ble_state)
+    {
+        Serial.printf("BLEDBG: state %s -> %s\n",
+                      ble_state_name(last_ble_state),
+                      ble_state_name(bs));
         last_ble_state = bs;
-        ui_update_ble_status(bs, ble_get_device_name(), ble_get_mac_address());
+        if (lvgl_ready)
+            ui_update_ble_status(bs, ble_get_device_name(), ble_get_mac_address());
+    }
+
+    uint32_t now_ms = millis();
+    if (now_ms - last_ble_dbg_ms >= 10000)
+    {
+        last_ble_dbg_ms = now_ms;
+        Serial.printf("BLEDBG: heartbeat state=%s mac=%s hasData=%d\n",
+                      ble_state_name(bs),
+                      ble_get_mac_address(),
+                      ble_has_data() ? 1 : 0);
     }
 
     // Update battery indicator
@@ -551,29 +837,38 @@ void loop() {
     static bool last_charging = false;
     int pct = power_battery_pct();
     bool charging = power_is_charging();
-    if (pct != last_pct || charging != last_charging) {
+    if (pct != last_pct || charging != last_charging)
+    {
         last_pct = pct;
         last_charging = charging;
-        ui_update_battery(pct, charging);
+        if (lvgl_ready)
+            ui_update_battery(pct, charging);
     }
 
     // Check for serial commands (screenshot, etc.)
     check_serial_cmd();
 
     // Process incoming BLE data
-    if (ble_has_data()) {
-        if (parse_json(ble_get_data(), &usage)) {
+    if (ble_has_data())
+    {
+        if (parse_json(ble_get_data(), &usage))
+        {
             int g_before = usage_rate_group();
             usage_rate_sample(usage.session_pct);
             int g_after = usage_rate_group();
-            if (g_after != g_before) {
+            if (lvgl_ready && g_after != g_before)
+            {
                 Serial.printf("usage rate: group %d -> %d (s=%.2f%%)\n",
-                    g_before, g_after, usage.session_pct);
-                if (splash_is_active()) splash_pick_for_current_rate();
+                              g_before, g_after, usage.session_pct);
+                if (splash_is_active())
+                    splash_pick_for_current_rate();
             }
-            ui_update(&usage);
+            if (lvgl_ready)
+                ui_update(&usage);
             ble_send_ack();
-        } else {
+        }
+        else
+        {
             ble_send_nack();
         }
     }

--- a/firmware/src/power.cpp
+++ b/firmware/src/power.cpp
@@ -2,6 +2,8 @@
 #include "display_cfg.h"
 #include <Arduino.h>
 
+#ifndef BOARD_XINGZHI_CUBE
+
 // Poll intervals
 #define BATTERY_POLL_MS   2000
 #define CHARGING_POLL_MS  500
@@ -72,3 +74,13 @@ bool power_pwr_pressed(void) {
     }
     return false;
 }
+
+#else  // BOARD_XINGZHI_CUBE — no AXP2101 PMU; return safe defaults
+
+void power_init(void)           {}
+void power_tick(void)           {}
+int  power_battery_pct(void)    { return -1; }
+bool power_is_charging(void)    { return false; }
+bool power_pwr_pressed(void)    { return false; }
+
+#endif // BOARD_XINGZHI_CUBE

--- a/firmware/src/splash.cpp
+++ b/firmware/src/splash.cpp
@@ -8,20 +8,20 @@
 #include <esp_heap_caps.h>
 
 // 20x20 grid scaled to panel height (480x480 on Waveshare, 240x240 on xingzhi)
-#define GRID         20
-#define CELL         (LCD_HEIGHT / GRID)
-#define CANVAS_W     (GRID * CELL)
-#define CANVAS_H     (GRID * CELL)
+#define GRID 20
+#define CELL (LCD_HEIGHT / GRID)
+#define CANVAS_W (GRID * CELL)
+#define CANVAS_H (GRID * CELL)
 
 // Background fallback when palette is missing
-#define COL_EMPTY    0x0000  // true black (matches THEME_BG)
+#define COL_EMPTY 0x0000 // true black (matches THEME_BG)
 
 LV_FONT_DECLARE(font_styrene_28);
 
 static lv_obj_t *splash_container = NULL;
 static lv_obj_t *canvas = NULL;
-static lv_obj_t *label_status = NULL;     // shown only when no animations loaded
-static uint16_t *canvas_buf = NULL;        // 480x480 RGB565 (PSRAM)
+static lv_obj_t *label_status = NULL; // shown only when no animations loaded
+static uint16_t *canvas_buf = NULL;   // 480x480 RGB565 (PSRAM)
 
 static uint16_t cur_anim = 0;
 static uint16_t cur_frame = 0;
@@ -36,31 +36,34 @@ static bool active = false;
 // Usage-rate animation groups: 4 groups × up to 4 animations each.
 // Filled at init by matching literal names from splash_anims[].
 #define GROUP_COUNT 4
-#define GROUP_MAX   4
-static int8_t  group_lists[GROUP_COUNT][GROUP_MAX];
+#define GROUP_MAX 4
+static int8_t group_lists[GROUP_COUNT][GROUP_MAX];
 static uint8_t group_size[GROUP_COUNT] = {0};
 static uint8_t group_rotation[GROUP_COUNT] = {0};
 
-static const char* GROUP_NAMES[GROUP_COUNT][GROUP_MAX] = {
+static const char *GROUP_NAMES[GROUP_COUNT][GROUP_MAX] = {
     // Group 0 — idle / sleepy
-    { "expression sleep", "idle breathe", "idle blink", "expression wink" },
+    {"expression sleep", "idle breathe", "idle blink", "expression wink"},
     // Group 1 — normal pace
-    { "idle look around", "work think", "work coding", NULL },
+    {"idle look around", "work think", "work coding", NULL},
     // Group 2 — active
-    { "dance sway", "expression surprise", "dance bounce", NULL },
+    {"dance sway", "expression surprise", "dance bounce", NULL},
     // Group 3 — heavy
-    { "dance bounce dj", "dance sway dj", "dance djmix", NULL },
+    {"dance bounce dj", "dance sway dj", "dance djmix", NULL},
 };
 
 #ifdef BOARD_XINGZHI_CUBE
-static inline uint16_t rgb565_from_888(uint8_t r, uint8_t g, uint8_t b) {
+static inline uint16_t rgb565_from_888(uint8_t r, uint8_t g, uint8_t b)
+{
     return (uint16_t)(((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3));
 }
 
 // Keep the sprite's shading but force hue toward Anthropic-style orange.
 // This avoids panel/order quirks that can make light tones look white.
-static uint16_t tint_orange_565(uint16_t color) {
-    if (color == COL_EMPTY) return COL_EMPTY;
+static uint16_t tint_orange_565(uint16_t color)
+{
+    if (color == COL_EMPTY)
+        return COL_EMPTY;
 
     uint8_t r5 = (color >> 11) & 0x1F;
     uint8_t g6 = (color >> 5) & 0x3F;
@@ -73,11 +76,15 @@ static uint16_t tint_orange_565(uint16_t color) {
     // Luminance preserves per-cell contrast from the source palette.
     uint8_t y = (uint8_t)((77 * r + 150 * g + 29 * b) >> 8);
 
+    // Keep near-black source pixels as true black so eye/details remain cut out.
+    if (y <= 32)
+        return COL_EMPTY;
+
     // Target accent: #D97757. Clamp to avoid near-white highlights.
     const uint8_t ar = 0xD9;
     const uint8_t ag = 0x77;
     const uint8_t ab = 0x57;
-    uint16_t scale = (uint16_t)(140 + ((uint16_t)y * 115) / 255); // 140..255
+    uint16_t scale = (uint16_t)(165 + ((uint16_t)y * 90) / 255); // 165..255
 
     uint8_t nr = (uint8_t)((ar * scale) / 255);
     uint8_t ng = (uint8_t)((ag * scale) / 255);
@@ -87,15 +94,21 @@ static uint16_t tint_orange_565(uint16_t color) {
 }
 #endif
 
-static void resolve_group_lists(void) {
-    for (int g = 0; g < GROUP_COUNT; g++) {
+static void resolve_group_lists(void)
+{
+    for (int g = 0; g < GROUP_COUNT; g++)
+    {
         group_size[g] = 0;
-        for (int s = 0; s < GROUP_MAX; s++) {
+        for (int s = 0; s < GROUP_MAX; s++)
+        {
             group_lists[g][s] = -1;
-            const char* want = GROUP_NAMES[g][s];
-            if (!want) continue;
-            for (int i = 0; i < SPLASH_ANIM_COUNT; i++) {
-                if (strcmp(splash_anims[i].name, want) == 0) {
+            const char *want = GROUP_NAMES[g][s];
+            if (!want)
+                continue;
+            for (int i = 0; i < SPLASH_ANIM_COUNT; i++)
+            {
+                if (strcmp(splash_anims[i].name, want) == 0)
+                {
                     group_lists[g][group_size[g]++] = (int8_t)i;
                     break;
                 }
@@ -104,21 +117,31 @@ static void resolve_group_lists(void) {
     }
 }
 
-static void render_frame(const uint8_t *cells, const uint16_t *palette) {
+static void render_frame(const uint8_t *cells, const uint16_t *palette)
+{
     bool any_visible = false;
-    for (int gy = 0; gy < GRID; gy++) {
+    for (int gy = 0; gy < GRID; gy++)
+    {
         uint16_t row[CANVAS_W];
-        for (int gx = 0; gx < GRID; gx++) {
+        for (int gx = 0; gx < GRID; gx++)
+        {
             uint8_t code = cells[gy * GRID + gx];
             uint16_t color = (palette && code < SPLASH_PALETTE_SIZE) ? palette[code] : COL_EMPTY;
 #ifdef BOARD_XINGZHI_CUBE
             color = tint_orange_565(color);
+            // Arduino_GFX SPI (MSB_32_16_16_SET) byte-swaps uint16_t before
+            // sending, so canvas_buf values must be pre-swapped to match.
+            if (color != COL_EMPTY) { color = __builtin_bswap16(color); any_visible = true; }
+#else
+            if (color != COL_EMPTY)
+                any_visible = true;
 #endif
-            if (color != COL_EMPTY) any_visible = true;
             uint16_t *p = &row[gx * CELL];
-            for (int i = 0; i < CELL; i++) p[i] = color;
+            for (int i = 0; i < CELL; i++)
+                p[i] = color;
         }
-        for (int dy = 0; dy < CELL; dy++) {
+        for (int dy = 0; dy < CELL; dy++)
+        {
             memcpy(&canvas_buf[(gy * CELL + dy) * CANVAS_W], row, CANVAS_W * 2);
         }
     }
@@ -126,15 +149,21 @@ static void render_frame(const uint8_t *cells, const uint16_t *palette) {
 #ifdef BOARD_XINGZHI_CUBE
     // Safety fallback: if a frame resolves to full black on this panel,
     // draw a small orange marker so the screen never looks dead.
-    if (!any_visible) {
-        const uint16_t marker = rgb565_from_888(0xD9, 0x77, 0x57);
+    if (!any_visible)
+    {
+        const uint16_t marker = __builtin_bswap16(rgb565_from_888(0xD9, 0x77, 0x57));
         const int cx = CANVAS_W / 2;
         const int cy = CANVAS_H / 2;
-        for (int y = cy - 8; y <= cy + 8; y++) {
-            if (y < 0 || y >= CANVAS_H) continue;
-            for (int x = cx - 8; x <= cx + 8; x++) {
-                if (x < 0 || x >= CANVAS_W) continue;
-                if (x == cx || y == cy) {
+        for (int y = cy - 8; y <= cy + 8; y++)
+        {
+            if (y < 0 || y >= CANVAS_H)
+                continue;
+            for (int x = cx - 8; x <= cx + 8; x++)
+            {
+                if (x < 0 || x >= CANVAS_W)
+                    continue;
+                if (x == cx || y == cy)
+                {
                     canvas_buf[y * CANVAS_W + x] = marker;
                 }
             }
@@ -142,19 +171,26 @@ static void render_frame(const uint8_t *cells, const uint16_t *palette) {
     }
 #endif
 
-    if (canvas) lv_obj_invalidate(canvas);
+    if (canvas)
+        lv_obj_invalidate(canvas);
 }
 
-static void show_placeholder() {
+static void show_placeholder()
+{
     // Solid dark background + centered status label.
-    for (int i = 0; i < CANVAS_W * CANVAS_H; i++) canvas_buf[i] = COL_EMPTY;
-    if (canvas) lv_obj_invalidate(canvas);
-    if (label_status) lv_obj_clear_flag(label_status, LV_OBJ_FLAG_HIDDEN);
+    for (int i = 0; i < CANVAS_W * CANVAS_H; i++)
+        canvas_buf[i] = COL_EMPTY;
+    if (canvas)
+        lv_obj_invalidate(canvas);
+    if (label_status)
+        lv_obj_clear_flag(label_status, LV_OBJ_FLAG_HIDDEN);
 }
 
-void splash_init(lv_obj_t *parent) {
-    canvas_buf = (uint16_t*)heap_caps_malloc(CANVAS_W * CANVAS_H * 2, MALLOC_CAP_SPIRAM);
-    if (!canvas_buf) {
+void splash_init(lv_obj_t *parent)
+{
+    canvas_buf = (uint16_t *)heap_caps_malloc(CANVAS_W * CANVAS_H * 2, MALLOC_CAP_SPIRAM);
+    if (!canvas_buf)
+    {
         Serial.println("splash: failed to alloc canvas buffer");
         return;
     }
@@ -175,9 +211,9 @@ void splash_init(lv_obj_t *parent) {
     // Placeholder label (visible only when no animations are loaded)
     label_status = lv_label_create(splash_container);
     lv_label_set_text(label_status,
-        "no animations loaded\n\n"
-        "run tools/scrape_claudepix.js\n"
-        "then tools/convert_to_c.js");
+                      "no animations loaded\n\n"
+                      "run tools/scrape_claudepix.js\n"
+                      "then tools/convert_to_c.js");
     lv_obj_set_style_text_font(label_status, &font_styrene_28, 0);
     lv_obj_set_style_text_color(label_status, lv_color_hex(0xb0aea5), 0);
     lv_obj_set_style_text_align(label_status, LV_TEXT_ALIGN_CENTER, 0);
@@ -185,9 +221,12 @@ void splash_init(lv_obj_t *parent) {
 
     resolve_group_lists();
 
-    if (SPLASH_ANIM_COUNT == 0) {
+    if (SPLASH_ANIM_COUNT == 0)
+    {
         show_placeholder();
-    } else {
+    }
+    else
+    {
         lv_obj_add_flag(label_status, LV_OBJ_FLAG_HIDDEN);
         const splash_anim_def_t *a = &splash_anims[0];
         render_frame(a->frames[0], a->palette);
@@ -197,27 +236,34 @@ void splash_init(lv_obj_t *parent) {
     lv_obj_add_flag(splash_container, LV_OBJ_FLAG_HIDDEN);
 }
 
-void splash_tick(void) {
-    if (!active || SPLASH_ANIM_COUNT == 0) return;
+void splash_tick(void)
+{
+    if (!active || SPLASH_ANIM_COUNT == 0)
+        return;
 
     // Auto-rotate to the next animation in the current group.
-    if (millis() - last_pick_ms >= SPLASH_ROTATE_INTERVAL_MS) {
+    if (millis() - last_pick_ms >= SPLASH_ROTATE_INTERVAL_MS)
+    {
         splash_pick_for_current_rate();
     }
 
     const splash_anim_def_t *a = &splash_anims[cur_anim];
-    if (a->frame_count == 0) return;
+    if (a->frame_count == 0)
+        return;
 
     uint16_t hold = a->holds[cur_frame];
-    if (millis() - frame_started_ms >= hold) {
+    if (millis() - frame_started_ms >= hold)
+    {
         cur_frame = (cur_frame + 1) % a->frame_count;
         frame_started_ms = millis();
         render_frame(a->frames[cur_frame], a->palette);
     }
 }
 
-void splash_next(void) {
-    if (SPLASH_ANIM_COUNT == 0) return;
+void splash_next(void)
+{
+    if (SPLASH_ANIM_COUNT == 0)
+        return;
     cur_anim = (cur_anim + 1) % SPLASH_ANIM_COUNT;
     cur_frame = 0;
     frame_started_ms = millis();
@@ -227,16 +273,21 @@ void splash_next(void) {
     Serial.printf("splash: -> %s\n", a->name);
 }
 
-void splash_pick_for_current_rate(void) {
-    if (SPLASH_ANIM_COUNT == 0) return;
+void splash_pick_for_current_rate(void)
+{
+    if (SPLASH_ANIM_COUNT == 0)
+        return;
     int g = usage_rate_group();
-    if (g < 0 || g >= GROUP_COUNT) g = 0;
-    if (group_size[g] == 0) return;
+    if (g < 0 || g >= GROUP_COUNT)
+        g = 0;
+    if (group_size[g] == 0)
+        return;
 
     uint8_t slot = group_rotation[g] % group_size[g];
     group_rotation[g]++;
     int8_t idx = group_lists[g][slot];
-    if (idx < 0) return;
+    if (idx < 0)
+        return;
 
     cur_anim = (uint16_t)idx;
     cur_frame = 0;
@@ -248,17 +299,22 @@ void splash_pick_for_current_rate(void) {
 
 bool splash_is_active(void) { return active; }
 
-void splash_show(void) {
+void splash_show(void)
+{
     splash_pick_for_current_rate();
-    if (splash_container) lv_obj_clear_flag(splash_container, LV_OBJ_FLAG_HIDDEN);
+    if (splash_container)
+        lv_obj_clear_flag(splash_container, LV_OBJ_FLAG_HIDDEN);
     active = true;
 }
 
-void splash_hide(void) {
-    if (splash_container) lv_obj_add_flag(splash_container, LV_OBJ_FLAG_HIDDEN);
+void splash_hide(void)
+{
+    if (splash_container)
+        lv_obj_add_flag(splash_container, LV_OBJ_FLAG_HIDDEN);
     active = false;
 }
 
-lv_obj_t* splash_get_root(void) {
+lv_obj_t *splash_get_root(void)
+{
     return splash_container;
 }

--- a/firmware/src/splash.cpp
+++ b/firmware/src/splash.cpp
@@ -1,14 +1,15 @@
 #include "splash.h"
 #include "splash_animations.h"
 #include "theme.h"
+#include "display_cfg.h"
 #include "usage_rate.h"
 #include <Arduino.h>
 #include <string.h>
 #include <esp_heap_caps.h>
 
-// 20x20 grid scaled 24x to fill 480x480
+// 20x20 grid scaled to panel height (480x480 on Waveshare, 240x240 on xingzhi)
 #define GRID         20
-#define CELL         24
+#define CELL         (LCD_HEIGHT / GRID)
 #define CANVAS_W     (GRID * CELL)
 #define CANVAS_H     (GRID * CELL)
 
@@ -51,6 +52,41 @@ static const char* GROUP_NAMES[GROUP_COUNT][GROUP_MAX] = {
     { "dance bounce dj", "dance sway dj", "dance djmix", NULL },
 };
 
+#ifdef BOARD_XINGZHI_CUBE
+static inline uint16_t rgb565_from_888(uint8_t r, uint8_t g, uint8_t b) {
+    return (uint16_t)(((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3));
+}
+
+// Keep the sprite's shading but force hue toward Anthropic-style orange.
+// This avoids panel/order quirks that can make light tones look white.
+static uint16_t tint_orange_565(uint16_t color) {
+    if (color == COL_EMPTY) return COL_EMPTY;
+
+    uint8_t r5 = (color >> 11) & 0x1F;
+    uint8_t g6 = (color >> 5) & 0x3F;
+    uint8_t b5 = color & 0x1F;
+
+    uint8_t r = (uint8_t)((r5 * 255) / 31);
+    uint8_t g = (uint8_t)((g6 * 255) / 63);
+    uint8_t b = (uint8_t)((b5 * 255) / 31);
+
+    // Luminance preserves per-cell contrast from the source palette.
+    uint8_t y = (uint8_t)((77 * r + 150 * g + 29 * b) >> 8);
+
+    // Target accent: #D97757. Clamp to avoid near-white highlights.
+    const uint8_t ar = 0xD9;
+    const uint8_t ag = 0x77;
+    const uint8_t ab = 0x57;
+    uint16_t scale = (uint16_t)(140 + ((uint16_t)y * 115) / 255); // 140..255
+
+    uint8_t nr = (uint8_t)((ar * scale) / 255);
+    uint8_t ng = (uint8_t)((ag * scale) / 255);
+    uint8_t nb = (uint8_t)((ab * scale) / 255);
+
+    return rgb565_from_888(nr, ng, nb);
+}
+#endif
+
 static void resolve_group_lists(void) {
     for (int g = 0; g < GROUP_COUNT; g++) {
         group_size[g] = 0;
@@ -69,11 +105,16 @@ static void resolve_group_lists(void) {
 }
 
 static void render_frame(const uint8_t *cells, const uint16_t *palette) {
+    bool any_visible = false;
     for (int gy = 0; gy < GRID; gy++) {
         uint16_t row[CANVAS_W];
         for (int gx = 0; gx < GRID; gx++) {
             uint8_t code = cells[gy * GRID + gx];
             uint16_t color = (palette && code < SPLASH_PALETTE_SIZE) ? palette[code] : COL_EMPTY;
+#ifdef BOARD_XINGZHI_CUBE
+            color = tint_orange_565(color);
+#endif
+            if (color != COL_EMPTY) any_visible = true;
             uint16_t *p = &row[gx * CELL];
             for (int i = 0; i < CELL; i++) p[i] = color;
         }
@@ -81,6 +122,26 @@ static void render_frame(const uint8_t *cells, const uint16_t *palette) {
             memcpy(&canvas_buf[(gy * CELL + dy) * CANVAS_W], row, CANVAS_W * 2);
         }
     }
+
+#ifdef BOARD_XINGZHI_CUBE
+    // Safety fallback: if a frame resolves to full black on this panel,
+    // draw a small orange marker so the screen never looks dead.
+    if (!any_visible) {
+        const uint16_t marker = rgb565_from_888(0xD9, 0x77, 0x57);
+        const int cx = CANVAS_W / 2;
+        const int cy = CANVAS_H / 2;
+        for (int y = cy - 8; y <= cy + 8; y++) {
+            if (y < 0 || y >= CANVAS_H) continue;
+            for (int x = cx - 8; x <= cx + 8; x++) {
+                if (x < 0 || x >= CANVAS_W) continue;
+                if (x == cx || y == cy) {
+                    canvas_buf[y * CANVAS_W + x] = marker;
+                }
+            }
+        }
+    }
+#endif
+
     if (canvas) lv_obj_invalidate(canvas);
 }
 
@@ -99,7 +160,7 @@ void splash_init(lv_obj_t *parent) {
     }
 
     splash_container = lv_obj_create(parent);
-    lv_obj_set_size(splash_container, 480, 480);
+    lv_obj_set_size(splash_container, LCD_WIDTH, LCD_HEIGHT);
     lv_obj_set_pos(splash_container, 0, 0);
     lv_obj_set_style_bg_color(splash_container, THEME_BG, 0);
     lv_obj_set_style_bg_opa(splash_container, LV_OPA_COVER, 0);

--- a/firmware/src/splash.h
+++ b/firmware/src/splash.h
@@ -3,7 +3,7 @@
 #include <lvgl.h>
 
 // Initialize splash module. Creates the canvas widget inside `parent` and
-// allocates the 480x480 pixel buffer (PSRAM).
+// allocates a panel-sized pixel buffer (PSRAM).
 void splash_init(lv_obj_t *parent);
 
 // Advance animation frame if hold time elapsed. Call from main loop.

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -7,11 +7,16 @@
 
 // Custom fonts (scaled for 314 PPI, ~1.9x from original 165 PPI)
 LV_FONT_DECLARE(font_tiempos_56);
+LV_FONT_DECLARE(font_tiempos_34);
 LV_FONT_DECLARE(font_styrene_48);
 LV_FONT_DECLARE(font_styrene_28);
 LV_FONT_DECLARE(font_styrene_24);
 LV_FONT_DECLARE(font_styrene_20);
+LV_FONT_DECLARE(font_styrene_16);
+LV_FONT_DECLARE(font_styrene_14);
+LV_FONT_DECLARE(font_styrene_12);
 LV_FONT_DECLARE(font_mono_32);
+LV_FONT_DECLARE(font_mono_18);
 
 // Anthropic brand palette — design tokens live in theme.h
 #include "theme.h"
@@ -25,13 +30,71 @@ LV_FONT_DECLARE(font_mono_32);
 #define COL_RED       THEME_RED
 #define COL_BAR_BG    THEME_BAR_BG
 
+#ifdef BOARD_XINGZHI_CUBE
+// ---- Layout constants for xingzhi 284x240 ----
+#define SCR_W         LCD_WIDTH
+#define SCR_H         LCD_HEIGHT
+#define MARGIN        8
+#define TITLE_Y       4
+#define TITLE_X_SHIFT 0
+#define CONTENT_Y     36
+#define CONTENT_W     (SCR_W - 2 * MARGIN)
+#define PANEL_H       68
+#define PANEL_GAP     8
+#define BAR_Y         30
+#define BAR_H         12
+#define RESET_Y       46
+#define ANIM_BOTTOM   -4
+#define BT_INFO_H     106
+#define BT_RESET_H    56
+#define BT_RESET_GAP  8
+#define SHOW_LOGO     0
+#define SHOW_CREDITS  0
+#define SHOW_BT_ICON  0
+#define SHOW_BT_RESET_ICON 0
+#define SHOW_BATTERY  0
+
+#define FONT_TITLE    (&font_tiempos_34)
+#define FONT_PCT      (&font_styrene_24)
+#define FONT_PILL     (&font_styrene_16)
+#define FONT_RESET    (&font_styrene_14)
+#define FONT_STATUS   (&font_styrene_24)
+#define FONT_BODY     (&font_styrene_14)
+#define FONT_ANIM     (&font_mono_18)
+#define FONT_CREDIT   (&font_styrene_12)
+#else
 // ---- Layout constants for 480x480 (scaled for 2.16" high-DPI + rounded corners) ----
 #define SCR_W         480
 #define SCR_H         480
-#define MARGIN        20    // wider margin for rounded display corners
+#define MARGIN        20
 #define TITLE_Y       30
+#define TITLE_X_SHIFT 16
 #define CONTENT_Y     100
-#define CONTENT_W     (SCR_W - 2 * MARGIN)   // 440
+#define CONTENT_W     (SCR_W - 2 * MARGIN)
+#define PANEL_H       150
+#define PANEL_GAP     16
+#define BAR_Y         56
+#define BAR_H         24
+#define RESET_Y       94
+#define ANIM_BOTTOM   -15
+#define BT_INFO_H     160
+#define BT_RESET_H    110
+#define BT_RESET_GAP  16
+#define SHOW_LOGO     1
+#define SHOW_CREDITS  1
+#define SHOW_BT_ICON  1
+#define SHOW_BT_RESET_ICON 1
+#define SHOW_BATTERY  1
+
+#define FONT_TITLE    (&font_tiempos_56)
+#define FONT_PCT      (&font_styrene_48)
+#define FONT_PILL     (&font_styrene_28)
+#define FONT_RESET    (&font_styrene_28)
+#define FONT_STATUS   (&font_styrene_48)
+#define FONT_BODY     (&font_styrene_28)
+#define FONT_ANIM     (&font_mono_32)
+#define FONT_CREDIT   (&font_styrene_24)
+#endif
 
 // ---- Usage screen widgets ----
 static lv_obj_t* usage_container;
@@ -197,7 +260,7 @@ static void init_icon_dsc_rgb565a8(lv_image_dsc_t* dsc, int w, int h, const uint
 static lv_obj_t* make_pill(lv_obj_t* parent, const char* text) {
     lv_obj_t* lbl = lv_label_create(parent);
     lv_label_set_text(lbl, text);
-    lv_obj_set_style_text_font(lbl, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(lbl, FONT_PILL, 0);
     lv_obj_set_style_text_color(lbl, COL_TEXT, 0);
     lv_obj_set_style_bg_color(lbl, COL_BAR_BG, 0);
     lv_obj_set_style_bg_opa(lbl, LV_OPA_COVER, 0);
@@ -220,9 +283,6 @@ static void init_battery_icons(void) {
 
 // ======== Usage Screen (480x480) ========
 
-#define PANEL_H     150
-#define PANEL_GAP   16
-
 // One Session/Weekly panel: big % label, pill on the right, bar, reset label.
 // Pill y=1: symmetric inside the panel — panel-outer-top → pill-top equals
 // pill-bottom → bar-top (pill height 42 + panel pad_top 12 + bar y=56).
@@ -233,20 +293,20 @@ static void make_usage_panel(lv_obj_t* parent, int y, const char* pill_text,
 
     *out_pct = lv_label_create(panel);
     lv_label_set_text(*out_pct, "---%");
-    lv_obj_set_style_text_font(*out_pct, &font_styrene_48, 0);
+    lv_obj_set_style_text_font(*out_pct, FONT_PCT, 0);
     lv_obj_set_style_text_color(*out_pct, COL_TEXT, 0);
     lv_obj_set_pos(*out_pct, 0, 0);
 
     *out_pill = make_pill(panel, pill_text);
     lv_obj_align(*out_pill, LV_ALIGN_TOP_RIGHT, 0, 1);
 
-    *out_bar = make_bar(panel, 0, 56, CONTENT_W - 32, 24);
+    *out_bar = make_bar(panel, 0, BAR_Y, CONTENT_W - 32, BAR_H);
 
     *out_reset = lv_label_create(panel);
     lv_label_set_text(*out_reset, "---");
-    lv_obj_set_style_text_font(*out_reset, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(*out_reset, FONT_RESET, 0);
     lv_obj_set_style_text_color(*out_reset, COL_DIM, 0);
-    lv_obj_set_pos(*out_reset, 0, 94);
+    lv_obj_set_pos(*out_reset, 0, RESET_Y);
 }
 
 static void init_usage_screen(lv_obj_t* scr) {
@@ -261,9 +321,9 @@ static void init_usage_screen(lv_obj_t* scr) {
 
     lbl_title = lv_label_create(usage_container);
     lv_label_set_text(lbl_title, "Usage");
-    lv_obj_set_style_text_font(lbl_title, &font_tiempos_56, 0);
+    lv_obj_set_style_text_font(lbl_title, FONT_TITLE, 0);
     lv_obj_set_style_text_color(lbl_title, COL_TEXT, 0);
-    lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 16, TITLE_Y);
+    lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, TITLE_X_SHIFT, TITLE_Y);
 
     make_usage_panel(usage_container, CONTENT_Y, "Current",
                      &lbl_session_pct, &lbl_session_label,
@@ -274,9 +334,9 @@ static void init_usage_screen(lv_obj_t* scr) {
 
     lbl_anim = lv_label_create(usage_container);
     lv_label_set_text(lbl_anim, "");
-    lv_obj_set_style_text_font(lbl_anim, &font_mono_32, 0);
+    lv_obj_set_style_text_font(lbl_anim, FONT_ANIM, 0);
     lv_obj_set_style_text_color(lbl_anim, COL_ACCENT, 0);
-    lv_obj_align(lbl_anim, LV_ALIGN_BOTTOM_MID, 0, -15);
+    lv_obj_align(lbl_anim, LV_ALIGN_BOTTOM_MID, 0, ANIM_BOTTOM);
 }
 
 // ======== Bluetooth Screen (480x480) ========
@@ -293,44 +353,49 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     // Title
     lv_obj_t* lbl_ble_title = lv_label_create(ble_container);
     lv_label_set_text(lbl_ble_title, "Bluetooth");
-    lv_obj_set_style_text_font(lbl_ble_title, &font_tiempos_56, 0);
+    lv_obj_set_style_text_font(lbl_ble_title, FONT_TITLE, 0);
     lv_obj_set_style_text_color(lbl_ble_title, COL_TEXT, 0);
-    lv_obj_align(lbl_ble_title, LV_ALIGN_TOP_MID, 16, TITLE_Y);
+    lv_obj_align(lbl_ble_title, LV_ALIGN_TOP_MID, TITLE_X_SHIFT, TITLE_Y);
 
-    // Info panel (taller for 480x480)
-    lv_obj_t* p_info = make_panel(ble_container, MARGIN, CONTENT_Y, CONTENT_W, 160);
+    lv_obj_t* p_info = make_panel(ble_container, MARGIN, CONTENT_Y, CONTENT_W, BT_INFO_H);
 
     // Bluetooth icon + status row
+#if SHOW_BT_ICON
     static lv_image_dsc_t icon_bt_dsc;
     init_icon_dsc(&icon_bt_dsc, ICON_BLUETOOTH_W, ICON_BLUETOOTH_H, icon_bluetooth_data);
 
     lv_obj_t* bt_img = lv_image_create(p_info);
     lv_image_set_src(bt_img, &icon_bt_dsc);
     lv_obj_set_pos(bt_img, 0, 0);
+#endif
 
     lbl_ble_status = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_status, "Initializing...");
-    lv_obj_set_style_text_font(lbl_ble_status, &font_styrene_48, 0);
+    lv_obj_set_style_text_font(lbl_ble_status, FONT_STATUS, 0);
     lv_obj_set_style_text_color(lbl_ble_status, COL_DIM, 0);
+#if SHOW_BT_ICON
     lv_obj_set_pos(lbl_ble_status, 56, 2);
+#else
+    lv_obj_set_pos(lbl_ble_status, 0, 0);
+#endif
 
     lbl_ble_device = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_device, "Device: ---");
-    lv_obj_set_style_text_font(lbl_ble_device, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(lbl_ble_device, FONT_BODY, 0);
     lv_obj_set_style_text_color(lbl_ble_device, COL_DIM, 0);
-    lv_obj_set_pos(lbl_ble_device, 0, 64);
+    lv_obj_set_pos(lbl_ble_device, 0, SHOW_BT_ICON ? 64 : 40);
 
     lbl_ble_mac = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_mac, "Address: ---");
-    lv_obj_set_style_text_font(lbl_ble_mac, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(lbl_ble_mac, FONT_BODY, 0);
     lv_obj_set_style_text_color(lbl_ble_mac, COL_DIM, 0);
-    lv_obj_set_pos(lbl_ble_mac, 0, 100);
+    lv_obj_set_pos(lbl_ble_mac, 0, SHOW_BT_ICON ? 100 : 66);
 
     // Reset Bluetooth tap zone with trash icon
-    int reset_y = CONTENT_Y + 160 + 16;
+    int reset_y = CONTENT_Y + BT_INFO_H + BT_RESET_GAP;
     lv_obj_t* reset_zone = lv_obj_create(ble_container);
     lv_obj_set_pos(reset_zone, MARGIN, reset_y);
-    lv_obj_set_size(reset_zone, CONTENT_W, 110);
+    lv_obj_set_size(reset_zone, CONTENT_W, BT_RESET_H);
     lv_obj_set_style_bg_color(reset_zone, COL_PANEL, 0);
     lv_obj_set_style_bg_opa(reset_zone, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(reset_zone, 8, 0);
@@ -341,20 +406,23 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_clear_flag(reset_zone, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_event_cb(reset_zone, ble_reset_click_cb, LV_EVENT_CLICKED, NULL);
 
+#if SHOW_BT_RESET_ICON
     static lv_image_dsc_t icon_trash_dsc;
     init_icon_dsc(&icon_trash_dsc, ICON_TRASH2_W, ICON_TRASH2_H, icon_trash2_data);
     lv_obj_t* trash_img = lv_image_create(reset_zone);
     lv_image_set_src(trash_img, &icon_trash_dsc);
+#endif
 
     lv_obj_t* reset_lbl = lv_label_create(reset_zone);
     lv_label_set_text(reset_lbl, "Reset Bluetooth");
-    lv_obj_set_style_text_font(reset_lbl, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(reset_lbl, FONT_BODY, 0);
     lv_obj_set_style_text_color(reset_lbl, COL_DIM, 0);
 
     // Attribution
+#if SHOW_CREDITS
     lv_obj_t* lbl_credit = lv_label_create(ble_container);
     lv_label_set_text(lbl_credit, "Built by @hermannbjorgvin");
-    lv_obj_set_style_text_font(lbl_credit, &font_styrene_24, 0);
+    lv_obj_set_style_text_font(lbl_credit, FONT_CREDIT, 0);
     lv_obj_set_style_text_color(lbl_credit, COL_DIM, 0);
     lv_obj_align(lbl_credit, LV_ALIGN_BOTTOM_MID, 0, -46);
 
@@ -363,6 +431,7 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_style_text_font(lbl_credit2, &font_styrene_20, 0);
     lv_obj_set_style_text_color(lbl_credit2, COL_DIM, 0);
     lv_obj_align(lbl_credit2, LV_ALIGN_BOTTOM_MID, 0, -20);
+#endif
 
     // Start hidden
     lv_obj_add_flag(ble_container, LV_OBJ_FLAG_HIDDEN);
@@ -393,14 +462,22 @@ void ui_init(void) {
     }
 
     // Logo on top of all containers (inset for rounded corners)
+#if SHOW_LOGO
     logo_img = lv_image_create(scr);
     lv_image_set_src(logo_img, &logo_dsc);
     lv_obj_set_pos(logo_img, MARGIN, TITLE_Y - 10);
+#else
+    logo_img = NULL;
+#endif
 
     // Battery indicator on top of all containers (upper-right, inset)
+#if SHOW_BATTERY
     battery_img = lv_image_create(scr);
     lv_image_set_src(battery_img, &battery_dscs[0]);
-    lv_obj_set_pos(battery_img, SCR_W - 48 - MARGIN, TITLE_Y);
+    lv_obj_set_pos(battery_img, SCR_W - ICON_BATTERY_W - MARGIN, TITLE_Y);
+#else
+    battery_img = NULL;
+#endif
 }
 
 void ui_update(const UsageData* data) {
@@ -544,6 +621,8 @@ void ui_update_ble_status(ble_state_t state, const char* name, const char* mac) 
 }
 
 void ui_update_battery(int percent, bool charging) {
+    if (!battery_img) return;
+
     int idx;
     if (charging) {
         idx = 4;  // charging icon

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -20,105 +20,105 @@ LV_FONT_DECLARE(font_mono_18);
 
 // Anthropic brand palette — design tokens live in theme.h
 #include "theme.h"
-#define COL_BG        THEME_BG
-#define COL_PANEL     THEME_PANEL
-#define COL_TEXT      THEME_TEXT
-#define COL_DIM       THEME_DIM
-#define COL_ACCENT    THEME_ACCENT
-#define COL_GREEN     THEME_GREEN
-#define COL_AMBER     THEME_AMBER
-#define COL_RED       THEME_RED
-#define COL_BAR_BG    THEME_BAR_BG
+#define COL_BG THEME_BG
+#define COL_PANEL THEME_PANEL
+#define COL_TEXT THEME_TEXT
+#define COL_DIM THEME_DIM
+#define COL_ACCENT THEME_ACCENT
+#define COL_GREEN THEME_GREEN
+#define COL_AMBER THEME_AMBER
+#define COL_RED THEME_RED
+#define COL_BAR_BG THEME_BAR_BG
 
 #ifdef BOARD_XINGZHI_CUBE
 // ---- Layout constants for xingzhi 284x240 ----
-#define SCR_W         LCD_WIDTH
-#define SCR_H         LCD_HEIGHT
-#define MARGIN        8
-#define TITLE_Y       4
+#define SCR_W LCD_WIDTH
+#define SCR_H LCD_HEIGHT
+#define MARGIN 8
+#define TITLE_Y 20
 #define TITLE_X_SHIFT 0
-#define CONTENT_Y     36
-#define CONTENT_W     (SCR_W - 2 * MARGIN)
-#define PANEL_H       68
-#define PANEL_GAP     8
-#define BAR_Y         30
-#define BAR_H         12
-#define RESET_Y       46
-#define ANIM_BOTTOM   -4
-#define BT_INFO_H     106
-#define BT_RESET_H    56
-#define BT_RESET_GAP  8
-#define SHOW_LOGO     0
-#define SHOW_CREDITS  0
-#define SHOW_BT_ICON  0
+#define CONTENT_Y 54
+#define CONTENT_W (SCR_W - 2 * MARGIN)
+#define PANEL_H 74
+#define PANEL_GAP 8
+#define BAR_Y 32
+#define BAR_H 12
+#define RESET_Y 48
+#define ANIM_BOTTOM -4
+#define BT_INFO_H 106
+#define BT_RESET_H 56
+#define BT_RESET_GAP 8
+#define SHOW_LOGO 0
+#define SHOW_CREDITS 0
+#define SHOW_BT_ICON 0
 #define SHOW_BT_RESET_ICON 0
-#define SHOW_BATTERY  0
+#define SHOW_BATTERY 0
 
-#define FONT_TITLE    (&font_tiempos_34)
-#define FONT_PCT      (&font_styrene_24)
-#define FONT_PILL     (&font_styrene_16)
-#define FONT_RESET    (&font_styrene_14)
-#define FONT_STATUS   (&font_styrene_24)
-#define FONT_BODY     (&font_styrene_14)
-#define FONT_ANIM     (&font_mono_18)
-#define FONT_CREDIT   (&font_styrene_12)
+#define FONT_TITLE (&font_tiempos_34)
+#define FONT_PCT (&font_styrene_24)
+#define FONT_PILL (&font_styrene_16)
+#define FONT_RESET (&font_styrene_14)
+#define FONT_STATUS (&font_styrene_24)
+#define FONT_BODY (&font_styrene_14)
+#define FONT_ANIM (&font_mono_18)
+#define FONT_CREDIT (&font_styrene_12)
 #else
 // ---- Layout constants for 480x480 (scaled for 2.16" high-DPI + rounded corners) ----
-#define SCR_W         480
-#define SCR_H         480
-#define MARGIN        20
-#define TITLE_Y       30
+#define SCR_W 480
+#define SCR_H 480
+#define MARGIN 20
+#define TITLE_Y 30
 #define TITLE_X_SHIFT 16
-#define CONTENT_Y     100
-#define CONTENT_W     (SCR_W - 2 * MARGIN)
-#define PANEL_H       150
-#define PANEL_GAP     16
-#define BAR_Y         56
-#define BAR_H         24
-#define RESET_Y       94
-#define ANIM_BOTTOM   -15
-#define BT_INFO_H     160
-#define BT_RESET_H    110
-#define BT_RESET_GAP  16
-#define SHOW_LOGO     1
-#define SHOW_CREDITS  1
-#define SHOW_BT_ICON  1
+#define CONTENT_Y 100
+#define CONTENT_W (SCR_W - 2 * MARGIN)
+#define PANEL_H 150
+#define PANEL_GAP 16
+#define BAR_Y 56
+#define BAR_H 24
+#define RESET_Y 94
+#define ANIM_BOTTOM -15
+#define BT_INFO_H 160
+#define BT_RESET_H 110
+#define BT_RESET_GAP 16
+#define SHOW_LOGO 1
+#define SHOW_CREDITS 1
+#define SHOW_BT_ICON 1
 #define SHOW_BT_RESET_ICON 1
-#define SHOW_BATTERY  1
+#define SHOW_BATTERY 1
 
-#define FONT_TITLE    (&font_tiempos_56)
-#define FONT_PCT      (&font_styrene_48)
-#define FONT_PILL     (&font_styrene_28)
-#define FONT_RESET    (&font_styrene_28)
-#define FONT_STATUS   (&font_styrene_48)
-#define FONT_BODY     (&font_styrene_28)
-#define FONT_ANIM     (&font_mono_32)
-#define FONT_CREDIT   (&font_styrene_24)
+#define FONT_TITLE (&font_tiempos_56)
+#define FONT_PCT (&font_styrene_48)
+#define FONT_PILL (&font_styrene_28)
+#define FONT_RESET (&font_styrene_28)
+#define FONT_STATUS (&font_styrene_48)
+#define FONT_BODY (&font_styrene_28)
+#define FONT_ANIM (&font_mono_32)
+#define FONT_CREDIT (&font_styrene_24)
 #endif
 
 // ---- Usage screen widgets ----
-static lv_obj_t* usage_container;
-static lv_obj_t* lbl_title;
-static lv_obj_t* bar_session;
-static lv_obj_t* lbl_session_pct;
-static lv_obj_t* lbl_session_label;
-static lv_obj_t* lbl_session_reset;
-static lv_obj_t* bar_weekly;
-static lv_obj_t* lbl_weekly_pct;
-static lv_obj_t* lbl_weekly_label;
-static lv_obj_t* lbl_weekly_reset;
-static lv_obj_t* lbl_anim;
+static lv_obj_t *usage_container;
+static lv_obj_t *lbl_title;
+static lv_obj_t *bar_session;
+static lv_obj_t *lbl_session_pct;
+static lv_obj_t *lbl_session_label;
+static lv_obj_t *lbl_session_reset;
+static lv_obj_t *bar_weekly;
+static lv_obj_t *lbl_weekly_pct;
+static lv_obj_t *lbl_weekly_label;
+static lv_obj_t *lbl_weekly_reset;
+static lv_obj_t *lbl_anim;
 
 // ---- Bluetooth screen widgets ----
-static lv_obj_t* ble_container;
-static lv_obj_t* lbl_ble_status;
-static lv_obj_t* lbl_ble_device;
-static lv_obj_t* lbl_ble_mac;
+static lv_obj_t *ble_container;
+static lv_obj_t *lbl_ble_status;
+static lv_obj_t *lbl_ble_device;
+static lv_obj_t *lbl_ble_mac;
 
 // ---- Battery indicator (shared, on top) ----
-static lv_obj_t* battery_img;
-static lv_obj_t* logo_img;
-static lv_image_dsc_t battery_dscs[5];  // empty, low, medium, full, charging
+static lv_obj_t *battery_img;
+static lv_obj_t *logo_img;
+static lv_image_dsc_t battery_dscs[5]; // empty, low, medium, full, charging
 
 // ---- Shared ----
 static lv_image_dsc_t logo_dsc;
@@ -130,81 +130,161 @@ static uint8_t anim_spinner_idx = 0;
 static uint8_t anim_phase = 0;
 static uint8_t anim_msg_idx = 0;
 static uint32_t anim_msg_start = 0;
-#define ANIM_MSG_MS     4000
+#define ANIM_MSG_MS 4000
 
-static const char* const spinner_frames[] = {
-    "\xC2\xB7", "\xE2\x9C\xBB", "\xE2\x9C\xBD",
-    "\xE2\x9C\xB6", "\xE2\x9C\xB3", "\xE2\x9C\xA2",
+static const char *const spinner_frames[] = {
+    "\xC2\xB7",
+    "\xE2\x9C\xBB",
+    "\xE2\x9C\xBD",
+    "\xE2\x9C\xB6",
+    "\xE2\x9C\xB3",
+    "\xE2\x9C\xA2",
 };
 #define SPINNER_COUNT 6
-#define SPINNER_PHASES (2 * (SPINNER_COUNT - 1))  // 10: ping-pong 0..5..0
+#define SPINNER_PHASES (2 * (SPINNER_COUNT - 1)) // 10: ping-pong 0..5..0
 
 // Per-frame hold time. Modeled on Claude Code's spinner (Cavalry triangle
 // oscillator, range 0..5, period 5s) — turn-around frames (0 and 5) appear
 // once per cycle, middle frames twice, so 0/5 read as held longer.
 static const uint16_t spinner_ms[SPINNER_COUNT] = {
-    260, 130, 130, 130, 130, 260,
+    260,
+    130,
+    130,
+    130,
+    130,
+    260,
 };
 
-static const char* const anim_messages[] = {
-    "Accomplishing", "Elucidating", "Perusing",
-    "Actioning", "Enchanting", "Philosophising",
-    "Actualizing", "Envisioning", "Pondering",
-    "Baking", "Finagling", "Pontificating",
-    "Booping", "Flibbertigibbeting", "Processing",
-    "Brewing", "Forging", "Puttering",
-    "Calculating", "Forming", "Puzzling",
-    "Cerebrating", "Frolicking", "Reticulating",
-    "Channelling", "Generating", "Ruminating",
-    "Churning", "Germinating", "Scheming",
-    "Clauding", "Hatching", "Schlepping",
-    "Coalescing", "Herding", "Shimmying",
-    "Cogitating", "Honking", "Shucking",
-    "Combobulating", "Hustling", "Simmering",
-    "Computing", "Ideating", "Smooshing",
-    "Concocting", "Imagining", "Spelunking",
-    "Conjuring", "Incubating", "Spinning",
-    "Considering", "Inferring", "Stewing",
-    "Contemplating", "Jiving", "Sussing",
-    "Cooking", "Manifesting", "Synthesizing",
-    "Crafting", "Marinating", "Thinking",
-    "Creating", "Meandering", "Tinkering",
-    "Crunching", "Moseying", "Transmuting",
-    "Deciphering", "Mulling", "Unfurling",
-    "Deliberating", "Mustering", "Unravelling",
-    "Determining", "Musing", "Vibing",
-    "Discombobulating", "Noodling", "Wandering",
-    "Divining", "Percolating", "Whirring",
-    "Doing", "Wibbling",
-    "Effecting", "Wizarding",
-    "Working", "Wrangling",
+static const char *const anim_messages[] = {
+    "Accomplishing",
+    "Elucidating",
+    "Perusing",
+    "Actioning",
+    "Enchanting",
+    "Philosophising",
+    "Actualizing",
+    "Envisioning",
+    "Pondering",
+    "Baking",
+    "Finagling",
+    "Pontificating",
+    "Booping",
+    "Flibbertigibbeting",
+    "Processing",
+    "Brewing",
+    "Forging",
+    "Puttering",
+    "Calculating",
+    "Forming",
+    "Puzzling",
+    "Cerebrating",
+    "Frolicking",
+    "Reticulating",
+    "Channelling",
+    "Generating",
+    "Ruminating",
+    "Churning",
+    "Germinating",
+    "Scheming",
+    "Clauding",
+    "Hatching",
+    "Schlepping",
+    "Coalescing",
+    "Herding",
+    "Shimmying",
+    "Cogitating",
+    "Honking",
+    "Shucking",
+    "Combobulating",
+    "Hustling",
+    "Simmering",
+    "Computing",
+    "Ideating",
+    "Smooshing",
+    "Concocting",
+    "Imagining",
+    "Spelunking",
+    "Conjuring",
+    "Incubating",
+    "Spinning",
+    "Considering",
+    "Inferring",
+    "Stewing",
+    "Contemplating",
+    "Jiving",
+    "Sussing",
+    "Cooking",
+    "Manifesting",
+    "Synthesizing",
+    "Crafting",
+    "Marinating",
+    "Thinking",
+    "Creating",
+    "Meandering",
+    "Tinkering",
+    "Crunching",
+    "Moseying",
+    "Transmuting",
+    "Deciphering",
+    "Mulling",
+    "Unfurling",
+    "Deliberating",
+    "Mustering",
+    "Unravelling",
+    "Determining",
+    "Musing",
+    "Vibing",
+    "Discombobulating",
+    "Noodling",
+    "Wandering",
+    "Divining",
+    "Percolating",
+    "Whirring",
+    "Doing",
+    "Wibbling",
+    "Effecting",
+    "Wizarding",
+    "Working",
+    "Wrangling",
 };
 #define ANIM_MSG_COUNT (sizeof(anim_messages) / sizeof(anim_messages[0]))
 
-static lv_color_t pct_color(float pct) {
-    if (pct >= 80.0f) return COL_RED;
-    if (pct >= 50.0f) return COL_AMBER;
+static lv_color_t pct_color(float pct)
+{
+    if (pct >= 80.0f)
+        return COL_RED;
+    if (pct >= 50.0f)
+        return COL_AMBER;
     return COL_GREEN;
 }
 
-static void format_reset_time(int mins, char* buf, size_t len) {
-    if (mins < 0) {
+static void format_reset_time(int mins, char *buf, size_t len)
+{
+    if (mins < 0)
+    {
         snprintf(buf, len, "---");
-    } else if (mins < 60) {
+    }
+    else if (mins < 60)
+    {
         snprintf(buf, len, "Resets in %dm", mins);
-    } else if (mins < 1440) {
+    }
+    else if (mins < 1440)
+    {
         snprintf(buf, len, "Resets in %dh %dm", mins / 60, mins % 60);
-    } else {
+    }
+    else
+    {
         snprintf(buf, len, "Resets in %dd %dh", mins / 1440, (mins % 1440) / 60);
     }
 }
 
 // Forward decls — callbacks defined near ui_show_screen below
-static void global_click_cb(lv_event_t* e);
-static void ble_reset_click_cb(lv_event_t* e);
+static void global_click_cb(lv_event_t *e);
+static void ble_reset_click_cb(lv_event_t *e);
 
-static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
-    lv_obj_t* panel = lv_obj_create(parent);
+static lv_obj_t *make_panel(lv_obj_t *parent, int x, int y, int w, int h)
+{
+    lv_obj_t *panel = lv_obj_create(parent);
     lv_obj_set_pos(panel, x, y);
     lv_obj_set_size(panel, w, h);
     lv_obj_set_style_bg_color(panel, COL_PANEL, 0);
@@ -222,8 +302,9 @@ static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     return panel;
 }
 
-static lv_obj_t* make_bar(lv_obj_t* parent, int x, int y, int w, int h) {
-    lv_obj_t* bar = lv_bar_create(parent);
+static lv_obj_t *make_bar(lv_obj_t *parent, int x, int y, int w, int h)
+{
+    lv_obj_t *bar = lv_bar_create(parent);
     lv_obj_set_pos(bar, x, y);
     lv_obj_set_size(bar, w, h);
     lv_bar_set_range(bar, 0, 100);
@@ -237,18 +318,20 @@ static lv_obj_t* make_bar(lv_obj_t* parent, int x, int y, int w, int h) {
     return bar;
 }
 
-static void init_icon_dsc(lv_image_dsc_t* dsc, int w, int h, const uint16_t* data) {
+static void init_icon_dsc(lv_image_dsc_t *dsc, int w, int h, const uint16_t *data)
+{
     dsc->header.w = w;
     dsc->header.h = h;
     dsc->header.cf = LV_COLOR_FORMAT_RGB565;
     dsc->header.stride = w * 2;
-    dsc->data = (const uint8_t*)data;
+    dsc->data = (const uint8_t *)data;
     dsc->data_size = w * h * 2;
 }
 
 // RGB565A8: planar — w*h RGB565 pixels followed by w*h alpha bytes.
 // Stride is RGB565-only (w*2); LVGL infers alpha plane location from header.
-static void init_icon_dsc_rgb565a8(lv_image_dsc_t* dsc, int w, int h, const uint8_t* data) {
+static void init_icon_dsc_rgb565a8(lv_image_dsc_t *dsc, int w, int h, const uint8_t *data)
+{
     dsc->header.w = w;
     dsc->header.h = h;
     dsc->header.cf = LV_COLOR_FORMAT_RGB565A8;
@@ -257,8 +340,9 @@ static void init_icon_dsc_rgb565a8(lv_image_dsc_t* dsc, int w, int h, const uint
     dsc->data_size = w * h * 3;
 }
 
-static lv_obj_t* make_pill(lv_obj_t* parent, const char* text) {
-    lv_obj_t* lbl = lv_label_create(parent);
+static lv_obj_t *make_pill(lv_obj_t *parent, const char *text)
+{
+    lv_obj_t *lbl = lv_label_create(parent);
     lv_label_set_text(lbl, text);
     lv_obj_set_style_text_font(lbl, FONT_PILL, 0);
     lv_obj_set_style_text_color(lbl, COL_TEXT, 0);
@@ -273,7 +357,8 @@ static lv_obj_t* make_pill(lv_obj_t* parent, const char* text) {
 }
 
 // ---- Battery icon initialization ----
-static void init_battery_icons(void) {
+static void init_battery_icons(void)
+{
     init_icon_dsc_rgb565a8(&battery_dscs[0], ICON_BATTERY_W, ICON_BATTERY_H, icon_battery_data);
     init_icon_dsc_rgb565a8(&battery_dscs[1], ICON_BATTERY_LOW_W, ICON_BATTERY_LOW_H, icon_battery_low_data);
     init_icon_dsc_rgb565a8(&battery_dscs[2], ICON_BATTERY_MEDIUM_W, ICON_BATTERY_MEDIUM_H, icon_battery_medium_data);
@@ -286,10 +371,11 @@ static void init_battery_icons(void) {
 // One Session/Weekly panel: big % label, pill on the right, bar, reset label.
 // Pill y=1: symmetric inside the panel — panel-outer-top → pill-top equals
 // pill-bottom → bar-top (pill height 42 + panel pad_top 12 + bar y=56).
-static void make_usage_panel(lv_obj_t* parent, int y, const char* pill_text,
-                             lv_obj_t** out_pct, lv_obj_t** out_pill,
-                             lv_obj_t** out_bar, lv_obj_t** out_reset) {
-    lv_obj_t* panel = make_panel(parent, MARGIN, y, CONTENT_W, PANEL_H);
+static void make_usage_panel(lv_obj_t *parent, int y, const char *pill_text,
+                             lv_obj_t **out_pct, lv_obj_t **out_pill,
+                             lv_obj_t **out_bar, lv_obj_t **out_reset)
+{
+    lv_obj_t *panel = make_panel(parent, MARGIN, y, CONTENT_W, PANEL_H);
 
     *out_pct = lv_label_create(panel);
     lv_label_set_text(*out_pct, "---%");
@@ -309,7 +395,8 @@ static void make_usage_panel(lv_obj_t* parent, int y, const char* pill_text,
     lv_obj_set_pos(*out_reset, 0, RESET_Y);
 }
 
-static void init_usage_screen(lv_obj_t* scr) {
+static void init_usage_screen(lv_obj_t *scr)
+{
     usage_container = lv_obj_create(scr);
     lv_obj_set_size(usage_container, SCR_W, SCR_H);
     lv_obj_set_pos(usage_container, 0, 0);
@@ -341,7 +428,8 @@ static void init_usage_screen(lv_obj_t* scr) {
 
 // ======== Bluetooth Screen (480x480) ========
 
-static void init_bluetooth_screen(lv_obj_t* scr) {
+static void init_bluetooth_screen(lv_obj_t *scr)
+{
     ble_container = lv_obj_create(scr);
     lv_obj_set_size(ble_container, SCR_W, SCR_H);
     lv_obj_set_pos(ble_container, 0, 0);
@@ -351,20 +439,20 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_SCROLLABLE);
 
     // Title
-    lv_obj_t* lbl_ble_title = lv_label_create(ble_container);
+    lv_obj_t *lbl_ble_title = lv_label_create(ble_container);
     lv_label_set_text(lbl_ble_title, "Bluetooth");
     lv_obj_set_style_text_font(lbl_ble_title, FONT_TITLE, 0);
     lv_obj_set_style_text_color(lbl_ble_title, COL_TEXT, 0);
     lv_obj_align(lbl_ble_title, LV_ALIGN_TOP_MID, TITLE_X_SHIFT, TITLE_Y);
 
-    lv_obj_t* p_info = make_panel(ble_container, MARGIN, CONTENT_Y, CONTENT_W, BT_INFO_H);
+    lv_obj_t *p_info = make_panel(ble_container, MARGIN, CONTENT_Y, CONTENT_W, BT_INFO_H);
 
     // Bluetooth icon + status row
 #if SHOW_BT_ICON
     static lv_image_dsc_t icon_bt_dsc;
     init_icon_dsc(&icon_bt_dsc, ICON_BLUETOOTH_W, ICON_BLUETOOTH_H, icon_bluetooth_data);
 
-    lv_obj_t* bt_img = lv_image_create(p_info);
+    lv_obj_t *bt_img = lv_image_create(p_info);
     lv_image_set_src(bt_img, &icon_bt_dsc);
     lv_obj_set_pos(bt_img, 0, 0);
 #endif
@@ -393,7 +481,7 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
 
     // Reset Bluetooth tap zone with trash icon
     int reset_y = CONTENT_Y + BT_INFO_H + BT_RESET_GAP;
-    lv_obj_t* reset_zone = lv_obj_create(ble_container);
+    lv_obj_t *reset_zone = lv_obj_create(ble_container);
     lv_obj_set_pos(reset_zone, MARGIN, reset_y);
     lv_obj_set_size(reset_zone, CONTENT_W, BT_RESET_H);
     lv_obj_set_style_bg_color(reset_zone, COL_PANEL, 0);
@@ -409,24 +497,24 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
 #if SHOW_BT_RESET_ICON
     static lv_image_dsc_t icon_trash_dsc;
     init_icon_dsc(&icon_trash_dsc, ICON_TRASH2_W, ICON_TRASH2_H, icon_trash2_data);
-    lv_obj_t* trash_img = lv_image_create(reset_zone);
+    lv_obj_t *trash_img = lv_image_create(reset_zone);
     lv_image_set_src(trash_img, &icon_trash_dsc);
 #endif
 
-    lv_obj_t* reset_lbl = lv_label_create(reset_zone);
+    lv_obj_t *reset_lbl = lv_label_create(reset_zone);
     lv_label_set_text(reset_lbl, "Reset Bluetooth");
     lv_obj_set_style_text_font(reset_lbl, FONT_BODY, 0);
     lv_obj_set_style_text_color(reset_lbl, COL_DIM, 0);
 
     // Attribution
 #if SHOW_CREDITS
-    lv_obj_t* lbl_credit = lv_label_create(ble_container);
+    lv_obj_t *lbl_credit = lv_label_create(ble_container);
     lv_label_set_text(lbl_credit, "Built by @hermannbjorgvin");
     lv_obj_set_style_text_font(lbl_credit, FONT_CREDIT, 0);
     lv_obj_set_style_text_color(lbl_credit, COL_DIM, 0);
     lv_obj_align(lbl_credit, LV_ALIGN_BOTTOM_MID, 0, -46);
 
-    lv_obj_t* lbl_credit2 = lv_label_create(ble_container);
+    lv_obj_t *lbl_credit2 = lv_label_create(ble_container);
     lv_label_set_text(lbl_credit2, "Clawd animation by @amaanbuilds");
     lv_obj_set_style_text_font(lbl_credit2, &font_styrene_20, 0);
     lv_obj_set_style_text_color(lbl_credit2, COL_DIM, 0);
@@ -439,8 +527,9 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
 
 // ======== Public API ========
 
-void ui_init(void) {
-    lv_obj_t* scr = lv_screen_active();
+void ui_init(void)
+{
+    lv_obj_t *scr = lv_screen_active();
     lv_obj_set_style_bg_color(scr, COL_BG, 0);
     lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
 
@@ -457,7 +546,8 @@ void ui_init(void) {
     splash_init(scr);
 
     // Splash is touch-toggled — tap anywhere on the splash dismisses it
-    if (splash_get_root()) {
+    if (splash_get_root())
+    {
         lv_obj_add_event_cb(splash_get_root(), global_click_cb, LV_EVENT_CLICKED, NULL);
     }
 
@@ -480,8 +570,10 @@ void ui_init(void) {
 #endif
 }
 
-void ui_update(const UsageData* data) {
-    if (!data->valid) return;
+void ui_update(const UsageData *data)
+{
+    if (!data->valid)
+        return;
 
     int s_pct = (int)(data->session_pct + 0.5f);
 
@@ -503,17 +595,21 @@ void ui_update(const UsageData* data) {
     lv_label_set_text(lbl_weekly_reset, buf);
 }
 
-void ui_tick_anim(void) {
-    if (current_screen != SCREEN_USAGE) return;
+void ui_tick_anim(void)
+{
+    if (current_screen != SCREEN_USAGE)
+        return;
 
     uint32_t now = lv_tick_get();
 
-    if (now - anim_msg_start >= ANIM_MSG_MS) {
+    if (now - anim_msg_start >= ANIM_MSG_MS)
+    {
         anim_msg_idx = (anim_msg_idx + 1) % ANIM_MSG_COUNT;
         anim_msg_start = now;
     }
 
-    if (now - anim_last_ms >= spinner_ms[anim_spinner_idx]) {
+    if (now - anim_last_ms >= spinner_ms[anim_spinner_idx])
+    {
         anim_last_ms = now;
         anim_phase = (anim_phase + 1) % SPINNER_PHASES;
         anim_spinner_idx = (anim_phase < SPINNER_COUNT) ? anim_phase
@@ -530,66 +626,93 @@ void ui_tick_anim(void) {
 static screen_t prev_non_splash_screen = SCREEN_USAGE;
 // Hide the battery indicator on the splash screen — the icon is visually
 // noisy over the pixel-art creature animations.
-static void apply_battery_visibility(void) {
-    if (!battery_img) return;
-    if (current_screen == SCREEN_SPLASH) lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
-    else                                  lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+static void apply_battery_visibility(void)
+{
+    if (!battery_img)
+        return;
+    if (current_screen == SCREEN_SPLASH)
+        lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+    else
+        lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
 }
 
 // LVGL handles click debouncing internally. Screen-level handler fires when
 // no child consumed the event (children only consume if they have their own
 // event callback, e.g. the Reset Bluetooth zone). On BT screen we skip the
 // splash toggle so only the reset zone is interactive there.
-static void global_click_cb(lv_event_t* e) {
+static void global_click_cb(lv_event_t *e)
+{
     (void)e;
-    if (ui_get_current_screen() == SCREEN_BLUETOOTH) return;
+    if (ui_get_current_screen() == SCREEN_BLUETOOTH)
+        return;
     ui_toggle_splash();
 }
 
-static void ble_reset_click_cb(lv_event_t* e) {
+static void ble_reset_click_cb(lv_event_t *e)
+{
     (void)e;
     ble_clear_bonds();
 }
 
-void ui_show_screen(screen_t screen) {
+void ui_show_screen(screen_t screen)
+{
     lv_obj_add_flag(usage_container, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(ble_container, LV_OBJ_FLAG_HIDDEN);
     splash_hide();
 
-    switch (screen) {
-    case SCREEN_SPLASH:     splash_show(); break;
-    case SCREEN_USAGE:      lv_obj_clear_flag(usage_container, LV_OBJ_FLAG_HIDDEN); break;
-    case SCREEN_BLUETOOTH:  lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_HIDDEN); break;
-    default: break;
+    switch (screen)
+    {
+    case SCREEN_SPLASH:
+        splash_show();
+        break;
+    case SCREEN_USAGE:
+        lv_obj_clear_flag(usage_container, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case SCREEN_BLUETOOTH:
+        lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_HIDDEN);
+        break;
+    default:
+        break;
     }
 
     // Hide the logo overlay on the splash screen so the animation has a clean canvas
-    if (logo_img) {
-        if (screen == SCREEN_SPLASH) lv_obj_add_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
-        else                          lv_obj_clear_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
+    if (logo_img)
+    {
+        if (screen == SCREEN_SPLASH)
+            lv_obj_add_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
+        else
+            lv_obj_clear_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
     }
 
-    if (screen != SCREEN_SPLASH) prev_non_splash_screen = screen;
+    if (screen != SCREEN_SPLASH)
+        prev_non_splash_screen = screen;
     current_screen = screen;
     apply_battery_visibility();
 }
 
-void ui_cycle_screen(void) {
+void ui_cycle_screen(void)
+{
     screen_t next = (current_screen == SCREEN_USAGE) ? SCREEN_BLUETOOTH : SCREEN_USAGE;
     ui_show_screen(next);
 }
 
-void ui_toggle_splash(void) {
-    if (current_screen == SCREEN_SPLASH) ui_show_screen(prev_non_splash_screen);
-    else                                  ui_show_screen(SCREEN_SPLASH);
+void ui_toggle_splash(void)
+{
+    if (current_screen == SCREEN_SPLASH)
+        ui_show_screen(prev_non_splash_screen);
+    else
+        ui_show_screen(SCREEN_SPLASH);
 }
 
-screen_t ui_get_current_screen(void) {
+screen_t ui_get_current_screen(void)
+{
     return current_screen;
 }
 
-void ui_update_ble_status(ble_state_t state, const char* name, const char* mac) {
-    switch (state) {
+void ui_update_ble_status(ble_state_t state, const char *name, const char *mac)
+{
+    switch (state)
+    {
     case BLE_STATE_CONNECTED:
         lv_label_set_text(lbl_ble_status, "Connected");
         lv_obj_set_style_text_color(lbl_ble_status, COL_GREEN, 0);
@@ -608,34 +731,49 @@ void ui_update_ble_status(ble_state_t state, const char* name, const char* mac) 
         break;
     }
 
-    if (name) {
+    if (name)
+    {
         static char nbuf[48];
         snprintf(nbuf, sizeof(nbuf), "Device: %s", name);
         lv_label_set_text(lbl_ble_device, nbuf);
     }
-    if (mac) {
+    if (mac)
+    {
         static char mbuf[48];
         snprintf(mbuf, sizeof(mbuf), "Address: %s", mac);
         lv_label_set_text(lbl_ble_mac, mbuf);
     }
 }
 
-void ui_update_battery(int percent, bool charging) {
-    if (!battery_img) return;
+void ui_update_battery(int percent, bool charging)
+{
+    if (!battery_img)
+        return;
 
     int idx;
-    if (charging) {
-        idx = 4;  // charging icon
-    } else if (percent < 0) {
-        idx = 0;  // no battery / unknown
-    } else if (percent <= 10) {
-        idx = 0;  // empty
-    } else if (percent <= 35) {
-        idx = 1;  // low
-    } else if (percent <= 75) {
-        idx = 2;  // medium
-    } else {
-        idx = 3;  // full
+    if (charging)
+    {
+        idx = 4; // charging icon
+    }
+    else if (percent < 0)
+    {
+        idx = 0; // no battery / unknown
+    }
+    else if (percent <= 10)
+    {
+        idx = 0; // empty
+    }
+    else if (percent <= 35)
+    {
+        idx = 1; // low
+    }
+    else if (percent <= 75)
+    {
+        idx = 2; // medium
+    }
+    else
+    {
+        idx = 3; // full
     }
     lv_image_set_src(battery_img, &battery_dscs[idx]);
     apply_battery_visibility();


### PR DESCRIPTION
## Summary
- add generic/xingzhi-cube board support and board-specific display config
- harden BLE advertising + connection behavior for cross-platform daemon compatibility
- add xingzhi-safe boot and LVGL guards for resilience
- tune xingzhi UI layout for 284x240 display
- add splash tint fixes, including byte-swap handling and dark-eye preservation
- improve daemon BLE discovery matching on Windows (name/local_name/service UUID)

## Validation
- built firmware: xingzhi_cube_183
- flashed successfully to COM15
- verified device advertising and Windows BLE discoverability