### PR TITLE
docs: link to ccusage-mqtt for the no-ESP32 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ See `tools/README.md` for details.
 - Lucide icon set ([lucide.dev](https://lucide.dev), MIT) for bluetooth and battery UI glyphs.
 - Anthropic brand fonts (Tiempos Text, Styrene B) — see licensing warning below.
 
+## Related projects
+
+- [ccusage-mqtt](https://github.com/george-vice/ccusage-mqtt) — same telemetry surface as a Home Assistant MQTT publisher (no ESP32 required). Mood / burn-rate thresholds are ported verbatim from this firmware's `usage_rate.cpp` so calibration matches frame-for-frame (golden test included).
+
 ## Licensing gray area warning
 
 The software in this repository uses and adheres to the Anthropic brand guidelines and uses the same proprietary fonts that Anthropic has a license for but this software uses without permission as well as using assets from Anthropic such as the copyrighted Clawd mascot so even though the code in this repo is non-proprietary I will not license it myself under a copyleft license since this repo includes proprietary fonts and copyrighted assets. Please be aware of this if you fork or copy the code from this repo. **You have been warned!**


### PR DESCRIPTION
Hey @HermannBjorgvin — really nice project. I built [ccusage-mqtt](https://github.com/george-vice/ccusage-mqtt), an MQTT publisher that mirrors Clawdmeter's telemetry surface for Home Assistant. The `mood`/burn-rate thresholds are ported verbatim from `firmware/src/usage_rate.cpp` with a golden test against the firmware behavior, so calibration stays in sync with whatever Clawdmeter does.

It's aimed at folks who want the dashboard but don't want to put an ESP32 on their desk — they get a Home Assistant device with 15 sensors + a pre-built Lovelace card instead.

Added a one-line entry under a "Related projects" section. Happy to adjust the wording / placement if you'd rather it sit somewhere else, or close this if it doesn't fit. Thanks for the firmware — the calibration ported cleanly. 🙏

- Repo: https://github.com/george-vice/ccusage-mqtt
- Landing: https://george-vice.github.io/ccusage-mqtt/