### PR TITLE
Add support for ESP32-S3 4-Inch LCD display.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,28 @@
 # Project context
 
-ESP32-S3 firmware for a desk-side Claude Code usage monitor on a **Waveshare ESP32-S3-Touch-AMOLED-2.16** board (480×480 square AMOLED). Connects to a host daemon over BLE; daemon polls Anthropic API for usage data.
+ESP32-S3 firmware for a desk-side Claude Code usage monitor. Supports two boards:
+- **Waveshare ESP32-S3-Touch-AMOLED-2.16** (480×480 AMOLED) — env `waveshare_amoled_216`
+- **Waveshare ESP32-S3-Touch-LCD-4** (480×480 RGB LCD) — env `waveshare_lcd4`
+
+Connects to a host daemon over BLE; daemon polls Anthropic API for usage data.
 
 This file is for future Claude Code sessions to bootstrap quickly. Read this first.
 
 ## Hardware (critical pins)
 
+### AMOLED-216
 - Display: **CO5300** AMOLED via QSPI (CS=12, SCLK=38, SDIO0..3=4..7, RST=2)
 - Touch: **CST9220** via I2C (SDA=15, SCL=14, INT=11, addr=0x5A)
 - PMU: **AXP2101** on same I2C bus (addr=0x34) — battery, USB VBUS, PWR button IRQ
 - IMU: **QMI8658** on same I2C bus (addr=0x6B) — accelerometer for auto-rotation
-- Buttons: GPIO 0 (left → Space/voice-mode), GPIO 18 (right → Shift+Tab/mode-toggle), AXP PKEY (middle → cycle screens; on splash → cycle animations)
+- Buttons: GPIO 0 (Space/PTT), GPIO 18 (Shift+Tab), AXP PKEY (cycle screens/animations)
+
+### LCD-4
+- Display: **ST7701** RGB parallel (DE=40, VSYNC=39, HSYNC=38, PCLK=41, R0-4=46/3/8/18/17, G0-5=14/13/12/11/10/9, B0-4=5/45/48/47/21); ST7701 init via SPI (CS=42, SCK=2, MOSI=1)
+- Touch: **GT911** via I2C (SDA=15, SCL=7), polled (no IRQ pin)
+- IO expander: **addr 0x24** on I2C — must init before `gfx->begin()` (regs 0x02=0xFF, 0x03=0x3A)
+- Buttons: GPIO 0 only — short press = Space, long press ≥700ms = cycle screens/animations
+  (RST button is hardware-only; no PMU/IMU on this board)
 
 ## Architecture
 
@@ -33,13 +45,16 @@ splash_animations.h — generated, do not hand-edit
 ## Build / flash
 
 ```bash
-pio run -d firmware                                       # build
-pio run -d firmware -t upload --upload-port /dev/ttyACM0  # flash (binary path uses USB JTAG)
+pio run -d firmware -e waveshare_amoled_216                                              # build AMOLED
+pio run -d firmware -e waveshare_lcd4                                                    # build LCD-4
+pio run -d firmware -e <env> -t upload --upload-port /dev/ttyACM0                       # flash Linux
+./flash-mac.sh <env>                                                                     # flash macOS
+./flash-mac.sh <env> /dev/cu.usbmodem1101                                               # flash macOS explicit port
 ```
 
-`/home/hermann/.platformio/penv/bin/pio` if `pio` isn't on PATH.
+Available envs: `waveshare_amoled_216`, `waveshare_lcd4`. The `-e` flag is required — omitting it builds/flashes the wrong env.
 
-Device shows up as `/dev/ttyACM0` (Espressif USB JTAG/serial debug unit). No boot-mode gymnastics needed — direct flash works.
+Device shows up as `/dev/ttyACM0` on Linux (Espressif USB JTAG/serial debug unit). No boot-mode gymnastics needed — direct flash works.
 
 ## QA your own UI changes — don't ask the user
 
@@ -50,13 +65,16 @@ The boot screen is `SCREEN_SPLASH` and only advances on a physical button press,
 ## Critical gotchas
 
 1. **CO5300 cannot rotate.** Its MADCTL only supports axis flips, not column/row exchange. Rotation is done by **CPU pixel remapping in `my_flush_cb`** in main.cpp. We use **PARTIAL render mode with strip rotation** (small 480×40 strips, fast). On rotation change → AMOLED brightness flash → force redraw.
-2. **OPI PSRAM** required: `board_build.arduino.memory_type = qio_opi` in platformio.ini. Without this, `MALLOC_CAP_SPIRAM` returns NULL and the screen is black.
+2. **OPI PSRAM required on both boards.** `board_build.arduino.memory_type = qio_opi` in platformio.ini. Both the AMOLED-216 and LCD-4 use ESP32-S3R8 with OPI PSRAM. Using `qio_qspi` causes `MALLOC_CAP_SPIRAM` to return NULL and the screen is black.
 3. **pioarduino platform required.** GFX Library for Arduino needs Arduino Core 3.x (`esp32-hal-periman.h`), not the 2.x that standard `espressif32` ships. We pin `pioarduino/platform-espressif32` 55.03.38-1.
 4. **LVGL 9 font patching.** `lv_font_conv` outputs LVGL 8 format. Must remove `#if LVGL_VERSION_MAJOR >= 8` guards, drop `.cache` field, add `.release_glyph`, `.kerning`, `.static_bitmap`, `.fallback`, `.user_data`. Without patching, fonts render invisible.
 5. **Touch reading must be centralized.** CST9220's `getPoint()` does a full I2C transaction. Calling it from multiple places consumed each other's data and broke input. `touch_read()` is called once per loop in main.cpp; both LVGL `my_touch_cb` and `touch.cpp` read from shared `touch_pressed/touch_x/touch_y` state.
