### PR TITLE
Make BLE pairing work on macOS, allow daemon + HID to coexist

### DIFF
--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -166,6 +166,9 @@ async def poll_api(token: str) -> dict | None:
     except httpx.HTTPError as e:
         log(f"API call failed: {e}")
         return None
+    if resp.status_code >= 400:
+        log(f"API HTTP {resp.status_code}: {resp.text[:200]}")
+        return None
 
     def hdr(name: str, default: str = "0") -> str:
         return resp.headers.get(name, default)

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -11,12 +11,14 @@ build_flags =
     -DBOARD_HAS_PSRAM
     ; AXP2101 PMU
     -DXPOWERS_CHIP_AXP2101
-    ; NimBLE config — peripheral-only, single connection
+    ; NimBLE config — peripheral, 2 simultaneous connections so the OS can
+    ; hold the HID link (Space key from BOOT button) while the daemon holds
+    ; its own connection for the custom data service.
     -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
     -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
     -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
     -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
-    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
     ; LVGL config via build flags
     -DLV_CONF_SKIP
     -DLV_COLOR_DEPTH=16

--- a/firmware/src/ble.cpp
+++ b/firmware/src/ble.cpp
@@ -13,7 +13,10 @@
 
 #define BLE_BUF_SIZE 512
 
-// HID keyboard report descriptor
+// HID keyboard report descriptor (standard 6-KRO boot-protocol-compatible).
+// Includes the LED output report (Num/Caps/Scroll Lock indicators) — without
+// it macOS's Keyboard Setup Assistant flags the device as "unidentifiable"
+// because the descriptor doesn't look like a complete keyboard.
 static const uint8_t HID_REPORT_MAP[] = {
     0x05, 0x01,  // Usage Page (Generic Desktop)
     0x09, 0x06,  // Usage (Keyboard)
@@ -30,6 +33,16 @@ static const uint8_t HID_REPORT_MAP[] = {
     0x95, 0x01,  //   Report Count (1)
     0x75, 0x08,  //   Report Size (8)
     0x81, 0x01,  //   Input (Constant) - Reserved byte
+    // LED output report — required for macOS to treat this as a full keyboard.
+    0x95, 0x05,  //   Report Count (5)
+    0x75, 0x01,  //   Report Size (1)
+    0x05, 0x08,  //   Usage Page (LEDs)
+    0x19, 0x01,  //   Usage Minimum (Num Lock)
+    0x29, 0x05,  //   Usage Maximum (Kana)
+    0x91, 0x02,  //   Output (Data, Variable, Absolute) - LED report
+    0x95, 0x01,  //   Report Count (1)
+    0x75, 0x03,  //   Report Size (3)
+    0x91, 0x01,  //   Output (Constant) - LED report padding
     0x95, 0x06,  //   Report Count (6)
     0x75, 0x08,  //   Report Size (8)
     0x15, 0x00,  //   Logical Minimum (0)
@@ -58,10 +71,21 @@ static char mac_str[18];
 static void start_advertising() {
     NimBLEAdvertising* adv = NimBLEDevice::getAdvertising();
     adv->reset();
-    adv->addServiceUUID(SERVICE_UUID);
+    // Primary advertising packet (≤31 bytes):
+    //   flags (3) + appearance (4) + HID service 0x1812 (4) + name "Claude Controller" (19)
+    //   = 30 bytes. macOS Bluetooth Settings only surfaces BLE-only devices
+    //   that explicitly advertise the standard HID service UUID (0x1812) —
+    //   without it the device is recognized internally but hidden from the
+    //   GUI nearby-devices list.
     adv->setAppearance(HID_KEYBOARD);
-    adv->enableScanResponse(true);
+    adv->addServiceUUID(NimBLEUUID((uint16_t)0x1812));  // BLE HID Service
     adv->setName(DEVICE_NAME);
+    // Scan response carries the 128-bit custom data-service UUID for active
+    // scanners (the host daemon scans actively).
+    NimBLEAdvertisementData scanResp;
+    scanResp.setCompleteServices(NimBLEUUID(SERVICE_UUID));
+    adv->setScanResponseData(scanResp);
+    adv->enableScanResponse(true);
     bool ok = adv->start();
     state = BLE_STATE_ADVERTISING;
     Serial.printf("BLE: advertising start=%s\n", ok ? "OK" : "FAILED");
@@ -70,13 +94,23 @@ static void start_advertising() {
 class ServerCallbacks : public NimBLEServerCallbacks {
     void onConnect(NimBLEServer* s, NimBLEConnInfo& info) override {
         state = BLE_STATE_CONNECTED;
-        Serial.printf("BLE: connected from %s\n", info.getAddress().toString().c_str());
+        Serial.printf("BLE: connected from %s (active=%u)\n",
+            info.getAddress().toString().c_str(),
+            (unsigned)s->getConnectedCount());
+        // Keep advertising while a connection slot is still free so a second
+        // central (e.g. the host daemon alongside an OS-held HID link) can
+        // discover and connect. NimBLE auto-stops advertising on each accept.
+        if (s->getConnectedCount() < CONFIG_BT_NIMBLE_MAX_CONNECTIONS) {
+            need_advertise = true;
+        }
     }
 
     void onDisconnect(NimBLEServer* s, NimBLEConnInfo& info, int reason) override {
-        state = BLE_STATE_DISCONNECTED;
+        // Only flip the UI state to DISCONNECTED when the last client leaves.
+        if (s->getConnectedCount() == 0) state = BLE_STATE_DISCONNECTED;
         need_advertise = true;
-        Serial.printf("BLE: disconnected (reason=%d)\n", reason);
+        Serial.printf("BLE: disconnected (reason=%d, remaining=%u)\n",
+            reason, (unsigned)s->getConnectedCount());
     }
 
 };
@@ -124,8 +158,17 @@ void ble_init(void) {
     hid_dev = new NimBLEHIDDevice(server);
     hid_dev->setReportMap((uint8_t*)HID_REPORT_MAP, sizeof(HID_REPORT_MAP));
     hid_dev->setManufacturer("Anthropic");
-    hid_dev->setPnp(0x02, 0x05AC, 0x820A, 0x0210);  // BT SIG, generic keyboard
-    hid_dev->setHidInfo(0x00, 0x02);  // country=0, flags=normally connectable
+    // PnP ID: (vendorIdSource, vendorId, productId, version).
+    // Source 1 = Bluetooth SIG, vendor 0x02E5 = Espressif. Originally claimed
+    // Apple's USB vendor 0x05AC + Magic Keyboard product 0x820A — macOS
+    // validates Apple-claimed HIDs against known device IDs and silently
+    // refuses to surface a Connect button for spoofers.
+    hid_dev->setPnp(0x01, 0x02E5, 0x0001, 0x0100);
+    // country=33 (US ANSI). Setting this to 0 ("not supported") causes macOS
+    // to launch the Keyboard Setup Assistant on first pair asking the user
+    // to identify the layout — we only ever send Space / Shift+Tab so the
+    // physical layout is irrelevant; advertise a known one to skip the wizard.
+    hid_dev->setHidInfo(33, 0x02);
     hid_dev->setBatteryLevel(100);
     input_kbd = hid_dev->getInputReport(1);  // report ID 1
 

--- a/screenshot.sh
+++ b/screenshot.sh
@@ -1,19 +1,36 @@
 #!/bin/bash
 # Take a screenshot from the Waveshare AMOLED display via LVGL snapshot.
 # Usage: ./screenshot.sh [output.png] [port]
+# Default port: /dev/cu.usbmodem101 on macOS, /dev/ttyACM0 on Linux.
 
 OUTPUT="${1:-screenshot.png}"
-PORT="${2:-/dev/ttyACM0}"
+if [ -z "$2" ]; then
+    case "$(uname -s)" in
+        Darwin) PORT="/dev/cu.usbmodem101" ;;
+        *)      PORT="/dev/ttyACM0" ;;
+    esac
+else
+    PORT="$2"
+fi
+
+# Use pio's bundled python if pyserial isn't on the system python.
+PY="python3"
+if ! python3 -c "import serial" 2>/dev/null; then
+    if [ -x "$HOME/.platformio/penv/bin/python" ]; then
+        PY="$HOME/.platformio/penv/bin/python"
+    fi
+fi
 
 TMPRAW=$(mktemp /tmp/screenshot_XXXXXX.raw)
-trap "rm -f '$TMPRAW'" EXIT
+TMPDIMS=$(mktemp /tmp/screenshot_XXXXXX.dims)
+trap "rm -f '$TMPRAW' '$TMPDIMS'" EXIT
 
 echo "Taking screenshot from $PORT..."
 
-python3 - "$PORT" "$TMPRAW" << 'PYEOF'
+"$PY" - "$PORT" "$TMPRAW" "$TMPDIMS" << 'PYEOF'
 import serial, sys
 
-port_path, raw_path = sys.argv[1], sys.argv[2]
+port_path, raw_path, dims_path = sys.argv[1], sys.argv[2], sys.argv[3]
 
 port = serial.Serial(port_path, 115200, timeout=10)
 port.reset_input_buffer()
@@ -40,6 +57,8 @@ while len(data) < raw_size:
 
 with open(raw_path, "wb") as f:
     f.write(data)
+with open(dims_path, "w") as f:
+    f.write(f"{w}x{h}\n")
 
 for _ in range(10):
     line = port.readline().decode("utf-8", errors="replace").strip()
@@ -55,12 +74,13 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-ffmpeg -y -f rawvideo -pixel_format rgb565le -video_size 480x480 \
+DIMS=$(cat "$TMPDIMS")
+ffmpeg -y -f rawvideo -pixel_format rgb565le -video_size "$DIMS" \
     -i "$TMPRAW" -update 1 -frames:v 1 "$OUTPUT" 2>/dev/null || true
 
 
 if [ -f "$OUTPUT" ]; then
-    echo "Saved: $OUTPUT"
+    echo "Saved: $OUTPUT ($DIMS)"
 else
     echo "Error: conversion failed"
     exit 1


### PR DESCRIPTION
Hi @HermannBjorgvin 👋 — really love this project, such a clever little
desk gadget, thanks for building it (and for accepting #6 to open the
door for Mac users). Sharing back the fixes I needed to get it talking
to my Mac end-to-end.

## Summary

Five focused firmware/script changes that fix the macOS host pieces shipped in #6 — verified end-to-end on macOS 15.7.3 against a live Anthropic API token.

Before this PR, on a Mac:

1. The device advertises but **never appears in System Settings → Bluetooth's Nearby Devices list** — macOS Sequoia hides BLE peripherals that don't explicitly advertise the standard HID service UUID.
2. Once visible (manually or via a BLE scanner app like LightBlue), there's **no Connect button** — macOS refuses to surface pairing for a HID claiming to be Apple's Magic Keyboard (Apple's USB vendor `0x05AC` + product `0x820A`).
3. After a successful pair, the **Keyboard Setup Assistant** pops up on every reconnect — the HID descriptor doesn't include an LED output report, and the country code is `0` (Not Supported).
4. Once paired, the **daemon can no longer reach the device** — macOS holds the single available connection slot for the HID link and the daemon's `BleakScanner` never sees the peripheral.

Each fix is independent and minimal.

## Firmware changes (`firmware/src/ble.cpp`)

- **Advertise the standard HID Service UUID `0x1812` in the primary advertising packet.** The custom 128-bit data-service UUID had to move to the scan response — keeping both in the primary packet overflowed the 31-byte BLE advertising limit and macOS's passive scanner doesn't read scan responses.
- **Switch PnP ID to Espressif's BT SIG vendor (`0x02E5`)** instead of Apple's USB vendor + Magic Keyboard product. macOS validates Apple-claimed HIDs and silently denies pairing for impostors.
- **Add the LED output report** (Num/Caps/Scroll Lock) to the HID descriptor. macOS treats a keyboard descriptor without LEDs as "incomplete" and triggers the Keyboard Setup Assistant on every fresh pair.
- **Set HID country code to 33 (US ANSI)** instead of 0 (Not Supported) so macOS can identify the layout without asking the user.
- **Bump `CONFIG_BT_NIMBLE_MAX_CONNECTIONS` to 2 and restart advertising after each accept.** macOS holds one connection for the HID keyboard; the daemon now gets its own slot for the data service in parallel instead of either side starving the other.

## Helper script changes (`screenshot.sh`)

- Auto-pick `/dev/cu.usbmodem101` on macOS vs `/dev/ttyACM0` on Linux instead of hardcoding the Linux path.
- Fall back to PlatformIO's bundled Python at `~/.platformio/penv/bin/python` if pyserial isn't on the system Python (PEP 668 blocks `pip install pyserial` on Homebrew Python by default).
- Pass the actual framebuffer dimensions reported in the `SCREENSHOT_START` header to ffmpeg instead of hardcoding `480x480` — useful preparation for any future board with a different resolution.

## Daemon changes (`daemon/claude_usage_daemon.py`)

- **Log API HTTP status + response body on 4xx/5xx and return None** instead of building a payload with all-zero fields. The previous behavior silently swallowed token-expiry 401s and pushed `{"s":0,"sr":0,"w":0,"wr":0,...}` to the device, so users saw a stuck-at-zero usage display with no clue why.

## Test plan

- [x] AMOLED-2.16 firmware still builds cleanly (`pio run -d firmware -e waveshare_amoled_216`)
- [x] Fresh pair on macOS 15.7.3 — device shows up in System Settings → Bluetooth, Connect button present, Keyboard Setup Assistant skipped on subsequent reconnects (after first cancel)
- [x] BOOT button sends Space over BLE HID after pairing (verified with `python3 -c "print(input())"` while pressing)
- [x] Daemon connects via UUID after one initial scan (the OS-held HID connection no longer blocks the second BLE slot)
- [x] Daemon now logs `API HTTP 401: {"type":"error",...}` on expired tokens instead of silently sending zeroes
- [x] `./screenshot.sh out.png` works on macOS without arguments

## Known follow-up (not in this PR)

The daemon could refresh expired access tokens itself using the `refreshToken` already stored in the same keychain blob (`claudeAiOauth.refreshToken`). For now the user has to `claude /login` again when the token expires; happy to do this in a follow-up if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)