### PR TITLE
Keep BLE UI state at CONNECTED while re-advertising

### DIFF
--- a/firmware/src/ble.cpp
+++ b/firmware/src/ble.cpp
@@ -87,8 +87,16 @@ static void start_advertising() {
     adv->setScanResponseData(scanResp);
     adv->enableScanResponse(true);
     bool ok = adv->start();
-    state = BLE_STATE_ADVERTISING;
-    Serial.printf("BLE: advertising start=%s\n", ok ? "OK" : "FAILED");
+    // Only reflect ADVERTISING in the UI state when no client is connected.
+    // With MAX_CONNECTIONS=2, onConnect re-advertises to fill the second slot;
+    // without this guard the UI would flip CONNECTED → ADVERTISING on every
+    // first connect and never come back until a second client arrived.
+    if (!server || server->getConnectedCount() == 0) {
+        state = BLE_STATE_ADVERTISING;
+    }
+    Serial.printf("BLE: advertising start=%s (connected=%u)\n",
+        ok ? "OK" : "FAILED",
+        server ? (unsigned)server->getConnectedCount() : 0);
 }
 
 class ServerCallbacks : public NimBLEServerCallbacks {


### PR DESCRIPTION
## Summary
After #18 enabled `MAX_CONNECTIONS=2`, `onConnect` sets `need_advertise=true` so a second central (the host daemon) can grab a slot alongside the OS-held HID link. `start_advertising()` then unconditionally set `state = BLE_STATE_ADVERTISING`, so with one connected client the UI flipped to "Advertising…" on the next `ble_tick()` and never recovered until a second client attached.

Only update the state to `ADVERTISING` when `getConnectedCount() == 0`.

## Test plan
- [x] macOS Sequoia, single client: pair from Bluetooth Settings, verify UI flips to "Connected" and stays there.
- [ ] Two clients (OS HID + host daemon): UI remains "Connected" with both slots in use.
- [x] Disconnect: UI flips back to "Advertising…" once the last client leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)