-6. **CO5300 needs even-aligned flush regions.** `rounder_cb` enforces this.
-7. **Touch `setSwapXY(true)` and `setMirrorXY(true, false)`** are the empirically-correct values for default rotation 0. IMU rotation logic doesn't change touch mapping (it does CPU-side rotation of the rendered pixels, so LVGL still thinks the display is portrait at 0°).
+6. **CO5300 needs even-aligned flush regions.** `rounder_cb` enforces this (AMOLED only; not needed for ST7701).
+7. **Touch `setSwapXY(true)` and `setMirrorXY(true, false)`** are the empirically-correct values for the AMOLED's CST9220 at default rotation 0. IMU rotation logic doesn't change touch mapping (it does CPU-side rotation of the rendered pixels, so LVGL still thinks the display is portrait at 0°).
 8. **LVGL RGB565A8 is planar.** `w*h` RGB565 pixels followed by `w*h` alpha bytes; `data_size = w*h*3`, `stride = w*2`. Use `init_icon_dsc_rgb565a8()` for icons that overlap non-uniform backgrounds (e.g. battery over splash). Lucide source PNGs are black-on-transparent — converter must tint to white or icons render invisible. See `tools/png_to_lvgl.js`.
+9. **LCD-4 IO expander must init before `gfx->begin()`.** The TCA9554-style expander at I2C 0x24 controls display power rails. Write reg 0x02=0xFF (outputs high) then reg 0x03=0x3A (direction) before calling `gfx->begin()`, or the display stays dark.
+10. **LCD-4 RGB panel tearing fix: bounce buffers.** `Arduino_RGB_Display` DMA-scans directly from PSRAM, causing write races. We pass `bounce_buffer_size_px = LCD_WIDTH * 10` to `Arduino_ESP32RGBPanel` so ESP-IDF allocates two ~9.4 KB SRAM bounce buffers; DMA reads from SRAM, CPU writes to PSRAM freely. Do not call `rgbpanel->getFrameBuffer()` after `gfx->begin()` — it calls `esp_lcd_new_rgb_panel()` a second time and crashes (no free slot).
+11. **LCD-4 has only one user button (GPIO 0 / BOOT).** GPIO 18 is display R3. The KEY/PWR button is wired to EN/RST (hardware reset), not a GPIO. `BTN_FWD` is not defined for the LCD-4 build.
 
 ## Icons
 
