### PR TITLE
feat: add minimal Freenove ESP32-S3 Display NonTouch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 A small ESP32 dashboard I made for my desk to keep an eye on Claude Code usage.
 
-It runs on a [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) and pairs with my laptop over Bluetooth, the splash screen plays pixel-art Clawd animations that get
-busier when your usage rate climbs. The two side buttons send Space and
-Shift+Tab over BLE HID for Claude Code's voice mode and mode-toggle shortcuts.
+It supports two firmware targets:
+
+| Target | Board | Experience |
+| --- | --- | --- |
+| `waveshare_amoled_216` | [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) | Full experience: touch UI, splash animations, Bluetooth screen, battery UI, auto-rotation, and BLE HID shortcuts |
+| `freenove_s3_display_minimal` | Freenove ESP32-S3 Display NonTouch **FNK0104B** (2.8" 240×320 ILI9341) | Minimal experience: one Usage screen plus BLE data updates |
+
+The Waveshare build is the original version: it pairs with my laptop over Bluetooth, the splash screen plays pixel-art Clawd animations that get busier when your usage rate climbs, and the two side buttons send Space and Shift+Tab over BLE HID for Claude Code's voice mode and mode-toggle shortcuts.
 
 |              Usage meter              |              Clawd animation screen              |
 | :-----------------------------------: | :----------------------------------------------: |
@@ -25,9 +30,17 @@ While the splash is up, the middle button cycles animations instead of screens. 
 
 ## Hardware
 
+### Waveshare target
+
 - [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) - ESP32-S3R8, 2.16" 480×480 AMOLED (CO5300 QSPI), CST9220 cap touch, AXP2101 PMU + Li-Po battery, QMI8658 IMU
 - USB-C cable for flashing firmware and charging
 - 3.7V Li-Po battery (MX1.25 2-pin connector, optional)
+
+### Freenove minimal target
+
+- Freenove ESP32-S3 Display NonTouch **FNK0104B** - 2.8" 240×320 ILI9341 TFT
+- USB-C cable for flashing firmware
+- No extra input hardware required for the minimal build
 
 ## Prerequisites
 
@@ -43,18 +56,26 @@ The macOS host pieces — Python daemon, LaunchAgent, and flash helper — were 
 
 ### Flash the firmware
 
+Waveshare target:
+
 ```bash
-./flash-mac.sh                       # auto-detects /dev/cu.usbmodem*
+./flash-mac.sh                        # auto-detects /dev/cu.usbmodem*
 ./flash-mac.sh /dev/cu.usbmodem1101  # or pass an explicit USB serial port
+```
+
+Freenove minimal target:
+
+```bash
+pio run -d firmware -e freenove_s3_display_minimal -t upload --upload-port /dev/cu.usbmodem101
 ```
 
 ### Pair the device
 
-After flashing, open **System Settings → Bluetooth** and click *Connect* next to "Clawdmeter". The daemon will discover it on its next scan (~30 s).
+After flashing, open **System Settings → Bluetooth** and click *Connect* next to **"Claude Controller"**. Both firmware targets advertise under that BLE name, and the daemon will discover the device on its next scan (~30 s).
 
 ### Install the daemon
 
-The daemon reads your Claude OAuth token from the macOS Keychain (service `Claude Code-credentials`), polls usage every 60 s, and pushes it to the display over BLE.
+The daemon reads your Claude OAuth token from the macOS Keychain (service `Claude Code-credentials`), polls usage every 60 s, and pushes it to the display over BLE. If Claude Code is already signed in on the Mac, you do not need to create a separate API key for this flow.
 
 ```bash
 ./install-mac.sh
@@ -75,14 +96,22 @@ launchctl load -w ~/Library/LaunchAgents/com.user.claude-usage-daemon.plist # st
 
 ### Flash the firmware
 
+Waveshare target:
+
 ```bash
 cd firmware
-pio run -t upload --upload-port /dev/ttyACM0
+pio run -e waveshare_amoled_216 -t upload --upload-port /dev/ttyACM0
+```
+
+Freenove minimal target:
+
+```bash
+pio run -d firmware -e freenove_s3_display_minimal -t upload --upload-port /dev/ttyACM0
 ```
 
 ### Pair the device
 
-After flashing, the device advertises as "Claudemeter". Pair it once:
+After flashing, the device advertises as **"Claude Controller"**. Pair it once:
 
 ```bash
 # Scan for the device
@@ -93,7 +122,7 @@ bluetoothctl pair F4:12:FA:C0:8F:E5    # use your device's MAC
 bluetoothctl trust F4:12:FA:C0:8F:E5
 ```
 
-The MAC address is shown on the Bluetooth screen — press the middle (PWR) button to cycle to it.
+On the Waveshare target, the MAC address is shown on the Bluetooth screen. The Freenove minimal target has no Bluetooth screen; use `bluetoothctl devices` after scanning instead.
 
 ### Install the daemon
 
@@ -110,7 +139,7 @@ View logs: `journalctl --user -u claude-usage-daemon -f`
 
 ## How it works
 
-1. The daemon reads your Claude Code OAuth token from `~/.claude/.credentials.json`.
+1. The daemon reads your Claude Code OAuth token from the macOS Keychain on macOS, or from `~/.claude/.credentials.json` on Linux.
 2. It makes a minimal API call to `api.anthropic.com/v1/messages` — one token of Haiku, basically free.
 3. The usage numbers come straight out of the response headers (`anthropic-ratelimit-unified-5h-utilization` and friends).
 4. The daemon connects to the ESP32 over BLE and writes a JSON payload to the GATT RX characteristic.
@@ -225,3 +254,18 @@ See `tools/README.md` for details.
 ## Licensing gray area warning
 
 The software in this repository uses and adheres to the Anthropic brand guidelines and uses the same proprietary fonts that Anthropic has a license for but this software uses without permission as well as using assets from Anthropic such as the copyrighted Clawd mascot so even though the code in this repo is non-proprietary I will not license it myself under a copyleft license since this repo includes proprietary fonts and copyrighted assets. Please be aware of this if you fork or copy the code from this repo. **You have been warned!**
+
+## Target comparison
+
+| Capability | Waveshare target | Freenove minimal target |
+| --- | --- | --- |
+| Usage meter | Yes | Yes |
+| BLE data service | Yes | Yes |
+| Splash animations | Yes | No |
+| Touch input | Yes | No |
+| Bluetooth status screen | Yes | No |
+| BLE HID keyboard buttons | Yes | No |
+| Battery indicator | Yes | No |
+| Auto-rotation | Yes | No |
+
+The Freenove build boots directly into the Usage screen and waits for BLE data from the same host daemon. It intentionally keeps only the core product loop: receive usage data over BLE and render the meter.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -5,6 +5,7 @@ framework = arduino
 board_build.arduino.memory_type = qio_opi
 upload_speed = 921600
 monitor_speed = 115200
+build_src_filter = +<*> -<main_freenove.cpp> -<ui_freenove.cpp> -<display_freenove.cpp>
 
 build_flags =
     -DARDUINO_USB_CDC_ON_BOOT=1
@@ -37,6 +38,43 @@ lib_deps =
     moononournation/GFX Library for Arduino@^1.5.6
     lewisxhe/SensorLib@^0.2.6
     lewisxhe/XPowersLib@^0.2.7
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1
+
+
+[env:freenove_s3_display_minimal]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+upload_speed = 921600
+monitor_speed = 115200
+build_src_filter = +<*> -<main.cpp> -<ui.cpp> -<power.cpp> -<imu.cpp> -<splash.cpp>
+
+build_flags =
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    -DCLAWDMETER_BOARD_FREENOVE=1
+    ; NimBLE config — peripheral-only, single connection
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+    ; LVGL config via build flags
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_TICK_CUSTOM=1
+
+lib_deps =
+    moononournation/GFX Library for Arduino@^1.5.6
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/src/display_freenove.cpp
+++ b/firmware/src/display_freenove.cpp
@@ -1,0 +1,29 @@
+#include "display_freenove.h"
+#include "freenove_board.h"
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+static Arduino_DataBus* bus = nullptr;
+static Arduino_GFX* gfx = nullptr;
+
+void display_init(void) {
+    pinMode(TFT_BL, OUTPUT);
+    digitalWrite(TFT_BL, HIGH);
+
+    bus = new Arduino_ESP32SPI(TFT_DC, TFT_CS, TFT_SCLK, TFT_MOSI, TFT_MISO);
+    gfx = new Arduino_ILI9341(bus, TFT_RST, 0, true, LCD_WIDTH, LCD_HEIGHT);
+    gfx->begin();
+    gfx->fillScreen(0x0000);
+}
+
+void display_flush(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
+    if (!gfx) {
+        lv_display_flush_ready(disp);
+        return;
+    }
+
+    const int32_t w = area->x2 - area->x1 + 1;
+    const int32_t h = area->y2 - area->y1 + 1;
+    gfx->draw16bitRGBBitmap(area->x1, area->y1, (uint16_t*)px_map, w, h);
+    lv_display_flush_ready(disp);
+}

--- a/firmware/src/display_freenove.h
+++ b/firmware/src/display_freenove.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <lvgl.h>
+
+void display_init(void);
+void display_flush(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map);

--- a/firmware/src/freenove_board.h
+++ b/firmware/src/freenove_board.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// Freenove ESP32-S3 Display NonTouch minimal target.
+#define LCD_WIDTH   240
+#define LCD_HEIGHT  320
+
+#define BOARD_HAS_TOUCH        0
+#define BOARD_HAS_PMU          0
+#define BOARD_HAS_IMU          0
+#define BOARD_HAS_HID_BUTTONS  0
+
+// TFT pins for FNK0104B NonTouch from Freenove's official TFT_eSPI setup.
+#define TFT_CS      10
+#define TFT_MOSI    11
+#define TFT_SCLK    12
+#define TFT_MISO    13
+#define TFT_BL      45
+#define TFT_DC      46
+#define TFT_RST     -1

--- a/firmware/src/main_freenove.cpp
+++ b/firmware/src/main_freenove.cpp
@@ -1,0 +1,77 @@
+#include <Arduino.h>
+#include <lvgl.h>
+#include <ArduinoJson.h>
+#include "freenove_board.h"
+#include "display_freenove.h"
+#include "data.h"
+#include "ui_freenove.h"
+#include "ble.h"
+
+static UsageData usage = {};
+static uint16_t* buf1 = nullptr;
+static uint16_t* buf2 = nullptr;
+#define BUF_LINES 32
+
+static uint32_t my_tick(void) {
+    return millis();
+}
+
+static bool parse_json(const char* json, UsageData* out) {
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, json);
+    if (err) {
+        Serial.printf("JSON parse error: %s\n", err.c_str());
+        return false;
+    }
+
+    out->session_pct = doc["s"] | 0.0f;
+    out->session_reset_mins = doc["sr"] | -1;
+    out->weekly_pct = doc["w"] | 0.0f;
+    out->weekly_reset_mins = doc["wr"] | -1;
+    strlcpy(out->status, doc["st"] | "unknown", sizeof(out->status));
+    out->ok = doc["ok"] | false;
+    out->valid = true;
+    return true;
+}
+
+void setup() {
+    Serial.begin(115200);
+    delay(300);
+    Serial.println("{\"ready\":true}");
+
+    display_init();
+
+    lv_init();
+    lv_tick_set_cb(my_tick);
+
+    buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA);
+    buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA);
+
+    lv_display_t* disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
+    lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
+    lv_display_set_flush_cb(disp, display_flush);
+    lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
+                           LV_DISPLAY_RENDER_MODE_PARTIAL);
+
+    ble_init();
+    ui_init();
+    ui_set_waiting_state();
+
+    Serial.println("Minimal dashboard ready, waiting for BLE data...");
+}
+
+void loop() {
+    lv_timer_handler();
+    ble_tick();
+
+    if (ble_has_data()) {
+        if (parse_json(ble_get_data(), &usage)) {
+            ui_update(&usage);
+            ble_send_ack();
+        } else {
+            ble_send_nack();
+        }
+    }
+
+    delay(5);
+}

--- a/firmware/src/ui_freenove.cpp
+++ b/firmware/src/ui_freenove.cpp
@@ -1,0 +1,140 @@
+#include "ui_freenove.h"
+#include "freenove_board.h"
+#include <lvgl.h>
+#include "theme.h"
+
+LV_FONT_DECLARE(font_styrene_28);
+LV_FONT_DECLARE(font_styrene_24);
+LV_FONT_DECLARE(font_styrene_20);
+
+#define COL_BG        THEME_BG
+#define COL_PANEL     THEME_PANEL
+#define COL_TEXT      THEME_TEXT
+#define COL_DIM       THEME_DIM
+#define COL_GREEN     THEME_GREEN
+#define COL_AMBER     THEME_AMBER
+#define COL_RED       THEME_RED
+#define COL_BAR_BG    THEME_BAR_BG
+
+static lv_obj_t* lbl_title;
+static lv_obj_t* lbl_status;
+static lv_obj_t* lbl_session_pct;
+static lv_obj_t* lbl_session_reset;
+static lv_obj_t* bar_session;
+static lv_obj_t* lbl_weekly_pct;
+static lv_obj_t* lbl_weekly_reset;
+static lv_obj_t* bar_weekly;
+
+static lv_color_t pct_color(float pct) {
+    if (pct >= 80.0f) return COL_RED;
+    if (pct >= 50.0f) return COL_AMBER;
+    return COL_GREEN;
+}
+
+static void format_reset_time(int mins, char* buf, size_t len) {
+    if (mins < 0) snprintf(buf, len, "---");
+    else if (mins < 60) snprintf(buf, len, "Resets in %dm", mins);
+    else if (mins < 1440) snprintf(buf, len, "Resets in %dh %dm", mins / 60, mins % 60);
+    else snprintf(buf, len, "Resets in %dd %dh", mins / 1440, (mins % 1440) / 60);
+}
+
+static lv_obj_t* make_panel(lv_obj_t* parent, int y) {
+    lv_obj_t* panel = lv_obj_create(parent);
+    lv_obj_set_pos(panel, 12, y);
+    lv_obj_set_size(panel, LCD_WIDTH - 24, 102);
+    lv_obj_set_style_bg_color(panel, COL_PANEL, 0);
+    lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(panel, 8, 0);
+    lv_obj_set_style_border_width(panel, 0, 0);
+    lv_obj_set_style_pad_all(panel, 12, 0);
+    lv_obj_clear_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
+    return panel;
+}
+
+static lv_obj_t* make_bar(lv_obj_t* parent, int y) {
+    lv_obj_t* bar = lv_bar_create(parent);
+    lv_obj_set_pos(bar, 0, y);
+    lv_obj_set_size(bar, LCD_WIDTH - 48, 16);
+    lv_bar_set_range(bar, 0, 100);
+    lv_bar_set_value(bar, 0, LV_ANIM_OFF);
+    lv_obj_set_style_bg_color(bar, COL_BAR_BG, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_set_style_radius(bar, 6, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(bar, COL_GREEN, LV_PART_INDICATOR);
+    lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, LV_PART_INDICATOR);
+    lv_obj_set_style_radius(bar, 6, LV_PART_INDICATOR);
+    return bar;
+}
+
+static void init_usage_panel(lv_obj_t* parent, int y, const char* label,
+                             lv_obj_t** out_pct, lv_obj_t** out_reset, lv_obj_t** out_bar) {
+    lv_obj_t* panel = make_panel(parent, y);
+
+    lv_obj_t* lbl = lv_label_create(panel);
+    lv_label_set_text(lbl, label);
+    lv_obj_set_style_text_font(lbl, &font_styrene_20, 0);
+    lv_obj_set_style_text_color(lbl, COL_DIM, 0);
+    lv_obj_set_pos(lbl, 0, 0);
+
+    *out_pct = lv_label_create(panel);
+    lv_label_set_text(*out_pct, "---%");
+    lv_obj_set_style_text_font(*out_pct, &font_styrene_28, 0);
+    lv_obj_set_style_text_color(*out_pct, COL_TEXT, 0);
+    lv_obj_align(*out_pct, LV_ALIGN_TOP_RIGHT, 0, -2);
+
+    *out_bar = make_bar(panel, 34);
+
+    *out_reset = lv_label_create(panel);
+    lv_label_set_text(*out_reset, "---");
+    lv_obj_set_style_text_font(*out_reset, &font_styrene_20, 0);
+    lv_obj_set_style_text_color(*out_reset, COL_DIM, 0);
+    lv_obj_set_pos(*out_reset, 0, 62);
+}
+
+void ui_init(void) {
+    lv_obj_t* scr = lv_screen_active();
+    lv_obj_set_style_bg_color(scr, COL_BG, 0);
+    lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
+
+    lbl_title = lv_label_create(scr);
+    lv_label_set_text(lbl_title, "Usage");
+    lv_obj_set_style_text_font(lbl_title, &font_styrene_28, 0);
+    lv_obj_set_style_text_color(lbl_title, COL_TEXT, 0);
+    lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 16);
+
+    lbl_status = lv_label_create(scr);
+    lv_label_set_text(lbl_status, "Waiting for BLE data...");
+    lv_obj_set_style_text_font(lbl_status, &font_styrene_20, 0);
+    lv_obj_set_style_text_color(lbl_status, COL_DIM, 0);
+    lv_obj_align(lbl_status, LV_ALIGN_TOP_MID, 0, 48);
+
+    init_usage_panel(scr, 78, "Current", &lbl_session_pct, &lbl_session_reset, &bar_session);
+    init_usage_panel(scr, 192, "Weekly", &lbl_weekly_pct, &lbl_weekly_reset, &bar_weekly);
+}
+
+void ui_set_waiting_state(void) {
+    lv_label_set_text(lbl_status, "Waiting for BLE data...");
+}
+
+void ui_update(const UsageData* data) {
+    if (!data || !data->valid) return;
+
+    lv_label_set_text(lbl_status, data->ok ? "Connected" : data->status);
+
+    int s_pct = (int)(data->session_pct + 0.5f);
+    lv_label_set_text_fmt(lbl_session_pct, "%d%%", s_pct);
+    lv_bar_set_value(bar_session, s_pct, LV_ANIM_ON);
+    lv_obj_set_style_bg_color(bar_session, pct_color(data->session_pct), LV_PART_INDICATOR);
+
+    char buf[48];
+    format_reset_time(data->session_reset_mins, buf, sizeof(buf));
+    lv_label_set_text(lbl_session_reset, buf);
+
+    int w_pct = (int)(data->weekly_pct + 0.5f);
+    lv_label_set_text_fmt(lbl_weekly_pct, "%d%%", w_pct);
+    lv_bar_set_value(bar_weekly, w_pct, LV_ANIM_ON);
+    lv_obj_set_style_bg_color(bar_weekly, pct_color(data->weekly_pct), LV_PART_INDICATOR);
+
+    format_reset_time(data->weekly_reset_mins, buf, sizeof(buf));
+    lv_label_set_text(lbl_weekly_reset, buf);
+}

--- a/firmware/src/ui_freenove.h
+++ b/firmware/src/ui_freenove.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "data.h"
+
+void ui_init(void);
+void ui_update(const UsageData* data);
+void ui_set_waiting_state(void);

--- a/flash-mac.sh
+++ b/flash-mac.sh
@@ -27,7 +27,7 @@ echo "Port: $PORT"
 echo ""
 
 cd "$SCRIPT_DIR/firmware"
-pio run -t upload --upload-port "$PORT"
+pio run -e waveshare_amoled_216 -t upload --upload-port "$PORT"
 
 echo ""
 echo "=== Done ==="

--- a/flash.sh
+++ b/flash.sh
@@ -10,7 +10,7 @@ echo "Port: $PORT"
 echo ""
 
 cd "$SCRIPT_DIR/firmware"
-~/.platformio/penv/bin/pio run -t upload --upload-port "$PORT"
+~/.platformio/penv/bin/pio run -e waveshare_amoled_216 -t upload --upload-port "$PORT"
 
 echo ""
 echo "=== Done! ==="


### PR DESCRIPTION
## Summary

- Add a new `freenove_s3_display_minimal` PlatformIO environment targeting the **Freenove ESP32-S3 Display NonTouch FNK0104B** (2.8" 240×320 ILI9341)
- Keep the existing Waveshare `waveshare_amoled_216` target fully intact — this is a parallel addition, not a replacement
- Update README to document both supported targets with flashing instructions and a capability comparison table

## What's included

The Freenove target adds board-specific files alongside the existing Waveshare code:

| File | Purpose |
|------|---------|
| `firmware/src/main_freenove.cpp` | Freenove entry point (setup/loop) |
| `firmware/src/ui_freenove.h/.cpp` | Minimal single-screen usage UI |
| `firmware/src/display_freenove.h/.cpp` | ILI9341 display backend |
| `firmware/src/freenove_board.h` | Pin definitions for FNK0104B |

The minimal target keeps the core flow (BLE GATT data service, Usage screen, host daemon protocol) while intentionally omitting Waveshare-specific features not available on the Freenove board: touch input, splash animations, Bluetooth screen, HID buttons, battery UI/PMU, and IMU auto-rotation.

## Testing

- Built `waveshare_amoled_216` ✅
- Built `freenove_s3_display_minimal` ✅
- Flashed to a Freenove ESP32-S3 Display NonTouch FNK0104B ✅
- macOS daemon connected over BLE ✅
- Usage payloads rendered on device ✅

## Notes

The Freenove FNK0104B uses an ILI9341 display controller. During bring-up, using ST7789 resulted in a lit backlight with no rendered pixels; switching to the ILI9341 configuration (as documented in the Freenove wiki) resolved the issue.

---
*Tested on macOS with the Python BLE daemon from the `macos-support` PR.*