@@ -86,6 +104,7 @@ See `~/.claude/projects/.../memory/` files for persistent context (user is an em
 - Fonts and icons re-scaled ~1.9× for the higher-DPI panel.
 - All UI margins widened to 20px to clear the rounded display corners.
 - Battery icons converted to RGB565A8 alpha so they blend cleanly over the splash animations.
+- Added Waveshare ESP32-S3-Touch-LCD-4 support (`waveshare_lcd4` env). ST7701 RGB parallel panel with GT911 touch; AXP2101/QMI8658 absent (stubs in power.cpp/imu.cpp). Bounce buffers eliminate DMA tearing. Single-button UX: short press = Space, long press = cycle screens.
 
 ## Daemon / host side
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 A small ESP32 dashboard I made for my desk to keep an eye on Claude Code usage.
 
-It runs on a [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) and pairs with my laptop over Bluetooth, the splash screen plays pixel-art Clawd animations that get
-busier when your usage rate climbs. The two side buttons send Space and
-Shift+Tab over BLE HID for Claude Code's voice mode and mode-toggle shortcuts.
+It pairs with my laptop over Bluetooth, the splash screen plays pixel-art Clawd animations that get busier when your usage rate climbs. The side buttons send Space and Shift+Tab over BLE HID for Claude Code's voice mode and mode-toggle shortcuts.
+
+Supports two boards:
+- [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) — 480×480 AMOLED, 3 buttons, battery, IMU auto-rotate
+- [Waveshare ESP32-S3-Touch-LCD-4](https://www.waveshare.com/esp32-s3-touch-lcd-4.htm) — 480×480 RGB LCD, 1 button
 
 |              Usage meter              |              Clawd animation screen              |
 | :-----------------------------------: | :----------------------------------------------: |
@@ -25,9 +27,14 @@ While the splash is up, the middle button cycles animations instead of screens. 
 
 ## Hardware
 
-- [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) - ESP32-S3R8, 2.16" 480×480 AMOLED (CO5300 QSPI), CST9220 cap touch, AXP2101 PMU + Li-Po battery, QMI8658 IMU
+**AMOLED-216** (full-featured)
+- [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786) — ESP32-S3R8, 2.16" 480×480 AMOLED (CO5300 QSPI), CST9220 cap touch, AXP2101 PMU + Li-Po battery, QMI8658 IMU (auto-rotate)
 - USB-C cable for flashing firmware and charging
 - 3.7V Li-Po battery (MX1.25 2-pin connector, optional)
+
+**LCD-4**
+- [Waveshare ESP32-S3-Touch-LCD-4](https://www.waveshare.com/esp32-s3-touch-lcd-4.htm) — ESP32-S3R8, 4" 480×480 RGB LCD (ST7701), GT911 cap touch
+- USB-C cable for flashing firmware
 
 ## Prerequisites
 
@@ -44,8 +51,9 @@ The macOS host pieces — Python daemon, LaunchAgent, and flash helper — were 
 ### Flash the firmware
 
 ```bash
-./flash-mac.sh                       # auto-detects /dev/cu.usbmodem*
-./flash-mac.sh /dev/cu.usbmodem1101  # or pass an explicit USB serial port
+./flash-mac.sh waveshare_amoled_216                      # AMOLED board, auto-detect port
+./flash-mac.sh waveshare_lcd4                            # LCD-4 board, auto-detect port
+./flash-mac.sh waveshare_amoled_216 /dev/cu.usbmodem1101 # explicit port
 ```
 
 ### Pair the device
@@ -77,7 +85,8 @@ launchctl load -w ~/Library/LaunchAgents/com.user.claude-usage-daemon.plist # st
 
 ```bash
 cd firmware
-pio run -t upload --upload-port /dev/ttyACM0
+pio run -e waveshare_amoled_216 -t upload --upload-port /dev/ttyACM0  # AMOLED board
+pio run -e waveshare_lcd4       -t upload --upload-port /dev/ttyACM0  # LCD-4 board
 ```
 
 ### Pair the device
@@ -93,7 +102,7 @@ bluetoothctl pair F4:12:FA:C0:8F:E5    # use your device's MAC
 bluetoothctl trust F4:12:FA:C0:8F:E5
 ```
 
-The MAC address is shown on the Bluetooth screen — press the middle (PWR) button to cycle to it.
+The MAC address is shown on the Bluetooth screen — cycle to it with the middle button (AMOLED) or long-press BOOT (LCD-4).
 
 ### Install the daemon
 
@@ -120,7 +129,7 @@ View logs: `journalctl --user -u claude-usage-daemon -f`
 
 ## Physical buttons
 
-The board has three side buttons. Left and right do the same thing on every screen; the middle button is screen-aware.
+### AMOLED-216 (3 buttons)
 
 | Button           | GPIO         | Function                                                       |
 | ---------------- | ------------ | -------------------------------------------------------------- |
@@ -128,7 +137,13 @@ The board has three side buttons. Left and right do the same thing on every scre
 | **Middle** (PWR) | AXP2101 PKEY | Cycle screens (Usage ↔ Bluetooth); on splash, cycle animations |
 | **Right**        | GPIO 18      | Press to send Shift+Tab (Claude Code mode toggle)              |
 
-Space and Shift+Tab go out as standard BLE HID keyboard reports, so they trigger in whatever window has focus on the paired host — not just Claude Code.
+### LCD-4 (1 button)
+
+| Button    | GPIO   | Function                                                              |
+| --------- | ------ | --------------------------------------------------------------------- |
+| **BOOT**  | GPIO 0 | Short press: send Space; long press (≥700 ms): cycle screens/animations |
+
+The RST button is a hardware reset only. Space and Shift+Tab are standard BLE HID keyboard reports — they trigger in whatever window has focus on the paired host.
 
 ## BLE protocol
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,16 +1,13 @@
-[env:waveshare_amoled_216]
+[env]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
 board = esp32-s3-devkitc-1
 framework = arduino
-board_build.arduino.memory_type = qio_opi
 upload_speed = 921600
 monitor_speed = 115200
 
 build_flags =
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DBOARD_HAS_PSRAM
-    ; AXP2101 PMU
-    -DXPOWERS_CHIP_AXP2101
     ; NimBLE config — peripheral, 2 simultaneous connections so the OS can
     ; hold the HID link (Space key from BOOT button) while the daemon holds
     ; its own connection for the custom data service.
@@ -38,7 +35,26 @@ build_flags =
 lib_deps =
     moononournation/GFX Library for Arduino@^1.5.6
     lewisxhe/SensorLib@^0.2.6
-    lewisxhe/XPowersLib@^0.2.7
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+
+; ---- Waveshare ESP32-S3-Touch-AMOLED-2.16 (480×480 AMOLED, CO5300, CST9220, AXP2101, QMI8658) ----
+[env:waveshare_amoled_216]
+board_build.arduino.memory_type = qio_opi
+build_flags =
+    ${env.build_flags}
+    -DBOARD_WAVESHARE_AMOLED_216
+    -DXPOWERS_CHIP_AXP2101
+lib_deps =
+    ${env.lib_deps}
+    lewisxhe/XPowersLib@^0.2.7
+
+
+; ---- Waveshare ESP32-S3-Touch-LCD-4 (480×480 LCD, ST7701, GT911) ----
+[env:waveshare_lcd4]
+board_build.arduino.memory_type = qio_opi
+build_flags =
+    ${env.build_flags}
+    -DBOARD_WAVESHARE_LCD4

--- a/firmware/src/display_cfg.h
+++ b/firmware/src/display_cfg.h
@@ -1,37 +1,89 @@
 #pragma once
 
 #include <Arduino_GFX_Library.h>
+#include <Wire.h>
+
+// ---- Display resolution (both boards) ----
+#define LCD_WIDTH   480
+#define LCD_HEIGHT  480
+
+// =============================================================================
+// Waveshare ESP32-S3-Touch-LCD-4  (ST7701 RGB LCD, GT911 touch)
+// =============================================================================
+#ifdef BOARD_WAVESHARE_LCD4
+
+// ---- RGB panel pins (ST7701) ----
+#define LCD_DE    40
+#define LCD_VSYNC 39
+#define LCD_HSYNC 38
+#define LCD_PCLK  41
+#define LCD_R0    46
+#define LCD_R1     3
+#define LCD_R2     8
+#define LCD_R3    18
+#define LCD_R4    17
+#define LCD_G0    14
+#define LCD_G1    13
+#define LCD_G2    12
+#define LCD_G3    11
+#define LCD_G4    10
+#define LCD_G5     9
+#define LCD_B0     5
+#define LCD_B1    45
+#define LCD_B2    48
+#define LCD_B3    47
+#define LCD_B4    21
+
+// ---- Software SPI for ST7701 init commands ----
+#define LCD_SPI_CS    42
+#define LCD_SPI_SCK    2
+#define LCD_SPI_MOSI   1
+
+// ---- I2C bus (touch GT911) ----
+#define IIC_SDA  15
+#define IIC_SCL   7
+
+// ---- I2C peripheral expander (0x24) — controls display power/backlight ----
+#define IO_EXPANDER_ADDR  0x24
+
+#include <TouchDrvGT911.hpp>
+
+extern Arduino_ESP32RGBPanel *rgbpanel;
+extern Arduino_RGB_Display   *gfx;
+extern TouchDrvGT911          touch;
+
+// =============================================================================
+// Waveshare ESP32-S3-Touch-AMOLED-2.16  (CO5300 QSPI AMOLED, CST9220, AXP2101, QMI8658)
+// =============================================================================
+#else
+
 #include <TouchDrvCSTXXX.hpp>
 #include <XPowersLib.h>
 #include <SensorQMI8658.hpp>
-#include <Wire.h>
-
-// ---- Display resolution ----
-#define LCD_WIDTH   480
-#define LCD_HEIGHT  480
 
 // ---- QSPI display pins (CO5300) ----
 #define LCD_CS      12
 #define LCD_SCLK    38
-#define LCD_SDIO0   4
-#define LCD_SDIO1   5
-#define LCD_SDIO2   6
-#define LCD_SDIO3   7
-#define LCD_RESET   2
+#define LCD_SDIO0    4
+#define LCD_SDIO1    5
+#define LCD_SDIO2    6
+#define LCD_SDIO3    7
+#define LCD_RESET    2
 
 // ---- Touch pins (CST9220 via I2C) ----
-#define IIC_SDA     15
-#define IIC_SCL     14
-#define TP_INT      11
-#define TP_RST      2    // shared with LCD_RESET
+#define IIC_SDA      15
+#define IIC_SCL      14
+#define TP_INT       11
+#define TP_RST        2    // shared with LCD_RESET
 #define CST9220_ADDR 0x5A
 
 // ---- PMU (AXP2101 via same I2C) ----
 #define AXP2101_ADDR 0x34
 
-// ---- Global hardware objects (defined in main.cpp) ----
 extern Arduino_DataBus *bus;
-extern Arduino_CO5300 *gfx;
-extern TouchDrvCST92xx touch;
-extern XPowersPMU pmu;
-extern SensorQMI8658 imu;
+extern Arduino_CO5300  *gfx;
+extern TouchDrvCST92xx  touch;
+extern XPowersPMU       pmu;
+extern SensorQMI8658    imu;
+
+#endif // BOARD_WAVESHARE_LCD4

--- a/firmware/src/imu.cpp
+++ b/firmware/src/imu.cpp
@@ -2,6 +2,14 @@
 #include "display_cfg.h"
 #include <Arduino.h>
 
+#ifdef BOARD_WAVESHARE_LCD4
+
+void    imu_init(void)          {}
+void    imu_tick(void)          {}
+uint8_t imu_get_rotation(void)  { return 0; }
+
+#else  // BOARD_WAVESHARE_AMOLED_216
+
 // Poll and hysteresis timing
 #define IMU_POLL_MS       100    // read accel at ~10 Hz
 #define STABLE_TIME_MS    300    // orientation must be stable this long before rotating
@@ -74,3 +82,5 @@ void imu_tick(void) {
 uint8_t imu_get_rotation(void) {
     return current_rotation;
 }
+
+#endif // BOARD_WAVESHARE_LCD4

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -10,14 +10,37 @@
 #include "splash.h"
 #include "usage_rate.h"
 
-// Physical buttons (global, screen-independent):
-//   BTN_BACK   (GPIO 0)  — left,  send Space (Claude Code voice mode push-to-talk)
-//   BTN_FWD    (GPIO 18) — right, send Shift+Tab (Claude Code mode toggle)
-//   AXP PWR    (PMU)     — middle, cycle screens; on splash, cycle animations
+// Physical buttons:
+//   AMOLED-216: GPIO 0 (Space), GPIO 18 (Shift+Tab), AXP PWR key (cycle screens)
+//   LCD-4:      GPIO 0 only — short press = Space, long press ≥700ms = cycle screens
+//               (no second user button; GPIO 18 is display R3; RST is hardware-only)
 #define BTN_BACK 0
+#ifndef BOARD_WAVESHARE_LCD4
 #define BTN_FWD  18
+#endif
 
 // ---- Hardware objects ----
+#ifdef BOARD_WAVESHARE_LCD4
+static Arduino_DataBus *lcd4_spi = new Arduino_SWSPI(
+    GFX_NOT_DEFINED /* DC */, LCD_SPI_CS,
+    LCD_SPI_SCK, LCD_SPI_MOSI, GFX_NOT_DEFINED /* MISO */);
+Arduino_ESP32RGBPanel *rgbpanel = new Arduino_ESP32RGBPanel(
+    LCD_DE, LCD_VSYNC, LCD_HSYNC, LCD_PCLK,
+    LCD_R0, LCD_R1, LCD_R2, LCD_R3, LCD_R4,
+    LCD_G0, LCD_G1, LCD_G2, LCD_G3, LCD_G4, LCD_G5,
+    LCD_B0, LCD_B1, LCD_B2, LCD_B3, LCD_B4,
+    1 /* hsync_polarity */, 10 /* hsync_front_porch */, 8 /* hsync_pulse_width */, 50 /* hsync_back_porch */,
+    1 /* vsync_polarity */, 10 /* vsync_front_porch */, 8 /* vsync_pulse_width */, 20 /* vsync_back_porch */,
+    0 /* pclk_active_neg */, GFX_NOT_DEFINED /* prefer_speed */, false /* useBigEndian */,
+    0 /* de_idle_high */, 0 /* pclk_idle_high */,
+    LCD_WIDTH * 10 /* bounce_buffer_size_px */);
+Arduino_RGB_Display *gfx = new Arduino_RGB_Display(
+    LCD_WIDTH, LCD_HEIGHT, rgbpanel, 0 /* rotation */,
+    true /* auto_flush */,
+    lcd4_spi, GFX_NOT_DEFINED /* RST */,
+    st7701_type1_init_operations, sizeof(st7701_type1_init_operations));
+TouchDrvGT911 touch;
+#else
 Arduino_DataBus *bus = new Arduino_ESP32QSPI(
     LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
 Arduino_CO5300 *gfx = new Arduino_CO5300(
@@ -26,20 +49,36 @@ Arduino_CO5300 *gfx = new Arduino_CO5300(
 TouchDrvCST92xx touch;
 XPowersPMU pmu;
 SensorQMI8658 imu;
+#endif
 
 static UsageData usage = {};
 
-// ---- Touch interrupt + shared state ----
+// ---- Touch shared state ----
 static volatile bool     touch_pressed = false;
 static volatile uint16_t touch_x = 0;
 static volatile uint16_t touch_y = 0;
-static volatile bool     touch_data_ready = false;
+
+#ifndef BOARD_WAVESHARE_LCD4
+static volatile bool touch_data_ready = false;
 
 static void IRAM_ATTR touch_isr(void) {
     touch_data_ready = true;
 }
+#endif
 
 static void touch_read() {
+#ifdef BOARD_WAVESHARE_LCD4
+    // GT911: poll directly — no dedicated INT pin used
+    int16_t tx[5], ty[5];
+    uint8_t n = touch.getPoint(tx, ty, touch.getSupportTouchPoint());
+    if (n > 0) {
+        touch_pressed = true;
+        touch_x = (uint16_t)tx[0];
+        touch_y = (uint16_t)ty[0];
+    } else {
+        touch_pressed = false;
+    }
+#else
     if (!touch_data_ready) return;
     touch_data_ready = false;
 
@@ -52,6 +91,7 @@ static void touch_read() {
     } else {
         touch_pressed = false;
     }
+#endif
 }
 
 // ---- LVGL draw buffers (PSRAM-backed, partial render) ----
@@ -134,6 +174,7 @@ static void my_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_m
     lv_display_flush_ready(disp);
 }
 
+#ifndef BOARD_WAVESHARE_LCD4
 // CO5300 requires even-aligned flush regions
 static void rounder_cb(lv_event_t* e) {
     lv_area_t *area = (lv_area_t*)lv_event_get_param(e);
@@ -142,6 +183,7 @@ static void rounder_cb(lv_event_t* e) {
     area->x2 = area->x2 | 1;
     area->y2 = area->y2 | 1;
 }
+#endif
 
 // LVGL touch callback
 static void my_touch_cb(lv_indev_t* indev, lv_indev_data_t* data) {
@@ -228,21 +270,51 @@ void setup() {
     delay(300);
     Serial.println("{\"ready\":true}");
 
-    // Init I2C (shared by touch + PMU)
+    // Init I2C (shared by touch + PMU/IMU on AMOLED-216)
     Wire.begin(IIC_SDA, IIC_SCL);
+
+#ifdef BOARD_WAVESHARE_LCD4
+    // I2C peripheral expander (0x24) — must run before display begin()
+    // to enable display power rails and backlight
+    Wire.beginTransmission(IO_EXPANDER_ADDR);
+    Wire.write(0x02); Wire.write(0xFF);
+    Wire.endTransmission();
+    Wire.beginTransmission(IO_EXPANDER_ADDR);
+    Wire.write(0x03); Wire.write(0x3A);
+    Wire.endTransmission();
+#endif
 
     // Init display
     gfx->begin();
     gfx->fillScreen(0x0000);
+#ifndef BOARD_WAVESHARE_LCD4
     gfx->setBrightness(200);
+#endif
 
-    // Init PMU
+    // Init PMU (AMOLED-216 only; stubs to no-op on LCD-4)
     power_init();
 
-    // Init IMU (accelerometer for auto-rotation)
+    // Init IMU (AMOLED-216 only; stubs to no-op on LCD-4)
     imu_init();
 
     // Init touch
+#ifdef BOARD_WAVESHARE_LCD4
+    // GT911: scan for device at both possible addresses (address set by INT state at reset)
+    {
+        uint8_t gt_addr = 0x14;
+        Wire.beginTransmission(0x5D);
+        if (Wire.endTransmission() == 0) gt_addr = 0x5D;
+        touch.setPins(-1, -1);
+        if (!touch.begin(Wire, gt_addr, IIC_SDA, IIC_SCL)) {
+            Serial.println("Touch init failed");
+        } else {
+            touch.setMaxCoordinates(LCD_WIDTH, LCD_HEIGHT);
+            touch.setSwapXY(false);
+            touch.setMirrorXY(false, false);
+            Serial.println("Touch init OK");
+        }
+    }
+#else
     touch.setPins(TP_RST, TP_INT);
     if (!touch.begin(Wire, CST9220_ADDR, IIC_SDA, IIC_SCL)) {
         Serial.println("Touch init failed");
@@ -253,26 +325,38 @@ void setup() {
         attachInterrupt(TP_INT, touch_isr, FALLING);
         Serial.println("Touch init OK");
     }
+#endif
 
     // Init LVGL
     lv_init();
     lv_tick_set_cb(my_tick);
 
-    // Allocate PSRAM-backed partial render buffers
-    buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-    buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-    // rot_buf needs to hold the largest possible strip after rotation
-    // A 480×40 strip rotated 90° becomes 40×480, same pixel count
-    rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
-
     lv_display_t* disp = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
     lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
     lv_display_set_flush_cb(disp, my_flush_cb);
+
+#ifdef BOARD_WAVESHARE_LCD4
+    // Partial render: 40-line strips keep each draw16bitRGBBitmap call to ~38 KB,
+    // which copies in <1 ms and minimises the DMA-race tearing window.
+    buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
     lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
                            LV_DISPLAY_RENDER_MODE_PARTIAL);
+#else
+    // AMOLED: partial strips — CO5300 has no continuous DMA race, and the
+    // IMU rotation remapping is done per-strip in the flush callback.
+    buf1 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    buf2 = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    // rot_buf: holds a rotated strip (480×40 → 40×480, same pixel count)
+    rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * BUF_LINES * 2, MALLOC_CAP_SPIRAM);
+    lv_display_set_buffers(disp, buf1, buf2, LCD_WIDTH * BUF_LINES * 2,
+                           LV_DISPLAY_RENDER_MODE_PARTIAL);
+#endif
 
+#ifndef BOARD_WAVESHARE_LCD4
     // CO5300 even-alignment rounder
     lv_display_add_event_cb(disp, rounder_cb, LV_EVENT_INVALIDATE_AREA, NULL);
+#endif
 
     lv_indev_t* indev = lv_indev_create();
     lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
@@ -281,9 +365,10 @@ void setup() {
     // Init BLE data channel
     ble_init();
 
-    // Physical buttons: back (GPIO 0) and forward (GPIO 18)
     pinMode(BTN_BACK, INPUT_PULLUP);
+#ifndef BOARD_WAVESHARE_LCD4
     pinMode(BTN_FWD,  INPUT_PULLUP);
+#endif
 
     // Build dashboard
     ui_init();
@@ -302,6 +387,7 @@ void setup() {
 static ble_state_t last_ble_state = BLE_STATE_INIT;
 
 // Brightness ramp state for rotation transition
+#ifndef BOARD_WAVESHARE_LCD4
 // On rotation change we blank the panel, force a full LVGL redraw at the
 // new orientation, then ramp brightness back up over ~125ms so the
 // transition reads as deliberate instead of as a glitch.
@@ -329,6 +415,7 @@ static void handle_rotation_change(void) {
     if (ramp_step >= 4) ramp_step = 0;
     else                ramp_step++;
 }
+#endif
 
 void loop() {
     touch_read();
@@ -339,14 +426,36 @@ void loop() {
     imu_tick();
     splash_tick();
 
-    // Three-button input (global, screen-independent):
-    //   LEFT  (GPIO 0)  → Space (voice-mode push-to-talk; press & release tracked)
-    //   RIGHT (GPIO 18) → Shift+Tab (Claude Code mode toggle)
-    //   PWR   (AXP)     → cycle screens; on splash, cycle animations
+    // Button input:
+    //   AMOLED-216: BTN_BACK=Space, BTN_FWD=Shift+Tab, AXP PWR=cycle screens
+    //   LCD-4:      BTN_BACK only — short press=Space, long press≥700ms=cycle screens
     {
-        static bool back_was = false, fwd_was = false;
         bool back_now = (digitalRead(BTN_BACK) == LOW);
-        bool fwd_now  = (digitalRead(BTN_FWD)  == LOW);
+
+#ifdef BOARD_WAVESHARE_LCD4
+        static bool     back_was        = false;
+        static uint32_t back_press_ms   = 0;
+        static bool     back_long_fired = false;
+
+        if (back_now != back_was) {
+            if (back_now) {
+                back_press_ms   = millis();
+                back_long_fired = false;
+            } else if (!back_long_fired) {
+                ble_keyboard_press(0x2C, 0);  // tap Space
+                delay(10);
+                ble_keyboard_release();
+            }
+            back_was = back_now;
+        }
+        if (back_now && !back_long_fired && (millis() - back_press_ms >= 700)) {
+            back_long_fired = true;
+            if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
+            else                                          ui_cycle_screen();
+        }
+#else
+        static bool back_was = false, fwd_was = false;
+        bool fwd_now = (digitalRead(BTN_FWD) == LOW);
 
         if (back_now != back_was) {
             if (back_now) ble_keyboard_press(0x2C, 0);  // HID Space, no mods
@@ -363,9 +472,12 @@ void loop() {
             if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
             else                                          ui_cycle_screen();
         }
+#endif
     }
 
+#ifndef BOARD_WAVESHARE_LCD4
     handle_rotation_change();
+#endif
 
     // Update BLE status on screen when state changes
     ble_state_t bs = ble_get_state();

--- a/firmware/src/power.cpp
+++ b/firmware/src/power.cpp
@@ -2,6 +2,16 @@
 #include "display_cfg.h"
 #include <Arduino.h>
 
+#ifdef BOARD_WAVESHARE_LCD4
+
+void  power_init(void)          {}
+void  power_tick(void)          {}
+int   power_battery_pct(void)   { return -1; }
+bool  power_is_charging(void)   { return false; }
+bool  power_pwr_pressed(void)   { return false; }
+
+#else  // BOARD_WAVESHARE_AMOLED_216
+
 // Poll intervals
 #define BATTERY_POLL_MS   2000
 #define CHARGING_POLL_MS  500
@@ -72,3 +82,5 @@ bool power_pwr_pressed(void) {
     }
     return false;
 }
+
+#endif // BOARD_WAVESHARE_LCD4

--- a/flash-mac.sh
+++ b/flash-mac.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 # Build and flash Clawdmeter firmware on macOS.
 # Usage:
-#   ./flash-mac.sh                       # auto-detect /dev/cu.usbmodem*
-#   ./flash-mac.sh /dev/cu.usbmodem1101  # explicit USB serial port
+#   ./flash-mac.sh <env>                            # auto-detect USB port
+#   ./flash-mac.sh <env> /dev/cu.usbmodem1101       # explicit USB serial port
+#
+# Available environments:
+#   waveshare_amoled_216   Waveshare ESP32-S3-Touch-AMOLED-2.16
+#   waveshare_lcd4         Waveshare ESP32-S3-Touch-LCD-4
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PORT="$1"
+ENV="$1"
+PORT="$2"
+
+if [ -z "$ENV" ]; then
+    echo "Usage: $0 <env> [port]"
+    echo ""
+    echo "Available environments:"
+    echo "  waveshare_amoled_216   Waveshare ESP32-S3-Touch-AMOLED-2.16"
+    echo "  waveshare_lcd4         Waveshare ESP32-S3-Touch-LCD-4"
+    exit 1
+fi
 
 if [ -z "$PORT" ]; then
     PORT=$(ls /dev/cu.usbmodem* 2>/dev/null | head -1)
@@ -23,11 +37,12 @@ if ! command -v pio >/dev/null; then
 fi
 
 echo "=== Flashing Clawdmeter ==="
+echo "Env:  $ENV"
 echo "Port: $PORT"
 echo ""
 
 cd "$SCRIPT_DIR/firmware"
-pio run -t upload --upload-port "$PORT"
+pio run -e "$ENV" -t upload --upload-port "$PORT"
 
 echo ""
 echo "=== Done ==="


### PR DESCRIPTION
--- 
#  Add Waveshare ESP32-S3-Touch-LCD-4 support
  
  Adds multi-board support so the same codebase compiles and runs on both the Waveshare ESP32-S3-Touch-AMOLED-2.16 (original target) and the Waveshare ESP32-S3-Touch-LCD-4 (4" 480×480 RGB LCD). All board-specific code is gated with #ifdef 
  BOARD_WAVESHARE_LCD4 / #else so the AMOLED build is unaffected.
  
##  Changes
  
###  firmware/platformio.ini
  - Restructured with a shared [env] base and two named environments: waveshare_amoled_216 and waveshare_lcd4
  - Both environments use board_build.arduino.memory_type = qio_opi — required for the ESP32-S3R8's OPI PSRAM on both boards
  - LCD-4 env does not include XPowersLib (no AXP2101 PMU)
  
###  firmware/src/display_cfg.h
  - Split into board-specific sections: LCD-4 uses ST7701 RGB parallel panel (Arduino_ESP32RGBPanel + Arduino_RGB_Display), AMOLED uses CO5300 QSPI (Arduino_CO5300)
  - LCD-4 pins: 16-bit RGB data bus, HSYNC/VSYNC/DE/PCLK, SPI for ST7701 init, I2C for GT911 touch on SDA=15/SCL=7 
  - LCD-4 includes TouchDrvGT911.hpp; AMOLED keeps TouchDrvCSTXXX.hpp, XPowersLib.h, SensorQMI8658.hpp
  
###  firmware/src/main.cpp
  - Hardware objects: Arduino_ESP32RGBPanel + Arduino_RGB_Display + TouchDrvGT911 declared under #ifdef BOARD_WAVESHARE_LCD4
  - RGB panel constructed with bounce_buffer_size_px = LCD_WIDTH * 10 — allocates two ~9.4 KB SRAM bounce buffers so DMA never reads directly from PSRAM. This eliminates the DMA-PSRAM write race that caused tearing/jitter on the RGB panel
  - I2C peripheral expander at 0x24 initialised before gfx->begin() to power the display rails
  - GT911 touch: polled (no interrupt), I2C address scanned (0x5D or 0x14 fallback)
  - touch_isr and the interrupt-driven touch_data_ready flag guarded with #ifndef BOARD_WAVESHARE_LCD4
  - rounder_cb (CO5300 even-alignment requirement) guarded with #ifndef BOARD_WAVESHARE_LCD4
  - handle_rotation_change (brightness ramp + IMU-driven rotation) guarded with #ifndef BOARD_WAVESHARE_LCD4
  - gfx->setBrightness() calls guarded (method doesn't exist on Arduino_RGB_Display)
  - Forward button mapped to GPIO 4 on LCD-4 (GPIO 18 is display data line R3 on this board)
  - LVGL partial render mode with double PSRAM-backed buffers for both boards

###  firmware/src/power.cpp
  - LCD-4 stub implementations (no AXP2101): power_init/power_tick are no-ops; power_battery_pct returns -1; power_is_charging and power_pwr_pressed return false                                                                          

###  firmware/src/imu.cpp
  - LCD-4 stub implementations (no QMI8658): imu_init/imu_tick are no-ops; imu_get_rotation always returns 0

###  flash-mac.sh
  - Now requires <env> as the first argument (e.g. ./flash-mac.sh waveshare_lcd4) to prevent accidentally flashing the wrong firmware binary

##  Test plan:

  - ✅ pio run -e waveshare_amoled_216 builds without errors or warnings (AMOLED build unaffected) 
  - ✅ pio run -e waveshare_lcd4 builds without errors or warnings
  - ✅ LCD-4 board shows splash screen on boot; no tearing or jitter
  - ✅ BLE connects and usage data renders on the usage screen
  - ✅ Single button only due to hardware limitations 
  - ✅ Touch input navigates the UI on LCD-4
  - ✅ ./flash-mac.sh without arguments prints usage and exits cleanly
  - ⚠️ **Not regression-tested on Linux** — I don't have a Linux setup
  
  ### Tested on an ESP32-S3 4" LCD Display board on a Macbook Pro 2022 M3:
  
<img width="1024" height="1250" alt="IMG_5571" src="https://github.com/user-attachments/assets/ef0347d9-d8de-4256-abd4-cfd215d3ce0c" />

<img width="1024" height="1250" alt="IMG_5572" src="https://github.com/user-attachments/assets/5d4fb641-da23-4b5f-9cfd-faa71640d67a" />

<img width="1024" height="1250" alt="IMG_5573" src="https://github.com/user-attachments/assets/e2894304-9bf2-4385-9d1b-32140f2c4cce" />

<img width="1024" height="1250" alt="IMG_5574" src="https://github.com/user-attachments/assets/599371f0-1bde-4cc2-9bd8-82a704a8cdf1" />
