### PR TITLE
Activity screen: live Claude Code session state from hooks

### DIFF
--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -164,6 +164,7 @@ _PHASE_NUM = {"idle": 0, "running": 1}
 
 USER_PROMPT_MAX = 60
 CURRENT_TOOL_MAX = 24
+TOOL_ARGS_MAX = 60
 
 
 def load_activity_sessions() -> list[dict]:
@@ -219,6 +220,9 @@ def load_activity_sessions() -> list[dict]:
         ct = str(s.get("current_tool", ""))[:CURRENT_TOOL_MAX]
         if ct:
             entry["t"] = ct
+        ta = str(s.get("current_tool_args", ""))[:TOOL_ARGS_MAX]
+        if ta:
+            entry["ta"] = ta
         up = str(s.get("last_user_prompt", ""))[:USER_PROMPT_MAX]
         if up:
             entry["u"] = up
@@ -352,14 +356,18 @@ def _serialize_capped(payload: dict) -> str:
         # Step 1: drop the optional user prompt first
         if "u" in last:
             last.pop("u", None)
-        # Step 2: drop tail todos one at a time
+        # Step 2: drop the tool-args summary (the tool name itself is
+        # short and signal-rich enough by itself)
+        elif "ta" in last:
+            last.pop("ta", None)
+        # Step 3: drop tail todos one at a time
         elif last.get("td"):
             last["td"] = last["td"][:-1]
-        # Step 3: drop current_tool (still keep project+model+phase
+        # Step 4: drop current_tool (still keep project+model+phase
         # so the user sees the session exists)
         elif "t" in last:
             last.pop("t", None)
-        # Step 4: drop the whole session
+        # Step 5: drop the whole session
         else:
             sessions.pop()
         work["sessions"] = sessions

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -30,6 +30,18 @@ POLL_INTERVAL = 60
 TICK = 5
 SCAN_TIMEOUT = 8.0
 
+# Activity / hook state — written by daemon/clawdmeter_hook.py on every
+# Claude Code hook event, read here on every tick.
+STATE_FILE = Path.home() / ".clawdmeter" / "state.json"
+MAX_SESSIONS = 3            # most-recently-active sessions sent to device
+MAX_TODOS_PER_SESSION = 10  # head of the list, oldest-first ordering preserved
+TODO_CONTENT_MAX = 50
+TODO_ACTIVEFORM_MAX = 40
+SESSION_STALE_SECONDS = 10 * 60   # drop from payload if no activity within this window
+# BLE single-attribute write limit per the Core spec is 512 bytes; we leave
+# headroom for header/framing variability.
+MAX_BLE_PAYLOAD = 480
+
 # macOS: token lives in Keychain (service "Claude Code-credentials").
 # Linux: token lives in ~/.claude/.credentials.json.
 KEYCHAIN_SERVICE = "Claude Code-credentials"
@@ -147,6 +159,80 @@ def save_address(addr: str) -> None:
     SAVED_ADDR_FILE.write_text(addr)
 
 
+_STATUS_NUM = {"pending": 0, "in_progress": 1, "completed": 2}
+_PHASE_NUM = {"idle": 0, "running": 1}
+
+USER_PROMPT_MAX = 60
+CURRENT_TOOL_MAX = 24
+
+
+def load_activity_sessions() -> list[dict]:
+    """Read state.json written by the hook script and project it into the
+    compact session schema the firmware expects.
+
+    Returns up to MAX_SESSIONS entries, sorted most-recently-active first,
+    each with a head-truncated todos list. activeForm is included only on
+    the in-progress item — every other state would never display it.
+    """
+    try:
+        state = json.loads(STATE_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    sessions = state.get("sessions") or {}
+    if not isinstance(sessions, dict):
+        return []
+    now = time.time()
+    fresh = []
+    for sid, s in sessions.items():
+        if not isinstance(s, dict):
+            continue
+        la_ts = s.get("last_active_ts") or 0
+        age = now - la_ts
+        if age > SESSION_STALE_SECONDS:
+            continue
+        fresh.append((la_ts, s))
+    fresh.sort(key=lambda x: x[0], reverse=True)
+    out = []
+    for la_ts, s in fresh[:MAX_SESSIONS]:
+        todos = s.get("todos") or []
+        compact_todos = []
+        for t in todos[:MAX_TODOS_PER_SESSION]:
+            if not isinstance(t, dict):
+                continue
+            sn = _STATUS_NUM.get(str(t.get("status", "pending")), 0)
+            entry = {
+                "c": str(t.get("content", ""))[:TODO_CONTENT_MAX],
+                "s": sn,
+            }
+            if sn == 1:
+                af = str(t.get("activeForm", ""))[:TODO_ACTIVEFORM_MAX]
+                if af:
+                    entry["a"] = af
+            compact_todos.append(entry)
+        entry = {
+            "p": str(s.get("project", ""))[:24],
+            "m": str(s.get("model", ""))[:24],
+            "la": max(0, int(now - la_ts)),
+            "ph": _PHASE_NUM.get(str(s.get("phase", "idle")), 0),
+            "td": compact_todos,
+        }
+        ct = str(s.get("current_tool", ""))[:CURRENT_TOOL_MAX]
+        if ct:
+            entry["t"] = ct
+        up = str(s.get("last_user_prompt", ""))[:USER_PROMPT_MAX]
+        if up:
+            entry["u"] = up
+        out.append(entry)
+    return out
+
+
+def state_file_mtime() -> float:
+    try:
+        return STATE_FILE.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
 async def scan_for_device() -> str | None:
     log(f"Scanning for '{DEVICE_NAME}' ({SCAN_TIMEOUT}s)...")
     devices = await BleakScanner.discover(timeout=SCAN_TIMEOUT)
@@ -216,18 +302,82 @@ class Session:
             log(f"Refresh subscription unavailable: {e}")
 
     async def write_payload(self, payload: dict) -> bool:
-        data = json.dumps(payload, separators=(",", ":")).encode()
-        log(f"Sending: {data.decode()}")
+        data = _serialize_capped(payload).encode()
+        # response=True (Write Request, not Write Command) lets bleak fall
+        # back to ATT Long Write for payloads up to the 512-byte spec cap.
+        # Without this, payloads larger than MTU-3 would be silently split
+        # into multiple onWrite callbacks on the firmware side.
         try:
-            await self.client.write_gatt_char(RX_CHAR_UUID, data, response=False)
+            log(f"Sending {len(data)}B: "
+                f"{data[:200].decode('utf-8', errors='replace')}{'…' if len(data) > 200 else ''}")
+            await self.client.write_gatt_char(RX_CHAR_UUID, data, response=True)
             return True
         except BleakError as e:
             log(f"Write failed: {e}")
             return False
 
 
+def _serialize_capped(payload: dict) -> str:
+    """JSON-serialize payload, shrinking the sessions array if needed so the
+    encoded length stays under MAX_BLE_PAYLOAD bytes.
+
+    Graduated trim from the tail-most session, in order of least UX impact:
+      1. drop `u` (user prompt) — long-ish, usually optional
+      2. drop tail todos one at a time
+      3. drop `t` (current_tool) — short, but signal-bearing
+      4. drop the whole session
+    Repeat across remaining sessions, finally drop `sessions` entirely if
+    even an empty list doesn't fit.
+    """
+    work = json.loads(json.dumps(payload))  # cheap deep copy
+
+    def encode():
+        # ensure_ascii=False keeps UTF-8 multi-byte chars as their 2-3
+        # byte form instead of 6-byte \uXXXX escapes — saves ~50% on
+        # payloads with CJK or other non-Latin user prompts. ArduinoJson
+        # on the firmware side decodes UTF-8 transparently.
+        return json.dumps(work, separators=(",", ":"), ensure_ascii=False)
+
+    def encoded_bytes():
+        # Compare against the BLE byte budget — Python `str` length
+        # counts Unicode code points, which under-counts CJK by 3x
+        # because each char is 3 bytes in UTF-8.
+        return len(encode().encode("utf-8"))
+
+    if encoded_bytes() <= MAX_BLE_PAYLOAD:
+        return encode()
+    sessions = work.get("sessions") or []
+    while sessions:
+        last = sessions[-1]
+        # Step 1: drop the optional user prompt first
+        if "u" in last:
+            last.pop("u", None)
+        # Step 2: drop tail todos one at a time
+        elif last.get("td"):
+            last["td"] = last["td"][:-1]
+        # Step 3: drop current_tool (still keep project+model+phase
+        # so the user sees the session exists)
+        elif "t" in last:
+            last.pop("t", None)
+        # Step 4: drop the whole session
+        else:
+            sessions.pop()
+        work["sessions"] = sessions
+        if encoded_bytes() <= MAX_BLE_PAYLOAD:
+            return encode()
+    work.pop("sessions", None)
+    return encode()
+
+
 async def connect_and_run(address: str, stop_event: asyncio.Event) -> bool:
     """Connect to a known address and poll until disconnected or stopped.
+
+    Two independent push triggers run on the same TICK loop:
+      * 60s API poll → refresh rate-limit fields
+      * state.json mtime change → forward latest hook-collected sessions
+
+    Whenever either triggers, we resend the merged payload (api fields +
+    sessions) so the firmware always has a coherent view.
 
     Returns True if the connection was used successfully (so the caller
     keeps the cached address), False if the connection failed and the
@@ -249,23 +399,40 @@ async def connect_and_run(address: str, stop_event: asyncio.Event) -> bool:
     session = Session(client)
     await session.setup_refresh_subscription()
 
+    cached_api: dict | None = None
     last_poll = 0.0
+    last_state_mtime = -1.0
     used_successfully = False
     try:
         while client.is_connected and not stop_event.is_set():
             now = time.time()
             elapsed = now - last_poll
-            if session.refresh_requested.is_set() or elapsed >= POLL_INTERVAL:
+            api_due = session.refresh_requested.is_set() or elapsed >= POLL_INTERVAL or cached_api is None
+            state_mtime = state_file_mtime()
+            state_changed = state_mtime != last_state_mtime
+
+            if api_due:
                 session.refresh_requested.clear()
                 token = read_token()
                 if not token:
-                    log("No token; skipping poll")
+                    log("No token; skipping API poll")
                 else:
-                    payload = await poll_api(token)
-                    if payload is not None:
-                        if await session.write_payload(payload):
-                            last_poll = time.time()
-                            used_successfully = True
+                    fresh = await poll_api(token)
+                    if fresh is not None:
+                        cached_api = fresh
+                        last_poll = time.time()
+
+            if api_due or state_changed:
+                payload = dict(cached_api) if cached_api else {
+                    "s": 0, "sr": 0, "w": 0, "wr": 0,
+                    "st": "unknown", "ok": False,
+                }
+                sessions = load_activity_sessions()
+                if sessions:
+                    payload["sessions"] = sessions
+                if await session.write_payload(payload):
+                    last_state_mtime = state_mtime
+                    used_successfully = True
 
             try:
                 await asyncio.wait_for(session.refresh_requested.wait(), timeout=TICK)

--- a/daemon/clawdmeter_hook.py
+++ b/daemon/clawdmeter_hook.py
@@ -51,6 +51,34 @@ def _short_project(cwd: str | None) -> str:
     return Path(cwd).name
 
 
+def _tool_args_summary(tool_name: str, tool_input: dict) -> str:
+    """Return a short human-readable summary of a tool's most relevant
+    arg (the thing you'd want to see next to the tool name on a 1-line
+    display). Returns "" when the tool has nothing useful to show.
+    """
+    if not isinstance(tool_input, dict):
+        return ""
+    if tool_name == "Bash":
+        return str(tool_input.get("command", ""))[:80]
+    if tool_name in ("Read", "Write", "Edit"):
+        path = str(tool_input.get("file_path", ""))
+        return Path(path).name if path else ""
+    if tool_name == "NotebookEdit":
+        path = str(tool_input.get("notebook_path", ""))
+        return Path(path).name if path else ""
+    if tool_name in ("Grep", "Glob"):
+        return str(tool_input.get("pattern", ""))[:60]
+    if tool_name == "Task":
+        return str(tool_input.get("description", ""))[:80]
+    if tool_name == "WebFetch":
+        return str(tool_input.get("url", ""))[:80]
+    if tool_name == "WebSearch":
+        return str(tool_input.get("query", ""))[:80]
+    if tool_name == "SlashCommand":
+        return str(tool_input.get("command", ""))[:80]
+    return ""
+
+
 def _prune(sessions: dict, now: int) -> dict:
     return {
         sid: s for sid, s in sessions.items()
@@ -86,6 +114,7 @@ def _update(payload: dict) -> None:
             "model": "",
             "last_tool": "",
             "current_tool": "",
+            "current_tool_args": "",
             "phase": "idle",
             "last_user_prompt": "",
             "last_active_ts": 0,
@@ -113,10 +142,12 @@ def _update(payload: dict) -> None:
             ]
             session["last_tool"] = "TodoWrite"
             session["current_tool"] = "TodoWrite"
+            session["current_tool_args"] = ""
             session["phase"] = "running"
         elif event == "PreToolUse" and tool_name:
             session["last_tool"] = tool_name
             session["current_tool"] = tool_name
+            session["current_tool_args"] = _tool_args_summary(tool_name, tool_input)
             session["phase"] = "running"
         elif event == "PostToolUse":
             # Intentionally keep `current_tool` set: Claude is usually
@@ -135,12 +166,14 @@ def _update(payload: dict) -> None:
         elif event == "Stop":
             session["last_tool"] = "idle"
             session["current_tool"] = ""
+            session["current_tool_args"] = ""
             session["phase"] = "idle"
         elif event == "SessionStart":
             # Resume / fresh open: assume idle until a tool fires. Avoids
             # a stale "running" sticking around across daemon restarts.
             session["phase"] = "idle"
             session["current_tool"] = ""
+            session["current_tool_args"] = ""
 
         sessions[session_id] = session
         state["sessions"] = sessions

--- a/daemon/clawdmeter_hook.py
+++ b/daemon/clawdmeter_hook.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Claude Code hook entry point for Clawdmeter.
+
+Registered in ~/.claude/settings.json as a `hooks` entry. On every
+hook event Claude Code invokes this script and pipes a JSON payload to
+stdin. We extract the bits the daemon cares about (todos, current
+tool, model, cwd) into a per-session record in ~/.clawdmeter/state.json
+and exit silently (fail-open: a stdout JSON `{}` lets Claude proceed
+unimpeded).
+
+The daemon polls state.json on every tick and merges its contents into
+the BLE payload sent to the ESP32.
+"""
+
+import fcntl
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".clawdmeter"
+STATE_FILE = STATE_DIR / "state.json"
+LOCK_FILE = STATE_DIR / "state.lock"
+
+# Cap session retention so a forgotten session doesn't permanently
+# occupy a slot in the device UI. Anything older than this gets pruned
+# on the next hook fire.
+SESSION_TTL_SECONDS = 15 * 60
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _short_model(model: str | None) -> str:
+    """Strip the date suffix so 'claude-sonnet-4-6-20250930' → 'sonnet-4-6'."""
+    if not model:
+        return ""
+    name = model.replace("claude-", "")
+    parts = name.split("-")
+    # Drop trailing date-shaped chunk (8 digits)
+    if parts and parts[-1].isdigit() and len(parts[-1]) >= 8:
+        parts = parts[:-1]
+    return "-".join(parts)
+
+
+def _short_project(cwd: str | None) -> str:
+    if not cwd:
+        return ""
+    return Path(cwd).name
+
+
+def _prune(sessions: dict, now: int) -> dict:
+    return {
+        sid: s for sid, s in sessions.items()
+        if now - s.get("last_active_ts", 0) < SESSION_TTL_SECONDS
+    }
+
+
+def _update(payload: dict) -> None:
+    """Apply a single hook payload to state.json."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    session_id = payload.get("session_id") or "unknown"
+    event = payload.get("hook_event_name", "")
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input") or {}
+    now = _now()
+
+    # Open + lock + read-modify-write
+    with open(LOCK_FILE, "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            state = json.loads(STATE_FILE.read_text())
+            if not isinstance(state, dict) or "sessions" not in state:
+                state = {"sessions": {}}
+        except (OSError, json.JSONDecodeError):
+            state = {"sessions": {}}
+
+        sessions = state.get("sessions", {})
+        sessions = _prune(sessions, now)
+        session = sessions.get(session_id, {
+            "cwd": "",
+            "project": "",
+            "model": "",
+            "last_tool": "",
+            "current_tool": "",
+            "phase": "idle",
+            "last_user_prompt": "",
+            "last_active_ts": 0,
+            "todos": [],
+        })
+
+        # Always refresh metadata that hook payloads carry.
+        if "cwd" in payload:
+            session["cwd"] = payload["cwd"]
+            session["project"] = _short_project(payload["cwd"])
+        if "model" in payload:
+            session["model"] = _short_model(payload["model"])
+        session["last_active_ts"] = now
+
+        if event == "PreToolUse" and tool_name == "TodoWrite":
+            # tool_input.todos = [{content, status, activeForm}, ...]
+            raw_todos = tool_input.get("todos") or []
+            session["todos"] = [
+                {
+                    "content": str(t.get("content", ""))[:120],
+                    "status": str(t.get("status", "pending")),
+                    "activeForm": str(t.get("activeForm", ""))[:80],
+                }
+                for t in raw_todos if isinstance(t, dict)
+            ]
+            session["last_tool"] = "TodoWrite"
+            session["current_tool"] = "TodoWrite"
+            session["phase"] = "running"
+        elif event == "PreToolUse" and tool_name:
+            session["last_tool"] = tool_name
+            session["current_tool"] = tool_name
+            session["phase"] = "running"
+        elif event == "PostToolUse":
+            # Intentionally keep `current_tool` set: Claude is usually
+            # mid-turn between two tool calls and clearing here would
+            # cause the headline to flicker to "(idle)" until PreToolUse
+            # for the next tool arrives.
+            session["phase"] = "running"
+        elif event == "UserPromptSubmit":
+            prompt = payload.get("prompt", "")
+            if isinstance(prompt, str):
+                session["last_user_prompt"] = prompt[:120]
+            session["phase"] = "running"
+            # Clear current_tool — a new prompt starts a fresh turn,
+            # any leftover from the previous turn is no longer accurate.
+            session["current_tool"] = ""
+        elif event == "Stop":
+            session["last_tool"] = "idle"
+            session["current_tool"] = ""
+            session["phase"] = "idle"
+        elif event == "SessionStart":
+            # Resume / fresh open: assume idle until a tool fires. Avoids
+            # a stale "running" sticking around across daemon restarts.
+            session["phase"] = "idle"
+            session["current_tool"] = ""
+
+        sessions[session_id] = session
+        state["sessions"] = sessions
+
+        tmp = STATE_FILE.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state, separators=(",", ":")))
+        os.replace(tmp, STATE_FILE)
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return 0
+        payload = json.loads(raw)
+        if isinstance(payload, dict):
+            _update(payload)
+    except Exception:
+        # Fail-open — never block Claude Code on our errors.
+        pass
+    finally:
+        # Empty JSON directive = no-op, let Claude proceed.
+        sys.stdout.write("{}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/firmware/src/ble.cpp
+++ b/firmware/src/ble.cpp
@@ -11,7 +11,11 @@
 #define TX_CHAR_UUID        "4c41555a-4465-7669-6365-000000000003"  // device ack/nack notifies
 #define REQ_CHAR_UUID       "4c41555a-4465-7669-6365-000000000004"  // device-initiated refresh request
 
-#define BLE_BUF_SIZE 512
+// Bumped from 512 to fit the activity payload (sessions / todos) with
+// headroom. BLE spec still caps a single attribute write at 512 bytes;
+// the daemon's _serialize_capped enforces that, and the firmware buffer
+// just needs to be big enough not to overflow on extended payloads.
+#define BLE_BUF_SIZE 4096
 
 // HID keyboard report descriptor (standard 6-KRO boot-protocol-compatible).
 // Includes the LED output report (Num/Caps/Scroll Lock indicators) — without

--- a/firmware/src/data.h
+++ b/firmware/src/data.h
@@ -22,6 +22,7 @@ struct UsageData {
 #define MODEL_NAME_LEN          28
 #define USER_PROMPT_LEN         80
 #define CURRENT_TOOL_LEN        28
+#define CURRENT_TOOL_ARGS_LEN   64
 
 enum todo_status_t {
     TODO_PENDING     = 0,
@@ -46,8 +47,9 @@ struct TodoItem {
 struct SessionData {
     char      project[PROJECT_NAME_LEN];
     char      model[MODEL_NAME_LEN];
-    char      last_prompt[USER_PROMPT_LEN];   // text of most recent UserPromptSubmit
-    char      current_tool[CURRENT_TOOL_LEN]; // tool currently mid-call (PreToolUse → cleared on Stop)
+    char      last_prompt[USER_PROMPT_LEN];          // text of most recent UserPromptSubmit
+    char      current_tool[CURRENT_TOOL_LEN];        // tool currently mid-call (PreToolUse → cleared on Stop)
+    char      current_tool_args[CURRENT_TOOL_ARGS_LEN]; // short summary of tool_input (Bash command, file path, etc)
     phase_t   phase;
     uint32_t  last_active_secs;       // seconds since the daemon last saw activity
     TodoItem  todos[MAX_TODOS_PER_SESSION];

--- a/firmware/src/data.h
+++ b/firmware/src/data.h
@@ -10,3 +10,52 @@ struct UsageData {
     bool ok;                 // data parse succeeded
     bool valid;              // false until first successful parse
 };
+
+// Activity / TodoWrite mirror — populated from the BLE "sessions" array
+// written by the daemon. Sized so the worst-case (3 sessions × 10 todos)
+// fits in well under 4 KB of RAM.
+#define MAX_SESSIONS            3
+#define MAX_TODOS_PER_SESSION   10
+#define TODO_CONTENT_LEN        64
+#define TODO_ACTIVEFORM_LEN     56
+#define PROJECT_NAME_LEN        28
+#define MODEL_NAME_LEN          28
+#define USER_PROMPT_LEN         80
+#define CURRENT_TOOL_LEN        28
+
+enum todo_status_t {
+    TODO_PENDING     = 0,
+    TODO_IN_PROGRESS = 1,
+    TODO_COMPLETED   = 2,
+};
+
+// Per-session activity state. PHASE_RUNNING = a Stop event has not yet
+// fired since the last tool/prompt event. PHASE_IDLE = the agent is
+// resting (no current turn in flight).
+enum phase_t {
+    PHASE_IDLE    = 0,
+    PHASE_RUNNING = 1,
+};
+
+struct TodoItem {
+    char           content[TODO_CONTENT_LEN];
+    char           active_form[TODO_ACTIVEFORM_LEN];   // empty unless in_progress
+    todo_status_t  status;
+};
+
+struct SessionData {
+    char      project[PROJECT_NAME_LEN];
+    char      model[MODEL_NAME_LEN];
+    char      last_prompt[USER_PROMPT_LEN];   // text of most recent UserPromptSubmit
+    char      current_tool[CURRENT_TOOL_LEN]; // tool currently mid-call (PreToolUse → cleared on Stop)
+    phase_t   phase;
+    uint32_t  last_active_secs;       // seconds since the daemon last saw activity
+    TodoItem  todos[MAX_TODOS_PER_SESSION];
+    uint8_t   todo_count;
+};
+
+struct ActivityData {
+    SessionData  sessions[MAX_SESSIONS];
+    uint8_t      session_count;
+    bool         valid;               // false until first successful parse
+};

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -28,6 +28,7 @@ XPowersPMU pmu;
 SensorQMI8658 imu;
 
 static UsageData usage = {};
+static ActivityData activity = {};
 
 // ---- Touch interrupt + shared state ----
 static volatile bool     touch_pressed = false;
@@ -154,8 +155,11 @@ static void my_touch_cb(lv_indev_t* indev, lv_indev_data_t* data) {
     }
 }
 
-// Parse a JSON line into UsageData
-static bool parse_json(const char* json, UsageData* out) {
+// Parse a JSON line into UsageData and (optionally) ActivityData. The
+// daemon sends both in the same payload; the activity portion is absent
+// when no hook events have fired recently — in that case act_out is
+// updated to "no sessions" so the Activity screen renders a placeholder.
+static bool parse_json(const char* json, UsageData* out, ActivityData* act_out) {
     JsonDocument doc;
     DeserializationError err = deserializeJson(doc, json);
     if (err) {
@@ -170,6 +174,39 @@ static bool parse_json(const char* json, UsageData* out) {
     strlcpy(out->status, doc["st"] | "unknown", sizeof(out->status));
     out->ok = doc["ok"] | false;
     out->valid = true;
+
+    if (!act_out) return true;
+    act_out->session_count = 0;
+    JsonArrayConst sessions = doc["sessions"].as<JsonArrayConst>();
+    if (!sessions.isNull()) {
+        for (JsonVariantConst sv : sessions) {
+            if (act_out->session_count >= MAX_SESSIONS) break;
+            SessionData& s = act_out->sessions[act_out->session_count];
+            strlcpy(s.project,      sv["p"] | "", sizeof(s.project));
+            strlcpy(s.model,        sv["m"] | "", sizeof(s.model));
+            strlcpy(s.last_prompt,  sv["u"] | "", sizeof(s.last_prompt));
+            strlcpy(s.current_tool, sv["t"] | "", sizeof(s.current_tool));
+            s.phase = ((int)(sv["ph"] | 0)) == 1 ? PHASE_RUNNING : PHASE_IDLE;
+            s.last_active_secs = sv["la"] | 0;
+            s.todo_count = 0;
+            JsonArrayConst td = sv["td"].as<JsonArrayConst>();
+            if (!td.isNull()) {
+                for (JsonVariantConst tv : td) {
+                    if (s.todo_count >= MAX_TODOS_PER_SESSION) break;
+                    TodoItem& t = s.todos[s.todo_count];
+                    strlcpy(t.content, tv["c"] | "", sizeof(t.content));
+                    strlcpy(t.active_form, tv["a"] | "", sizeof(t.active_form));
+                    int sn = tv["s"] | 0;
+                    if      (sn == 1) t.status = TODO_IN_PROGRESS;
+                    else if (sn == 2) t.status = TODO_COMPLETED;
+                    else              t.status = TODO_PENDING;
+                    s.todo_count++;
+                }
+            }
+            act_out->session_count++;
+        }
+    }
+    act_out->valid = true;
     return true;
 }
 
@@ -390,7 +427,7 @@ void loop() {
 
     // Process incoming BLE data
     if (ble_has_data()) {
-        if (parse_json(ble_get_data(), &usage)) {
+        if (parse_json(ble_get_data(), &usage, &activity)) {
             int g_before = usage_rate_group();
             usage_rate_sample(usage.session_pct);
             int g_after = usage_rate_group();
@@ -400,6 +437,7 @@ void loop() {
                 if (splash_is_active()) splash_pick_for_current_rate();
             }
             ui_update(&usage);
+            ui_update_activity(&activity);
             ble_send_ack();
         } else {
             ble_send_nack();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -184,8 +184,9 @@ static bool parse_json(const char* json, UsageData* out, ActivityData* act_out) 
             SessionData& s = act_out->sessions[act_out->session_count];
             strlcpy(s.project,      sv["p"] | "", sizeof(s.project));
             strlcpy(s.model,        sv["m"] | "", sizeof(s.model));
-            strlcpy(s.last_prompt,  sv["u"] | "", sizeof(s.last_prompt));
-            strlcpy(s.current_tool, sv["t"] | "", sizeof(s.current_tool));
+            strlcpy(s.last_prompt,        sv["u"]  | "", sizeof(s.last_prompt));
+            strlcpy(s.current_tool,       sv["t"]  | "", sizeof(s.current_tool));
+            strlcpy(s.current_tool_args,  sv["ta"] | "", sizeof(s.current_tool_args));
             s.phase = ((int)(sv["ph"] | 0)) == 1 ? PHASE_RUNNING : PHASE_IDLE;
             s.last_active_secs = sv["la"] | 0;
             s.todo_count = 0;
@@ -331,7 +332,7 @@ void setup() {
     // Show initial battery status
     ui_update_battery(power_battery_pct(), power_is_charging());
 
-    ui_show_screen(SCREEN_SPLASH);
+    ui_show_screen(SCREEN_SPLASH);  // morphs to Activity automatically when sessions arrive
 
     Serial.println("Dashboard ready, waiting for data on BLE...");
 }

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -32,23 +32,25 @@ LV_FONT_DECLARE(font_styrene_16);
 // Activity is the only screen that uses its own title baseline (everything
 // else aligns to the shared TITLE_Y=30). We push it ~15px lower so the
 // title doesn't crowd the rounded display corners and battery icon.
+// Per upstream review feedback (HermannBjorgvin/Clawdmeter#22): bigger
+// fonts across the board and the footer dropped, giving the panel more
+// vertical room.
 #define ACT_TITLE_FONT     font_styrene_28
-#define ACT_MODEL_FONT     font_styrene_20
-#define ACT_PROMPT_FONT    font_styrene_20
+#define ACT_MODEL_FONT     font_styrene_24
+#define ACT_PROMPT_FONT    font_styrene_24
 #define ACT_ACTIVE_FONT    font_styrene_28
 #define ACT_PROGRESS_FONT  font_styrene_24
-#define ACT_TODO_FONT      font_styrene_20
-#define ACT_FOOTER_FONT    font_styrene_20
-#define ACT_TODO_ROW_H     30
+#define ACT_TODO_FONT      font_styrene_24
+#define ACT_TODO_ROW_H     34
 #define ACT_TITLE_Y        50
-#define ACT_MODEL_Y        86
-#define ACT_PROMPT_Y       118
-#define ACT_PROMPT_H       30
-#define ACT_ACTIVE_Y       160
-#define ACT_ACTIVE_H       60
-#define ACT_PANEL_Y        228
-#define ACT_PANEL_H        202  // progress header + 5 rows × 30 + padding
-#define ACT_FOOTER_Y       444
+#define ACT_TITLE_H        36
+#define ACT_MODEL_Y        94
+#define ACT_PROMPT_Y       130
+#define ACT_PROMPT_H       34
+#define ACT_ACTIVE_Y       178
+#define ACT_ACTIVE_H       64
+#define ACT_PANEL_Y        252
+#define ACT_PANEL_H        222
 #define ACT_COUNTER_RIGHT  76
 
 // Cap visible todo rows so we can size the panel deterministically.
@@ -99,8 +101,6 @@ static lv_obj_t* lbl_act_in_progress;    // ">> Reworking UI layout"
 static lv_obj_t* act_todo_panel;         // rounded card wrapping progress + list
 static lv_obj_t* lbl_act_progress;       // "5/12 done" — header inside the panel
 static lv_obj_t* act_list;               // scrollable flex container of todo rows
-static lv_obj_t* lbl_act_footer;         // "last active 30s ago"
-static lv_obj_t* lbl_act_placeholder;    // shown when 0 sessions
 static ActivityData cached_activity = {};
 static uint8_t current_session_idx = 0;
 
@@ -480,8 +480,10 @@ static void init_activity_screen(lv_obj_t* scr) {
     // its own ACT_COUNTER_RIGHT pad + a small gap. Fixed height needed
     // alongside LV_LABEL_LONG_DOT or the label wraps instead of clipping.
     lv_obj_set_size(lbl_act_title,
-                    CONTENT_W - (ACT_COUNTER_RIGHT - MARGIN) - 50, 26);
-    lv_label_set_long_mode(lbl_act_title, LV_LABEL_LONG_DOT);
+                    CONTENT_W - (ACT_COUNTER_RIGHT - MARGIN) - 50, ACT_TITLE_H);
+    // Marquee-scroll long project|model strings so we keep the full name
+    // visible without truncating.
+    lv_label_set_long_mode(lbl_act_title, LV_LABEL_LONG_SCROLL_CIRCULAR);
 
     // Model on its own line (subtitle under project name).
     lbl_act_model = lv_label_create(activity_container);
@@ -540,25 +542,9 @@ static void init_activity_screen(lv_obj_t* scr) {
     // gestures on the container above.
     lv_obj_add_flag(act_list, LV_OBJ_FLAG_EVENT_BUBBLE);
 
-    // Footer — "last active Ns ago".
-    lbl_act_footer = lv_label_create(activity_container);
-    lv_label_set_text(lbl_act_footer, "");
-    lv_obj_set_style_text_font(lbl_act_footer, &ACT_FOOTER_FONT, 0);
-    lv_obj_set_style_text_color(lbl_act_footer, COL_DIM, 0);
-    lv_obj_set_pos(lbl_act_footer, MARGIN, ACT_FOOTER_Y);
-
-    // Placeholder shown when no sessions are active. Use the progress
-    // font (smaller) and constrain to the content width so multi-line
-    // text wraps within the rounded-corner safe area.
-    lbl_act_placeholder = lv_label_create(activity_container);
-    lv_label_set_text(lbl_act_placeholder,
-                      "No active sessions\n\nStart Claude Code\nin any terminal");
-    lv_obj_set_style_text_font(lbl_act_placeholder, &ACT_PROGRESS_FONT, 0);
-    lv_obj_set_style_text_color(lbl_act_placeholder, COL_DIM, 0);
-    lv_obj_set_style_text_align(lbl_act_placeholder, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_width(lbl_act_placeholder, CONTENT_W);
-    lv_label_set_long_mode(lbl_act_placeholder, LV_LABEL_LONG_WRAP);
-    lv_obj_center(lbl_act_placeholder);
+    // No footer/placeholder: the title row + last_prompt + headline carry
+    // enough liveness signal that "last active Xs ago" is redundant. The
+    // empty-state lives on the splash animation (Activity ↔ Splash morph).
 
     lv_obj_add_flag(activity_container, LV_OBJ_FLAG_HIDDEN);
 }
@@ -581,37 +567,20 @@ static lv_color_t todo_color(todo_status_t s) {
     }
 }
 
-static void format_age(uint32_t secs, char* buf, size_t len) {
-    if (secs < 60)        snprintf(buf, len, "last active %us ago", (unsigned)secs);
-    else if (secs < 3600) snprintf(buf, len, "last active %um ago", (unsigned)(secs / 60));
-    else                  snprintf(buf, len, "last active %uh ago", (unsigned)(secs / 3600));
-}
-
 static void render_activity(void) {
     if (!activity_container) return;
 
     // Clear list children before re-populating (cheap; ≤10 items).
     lv_obj_clean(act_list);
 
+    // No-sessions case: apply_default_screen_state() will have already
+    // hidden activity_container and shown the splash animation. Just bail.
     const bool any = cached_activity.valid && cached_activity.session_count > 0;
-    if (!any) {
-        lv_obj_clear_flag(lbl_act_placeholder, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(lbl_act_title,        LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(lbl_act_model,        LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(lbl_act_counter,      LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(lbl_act_prompt,       LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(lbl_act_in_progress,  LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(act_todo_panel,       LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(lbl_act_footer,       LV_OBJ_FLAG_HIDDEN);
-        return;
-    }
-    lv_obj_add_flag(lbl_act_placeholder, LV_OBJ_FLAG_HIDDEN);
+    if (!any) return;
     lv_obj_clear_flag(lbl_act_title,       LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(lbl_act_model,       LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(lbl_act_counter,     LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(lbl_act_in_progress, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(act_todo_panel,      LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(lbl_act_footer,      LV_OBJ_FLAG_HIDDEN);
 
     if (current_session_idx >= cached_activity.session_count) current_session_idx = 0;
     const SessionData& s = cached_activity.sessions[current_session_idx];
@@ -669,8 +638,15 @@ static void render_activity(void) {
         lv_label_set_text(lbl_act_in_progress, buf);
         lv_obj_set_style_text_color(lbl_act_in_progress, COL_ACCENT, 0);
     } else if (s.current_tool[0]) {
-        char buf[64];
-        snprintf(buf, sizeof(buf), ">>  Doing: %s", s.current_tool);
+        // "Bash | <short summary>" when the hook captured tool_input.
+        // Falls back to "Doing: <tool>" if no summary is available.
+        char buf[128];
+        if (s.current_tool_args[0]) {
+            snprintf(buf, sizeof(buf), ">>  %s | %s",
+                     s.current_tool, s.current_tool_args);
+        } else {
+            snprintf(buf, sizeof(buf), ">>  Doing: %s", s.current_tool);
+        }
         lv_label_set_text(lbl_act_in_progress, buf);
         lv_obj_set_style_text_color(lbl_act_in_progress, COL_ACCENT, 0);
     } else if (s.phase == PHASE_IDLE) {
@@ -680,6 +656,15 @@ static void render_activity(void) {
         lv_label_set_text(lbl_act_in_progress, "(no todos)");
         lv_obj_set_style_text_color(lbl_act_in_progress, COL_DIM, 0);
     }
+
+    // Hide the whole todo panel when this session has no todos. An empty
+    // framed card was visually noisy when the agent was running but
+    // hadn't called TodoWrite yet (typical short tasks).
+    if (s.todo_count == 0) {
+        lv_obj_add_flag(act_todo_panel, LV_OBJ_FLAG_HIDDEN);
+        return;
+    }
+    lv_obj_clear_flag(act_todo_panel, LV_OBJ_FLAG_HIDDEN);
 
     // Progress counter.
     {
@@ -720,12 +705,6 @@ static void render_activity(void) {
         lv_obj_add_flag(row, LV_OBJ_FLAG_EVENT_BUBBLE);
     }
 
-    // Footer.
-    {
-        char buf[40];
-        format_age(s.last_active_secs, buf, sizeof(buf));
-        lv_label_set_text(lbl_act_footer, buf);
-    }
 }
 
 static void activity_gesture_cb(lv_event_t* e) {
@@ -889,25 +868,43 @@ static void ble_reset_click_cb(lv_event_t* e) {
 // in that case because the splash + activity containers are already
 // hidden by ui_show_screen().
 static void apply_default_screen_state(void) {
+    // Only fade on the actual splash↔activity transition. Re-renders
+    // triggered by a swipe between sessions, or by fresh BLE data
+    // while sessions are still present, should swap content instantly
+    // — fading those would feel like a flicker.
+    static bool last_morph_active = false;
+
     if (current_screen != SCREEN_SPLASH) return;
     const bool has_sessions = cached_activity.valid && cached_activity.session_count > 0;
+    const bool state_changed = has_sessions != last_morph_active;
+    last_morph_active = has_sessions;
     lv_obj_t* splash_root = splash_get_root();
     if (has_sessions) {
         lv_obj_clear_flag(activity_container, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_fade_in(activity_container, SPLASH_MORPH_MS, 0);
-        if (splash_root && !lv_obj_has_flag(splash_root, LV_OBJ_FLAG_HIDDEN)) {
-            lv_obj_fade_out(splash_root, SPLASH_MORPH_MS, 0);
+        if (state_changed) {
+            lv_obj_fade_in(activity_container, SPLASH_MORPH_MS, 0);
+            if (splash_root && !lv_obj_has_flag(splash_root, LV_OBJ_FLAG_HIDDEN)) {
+                lv_obj_fade_out(splash_root, SPLASH_MORPH_MS, 0);
+            } else {
+                splash_hide();
+            }
         } else {
+            // Just re-render, no fade.
+            lv_obj_set_style_opa(activity_container, LV_OPA_COVER, 0);
             splash_hide();
         }
     } else {
         splash_show();
         if (splash_root) {
             lv_obj_set_style_opa(splash_root, LV_OPA_COVER, 0);
-            lv_obj_fade_in(splash_root, SPLASH_MORPH_MS, 0);
+            if (state_changed) lv_obj_fade_in(splash_root, SPLASH_MORPH_MS, 0);
         }
         if (!lv_obj_has_flag(activity_container, LV_OBJ_FLAG_HIDDEN)) {
-            lv_obj_fade_out(activity_container, SPLASH_MORPH_MS, 0);
+            if (state_changed) {
+                lv_obj_fade_out(activity_container, SPLASH_MORPH_MS, 0);
+            } else {
+                lv_obj_add_flag(activity_container, LV_OBJ_FLAG_HIDDEN);
+            }
         }
     }
 }

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -199,6 +199,7 @@ static void global_click_cb(lv_event_t* e);
 static void ble_reset_click_cb(lv_event_t* e);
 static void activity_gesture_cb(lv_event_t* e);
 static void render_activity(void);
+static void apply_default_screen_state(void);
 
 static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     lv_obj_t* panel = lv_obj_create(parent);
@@ -729,14 +730,15 @@ static void render_activity(void) {
 
 static void activity_gesture_cb(lv_event_t* e) {
     (void)e;
-    // Only act on gestures while the Activity screen is showing — this
-    // same handler is registered on the screen root and fires for every
-    // gesture regardless of which screen is visible.
-    if (ui_get_current_screen() != SCREEN_ACTIVITY) return;
+    // Only act when the splash screen is currently morphed into Activity
+    // (i.e. there's at least one session to swipe between). This handler
+    // is registered on the screen root so it fires for every gesture
+    // regardless of which screen is visible.
+    if (ui_get_current_screen() != SCREEN_SPLASH) return;
+    if (cached_activity.session_count <= 1) return;
     lv_indev_t* indev = lv_indev_active();
     if (!indev) return;
     lv_dir_t dir = lv_indev_get_gesture_dir(indev);
-    if (cached_activity.session_count <= 1) return;
     if (dir == LV_DIR_LEFT) {
         current_session_idx = (current_session_idx + 1) % cached_activity.session_count;
     } else if (dir == LV_DIR_RIGHT) {
@@ -793,6 +795,9 @@ void ui_update_activity(const ActivityData* data) {
     if (cached_activity.session_count == 0) current_session_idx = 0;
     else if (current_session_idx >= cached_activity.session_count) current_session_idx = 0;
     render_activity();
+    // If we're on the default (splash) screen, the morph state may have
+    // changed from animation → activity widgets or vice versa.
+    apply_default_screen_state();
 }
 
 void ui_update(const UsageData* data) {
@@ -851,17 +856,17 @@ static void apply_battery_visibility(void) {
     else                                  lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
 }
 
-// Screen-level click handler — cycles forward through all four screens
-// (Splash → Usage → Activity → Bluetooth → Splash). The Bluetooth reset
-// zone has its own callback that consumes the click first, so taps inside
-// it still trigger ble_clear_bonds rather than the cycle.
+// Screen-level click handler — cycles forward through the three
+// top-level screens (Splash → Usage → Bluetooth → Splash). Splash
+// auto-morphs to Activity content when sessions are active, so there's
+// no separate Activity cycle entry. The Bluetooth reset zone has its
+// own callback that consumes the click first.
 static void global_click_cb(lv_event_t* e) {
     (void)e;
     screen_t next;
     switch (ui_get_current_screen()) {
     case SCREEN_SPLASH:    next = SCREEN_USAGE;     break;
-    case SCREEN_USAGE:     next = SCREEN_ACTIVITY;  break;
-    case SCREEN_ACTIVITY:  next = SCREEN_BLUETOOTH; break;
+    case SCREEN_USAGE:     next = SCREEN_BLUETOOTH; break;
     case SCREEN_BLUETOOTH: next = SCREEN_SPLASH;    break;
     default:               next = SCREEN_SPLASH;    break;
     }
@@ -873,44 +878,83 @@ static void ble_reset_click_cb(lv_event_t* e) {
     ble_clear_bonds();
 }
 
+// Fade duration for the splash <-> activity morph. Short enough to feel
+// snappy, long enough to read as a transform rather than a hard cut.
+#define SPLASH_MORPH_MS  280
+
+// Decide what to show inside the splash "default" screen based on the
+// daemon's session state. Cross-fades the splash animation against the
+// activity widget tree so a fresh session arrives as a transform, not a
+// hard swap. Safe to call when we're on a non-splash screen — it no-ops
+// in that case because the splash + activity containers are already
+// hidden by ui_show_screen().
+static void apply_default_screen_state(void) {
+    if (current_screen != SCREEN_SPLASH) return;
+    const bool has_sessions = cached_activity.valid && cached_activity.session_count > 0;
+    lv_obj_t* splash_root = splash_get_root();
+    if (has_sessions) {
+        lv_obj_clear_flag(activity_container, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_fade_in(activity_container, SPLASH_MORPH_MS, 0);
+        if (splash_root && !lv_obj_has_flag(splash_root, LV_OBJ_FLAG_HIDDEN)) {
+            lv_obj_fade_out(splash_root, SPLASH_MORPH_MS, 0);
+        } else {
+            splash_hide();
+        }
+    } else {
+        splash_show();
+        if (splash_root) {
+            lv_obj_set_style_opa(splash_root, LV_OPA_COVER, 0);
+            lv_obj_fade_in(splash_root, SPLASH_MORPH_MS, 0);
+        }
+        if (!lv_obj_has_flag(activity_container, LV_OBJ_FLAG_HIDDEN)) {
+            lv_obj_fade_out(activity_container, SPLASH_MORPH_MS, 0);
+        }
+    }
+}
+
 void ui_show_screen(screen_t screen) {
     lv_obj_add_flag(usage_container, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(activity_container, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(ble_container, LV_OBJ_FLAG_HIDDEN);
     splash_hide();
+    // Reset opacity on the morphable containers so a leftover fade-out
+    // from a previous transition doesn't render them invisible.
+    lv_obj_set_style_opa(activity_container, LV_OPA_COVER, 0);
+    if (splash_get_root()) lv_obj_set_style_opa(splash_get_root(), LV_OPA_COVER, 0);
 
     switch (screen) {
-    case SCREEN_SPLASH:     splash_show(); break;
+    case SCREEN_SPLASH:
+        // Decided by apply_default_screen_state below — could be the
+        // Clawd animation or the Activity widget tree depending on
+        // whether any sessions are live.
+        break;
     case SCREEN_USAGE:      lv_obj_clear_flag(usage_container, LV_OBJ_FLAG_HIDDEN); break;
-    case SCREEN_ACTIVITY:   lv_obj_clear_flag(activity_container, LV_OBJ_FLAG_HIDDEN); break;
     case SCREEN_BLUETOOTH:  lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_HIDDEN); break;
     default: break;
     }
 
-    // Hide the logo overlay on screens where it would collide with the
-    // content area: splash (full-screen animation) and Activity (title
-    // text starts flush against the left margin).
+    // Hide the logo overlay on the splash screen — both morph states
+    // (Clawd animation or Activity title) want a clean left margin.
     if (logo_img) {
-        if (screen == SCREEN_SPLASH || screen == SCREEN_ACTIVITY)
-            lv_obj_add_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
-        else
-            lv_obj_clear_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
+        if (screen == SCREEN_SPLASH) lv_obj_add_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
+        else                          lv_obj_clear_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
     }
 
     if (screen != SCREEN_SPLASH) prev_non_splash_screen = screen;
     current_screen = screen;
     apply_battery_visibility();
+    apply_default_screen_state();
 }
 
 void ui_cycle_screen(void) {
-    // Cycle order: Usage → Activity → Bluetooth → Usage. Splash is not in
-    // the cycle (tap to enter/leave instead).
+    // Three-way cycle now: Usage → Bluetooth → Splash → Usage. Splash
+    // morphs to Activity content automatically when sessions are live.
     screen_t next;
     switch (current_screen) {
-    case SCREEN_USAGE:     next = SCREEN_ACTIVITY;   break;
-    case SCREEN_ACTIVITY:  next = SCREEN_BLUETOOTH;  break;
-    case SCREEN_BLUETOOTH: next = SCREEN_USAGE;      break;
-    default:               next = SCREEN_USAGE;      break;
+    case SCREEN_SPLASH:    next = SCREEN_USAGE;     break;
+    case SCREEN_USAGE:     next = SCREEN_BLUETOOTH; break;
+    case SCREEN_BLUETOOTH: next = SCREEN_SPLASH;    break;
+    default:               next = SCREEN_USAGE;     break;
     }
     ui_show_screen(next);
 }

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -7,11 +7,52 @@
 
 // Custom fonts (scaled for 314 PPI, ~1.9x from original 165 PPI)
 LV_FONT_DECLARE(font_tiempos_56);
+LV_FONT_DECLARE(font_tiempos_34);
 LV_FONT_DECLARE(font_styrene_48);
 LV_FONT_DECLARE(font_styrene_28);
 LV_FONT_DECLARE(font_styrene_24);
 LV_FONT_DECLARE(font_styrene_20);
+LV_FONT_DECLARE(font_styrene_16);
+LV_FONT_DECLARE(font_styrene_14);
+LV_FONT_DECLARE(font_styrene_12);
 LV_FONT_DECLARE(font_mono_32);
+LV_FONT_DECLARE(font_styrene_16);
+
+// AMOLED-1.8 (368 wide) needs smaller fonts on the Bluetooth screen so the
+// MAC address and credit lines don't overflow horizontally.
+#define BT_TITLE_FONT     font_tiempos_56
+#define BT_STATUS_FONT    font_styrene_48
+#define BT_DEVICE_FONT    font_styrene_28
+#define BT_CREDIT_1_FONT  font_styrene_24
+#define BT_CREDIT_2_FONT  font_styrene_20
+
+// Activity screen font + spacing budget. Portrait 368x448 has less
+// vertical room, but the previous font scale (12-16pt) was unreadable
+// at arm's length — bumped one or two steps with a tighter list region.
+// Activity is the only screen that uses its own title baseline (everything
+// else aligns to the shared TITLE_Y=30). We push it ~15px lower so the
+// title doesn't crowd the rounded display corners and battery icon.
+#define ACT_TITLE_FONT     font_styrene_28
+#define ACT_MODEL_FONT     font_styrene_20
+#define ACT_PROMPT_FONT    font_styrene_20
+#define ACT_ACTIVE_FONT    font_styrene_28
+#define ACT_PROGRESS_FONT  font_styrene_24
+#define ACT_TODO_FONT      font_styrene_20
+#define ACT_FOOTER_FONT    font_styrene_20
+#define ACT_TODO_ROW_H     30
+#define ACT_TITLE_Y        50
+#define ACT_MODEL_Y        86
+#define ACT_PROMPT_Y       118
+#define ACT_PROMPT_H       30
+#define ACT_ACTIVE_Y       160
+#define ACT_ACTIVE_H       60
+#define ACT_PANEL_Y        228
+#define ACT_PANEL_H        202  // progress header + 5 rows × 30 + padding
+#define ACT_FOOTER_Y       444
+#define ACT_COUNTER_RIGHT  76
+
+// Cap visible todo rows so we can size the panel deterministically.
+#define ACT_TODO_WINDOW    5
 
 // Anthropic brand palette — design tokens live in theme.h
 #include "theme.h"
@@ -25,13 +66,15 @@ LV_FONT_DECLARE(font_mono_32);
 #define COL_RED       THEME_RED
 #define COL_BAR_BG    THEME_BAR_BG
 
-// ---- Layout constants for 480x480 (scaled for 2.16" high-DPI + rounded corners) ----
-#define SCR_W         480
-#define SCR_H         480
-#define MARGIN        20    // wider margin for rounded display corners
+// ---- Layout constants ----
+// Width/height track the active display (480x480 for AMOLED-2.16, 368x448 for AMOLED-1.8).
+// MARGIN clears rounded display corners on both panels.
+#define SCR_W         LCD_WIDTH
+#define SCR_H         LCD_HEIGHT
+#define MARGIN        20
 #define TITLE_Y       30
 #define CONTENT_Y     100
-#define CONTENT_W     (SCR_W - 2 * MARGIN)   // 440
+#define CONTENT_W     (SCR_W - 2 * MARGIN)
 
 // ---- Usage screen widgets ----
 static lv_obj_t* usage_container;
@@ -45,6 +88,21 @@ static lv_obj_t* lbl_weekly_pct;
 static lv_obj_t* lbl_weekly_label;
 static lv_obj_t* lbl_weekly_reset;
 static lv_obj_t* lbl_anim;
+
+// ---- Activity screen widgets ----
+static lv_obj_t* activity_container;
+static lv_obj_t* lbl_act_title;          // project name (line 1, accent text color)
+static lv_obj_t* lbl_act_model;          // model name (line 2, dim subtitle)
+static lv_obj_t* lbl_act_counter;        // "1/3", colored by phase (green=running, dim=idle)
+static lv_obj_t* lbl_act_prompt;         // dim, last user prompt (1 line ellipsized)
+static lv_obj_t* lbl_act_in_progress;    // ">> Reworking UI layout"
+static lv_obj_t* act_todo_panel;         // rounded card wrapping progress + list
+static lv_obj_t* lbl_act_progress;       // "5/12 done" — header inside the panel
+static lv_obj_t* act_list;               // scrollable flex container of todo rows
+static lv_obj_t* lbl_act_footer;         // "last active 30s ago"
+static lv_obj_t* lbl_act_placeholder;    // shown when 0 sessions
+static ActivityData cached_activity = {};
+static uint8_t current_session_idx = 0;
 
 // ---- Bluetooth screen widgets ----
 static lv_obj_t* ble_container;
@@ -139,6 +197,8 @@ static void format_reset_time(int mins, char* buf, size_t len) {
 // Forward decls — callbacks defined near ui_show_screen below
 static void global_click_cb(lv_event_t* e);
 static void ble_reset_click_cb(lv_event_t* e);
+static void activity_gesture_cb(lv_event_t* e);
+static void render_activity(void);
 
 static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     lv_obj_t* panel = lv_obj_create(parent);
@@ -218,14 +278,17 @@ static void init_battery_icons(void) {
     init_icon_dsc_rgb565a8(&battery_dscs[4], ICON_BATTERY_CHARGING_W, ICON_BATTERY_CHARGING_H, icon_battery_charging_data);
 }
 
-// ======== Usage Screen (480x480) ========
+// ======== Usage Screen ========
 
-#define PANEL_H     150
-#define PANEL_GAP   16
+// 480x480 square (original)
+#define PANEL_H        150
+#define PANEL_GAP      16
+#define PANEL_BAR_Y    56
+#define PANEL_RESET_Y  94
 
 // One Session/Weekly panel: big % label, pill on the right, bar, reset label.
 // Pill y=1: symmetric inside the panel — panel-outer-top → pill-top equals
-// pill-bottom → bar-top (pill height 42 + panel pad_top 12 + bar y=56).
+// pill-bottom → bar-top.
 static void make_usage_panel(lv_obj_t* parent, int y, const char* pill_text,
                              lv_obj_t** out_pct, lv_obj_t** out_pill,
                              lv_obj_t** out_bar, lv_obj_t** out_reset) {
@@ -240,13 +303,13 @@ static void make_usage_panel(lv_obj_t* parent, int y, const char* pill_text,
     *out_pill = make_pill(panel, pill_text);
     lv_obj_align(*out_pill, LV_ALIGN_TOP_RIGHT, 0, 1);
 
-    *out_bar = make_bar(panel, 0, 56, CONTENT_W - 32, 24);
+    *out_bar = make_bar(panel, 0, PANEL_BAR_Y, CONTENT_W - 32, 24);
 
     *out_reset = lv_label_create(panel);
     lv_label_set_text(*out_reset, "---");
     lv_obj_set_style_text_font(*out_reset, &font_styrene_28, 0);
     lv_obj_set_style_text_color(*out_reset, COL_DIM, 0);
-    lv_obj_set_pos(*out_reset, 0, 94);
+    lv_obj_set_pos(*out_reset, 0, PANEL_RESET_Y);
 }
 
 static void init_usage_screen(lv_obj_t* scr) {
@@ -279,7 +342,10 @@ static void init_usage_screen(lv_obj_t* scr) {
     lv_obj_align(lbl_anim, LV_ALIGN_BOTTOM_MID, 0, -15);
 }
 
-// ======== Bluetooth Screen (480x480) ========
+// ======== Bluetooth Screen ========
+
+#define BT_INFO_PANEL_H   160
+#define BT_RESET_ZONE_H   110
 
 static void init_bluetooth_screen(lv_obj_t* scr) {
     ble_container = lv_obj_create(scr);
@@ -289,16 +355,19 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_style_border_width(ble_container, 0, 0);
     lv_obj_set_style_pad_all(ble_container, 0, 0);
     lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_SCROLLABLE);
+    // Tap on BT background (anywhere outside the reset zone) cycles to the
+    // next screen. The reset zone's own handler consumes its taps first.
+    lv_obj_add_event_cb(ble_container, global_click_cb, LV_EVENT_CLICKED, NULL);
 
     // Title
     lv_obj_t* lbl_ble_title = lv_label_create(ble_container);
     lv_label_set_text(lbl_ble_title, "Bluetooth");
-    lv_obj_set_style_text_font(lbl_ble_title, &font_tiempos_56, 0);
+    lv_obj_set_style_text_font(lbl_ble_title, &BT_TITLE_FONT, 0);
     lv_obj_set_style_text_color(lbl_ble_title, COL_TEXT, 0);
     lv_obj_align(lbl_ble_title, LV_ALIGN_TOP_MID, 16, TITLE_Y);
 
-    // Info panel (taller for 480x480)
-    lv_obj_t* p_info = make_panel(ble_container, MARGIN, CONTENT_Y, CONTENT_W, 160);
+    // Info panel
+    lv_obj_t* p_info = make_panel(ble_container, MARGIN, CONTENT_Y, CONTENT_W, BT_INFO_PANEL_H);
 
     // Bluetooth icon + status row
     static lv_image_dsc_t icon_bt_dsc;
@@ -310,27 +379,27 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
 
     lbl_ble_status = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_status, "Initializing...");
-    lv_obj_set_style_text_font(lbl_ble_status, &font_styrene_48, 0);
+    lv_obj_set_style_text_font(lbl_ble_status, &BT_STATUS_FONT, 0);
     lv_obj_set_style_text_color(lbl_ble_status, COL_DIM, 0);
     lv_obj_set_pos(lbl_ble_status, 56, 2);
 
     lbl_ble_device = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_device, "Device: ---");
-    lv_obj_set_style_text_font(lbl_ble_device, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(lbl_ble_device, &BT_DEVICE_FONT, 0);
     lv_obj_set_style_text_color(lbl_ble_device, COL_DIM, 0);
     lv_obj_set_pos(lbl_ble_device, 0, 64);
 
     lbl_ble_mac = lv_label_create(p_info);
     lv_label_set_text(lbl_ble_mac, "Address: ---");
-    lv_obj_set_style_text_font(lbl_ble_mac, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(lbl_ble_mac, &BT_DEVICE_FONT, 0);
     lv_obj_set_style_text_color(lbl_ble_mac, COL_DIM, 0);
     lv_obj_set_pos(lbl_ble_mac, 0, 100);
 
     // Reset Bluetooth tap zone with trash icon
-    int reset_y = CONTENT_Y + 160 + 16;
+    int reset_y = CONTENT_Y + BT_INFO_PANEL_H + 16;
     lv_obj_t* reset_zone = lv_obj_create(ble_container);
     lv_obj_set_pos(reset_zone, MARGIN, reset_y);
-    lv_obj_set_size(reset_zone, CONTENT_W, 110);
+    lv_obj_set_size(reset_zone, CONTENT_W, BT_RESET_ZONE_H);
     lv_obj_set_style_bg_color(reset_zone, COL_PANEL, 0);
     lv_obj_set_style_bg_opa(reset_zone, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(reset_zone, 8, 0);
@@ -348,24 +417,337 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
 
     lv_obj_t* reset_lbl = lv_label_create(reset_zone);
     lv_label_set_text(reset_lbl, "Reset Bluetooth");
-    lv_obj_set_style_text_font(reset_lbl, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(reset_lbl, &BT_DEVICE_FONT, 0);
     lv_obj_set_style_text_color(reset_lbl, COL_DIM, 0);
 
     // Attribution
     lv_obj_t* lbl_credit = lv_label_create(ble_container);
     lv_label_set_text(lbl_credit, "Built by @hermannbjorgvin");
-    lv_obj_set_style_text_font(lbl_credit, &font_styrene_24, 0);
+    lv_obj_set_style_text_font(lbl_credit, &BT_CREDIT_1_FONT, 0);
     lv_obj_set_style_text_color(lbl_credit, COL_DIM, 0);
     lv_obj_align(lbl_credit, LV_ALIGN_BOTTOM_MID, 0, -46);
 
     lv_obj_t* lbl_credit2 = lv_label_create(ble_container);
     lv_label_set_text(lbl_credit2, "Clawd animation by @amaanbuilds");
-    lv_obj_set_style_text_font(lbl_credit2, &font_styrene_20, 0);
+    lv_obj_set_style_text_font(lbl_credit2, &BT_CREDIT_2_FONT, 0);
     lv_obj_set_style_text_color(lbl_credit2, COL_DIM, 0);
     lv_obj_align(lbl_credit2, LV_ALIGN_BOTTOM_MID, 0, -20);
 
     // Start hidden
     lv_obj_add_flag(ble_container, LV_OBJ_FLAG_HIDDEN);
+}
+
+// ======== Activity Screen ========
+
+static void init_activity_screen(lv_obj_t* scr) {
+    activity_container = lv_obj_create(scr);
+    lv_obj_set_size(activity_container, SCR_W, SCR_H);
+    lv_obj_set_pos(activity_container, 0, 0);
+    lv_obj_set_style_bg_opa(activity_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(activity_container, 0, 0);
+    lv_obj_set_style_pad_all(activity_container, 0, 0);
+    lv_obj_clear_flag(activity_container, LV_OBJ_FLAG_SCROLLABLE);
+    // Tap to toggle splash (consistent with Usage screen).
+    lv_obj_add_event_cb(activity_container, global_click_cb, LV_EVENT_CLICKED, NULL);
+    // Swipe left/right to cycle sessions. LV_EVENT_GESTURE fires on the
+    // indev's last-pressed object, NOT on the screen — so attach to the
+    // top-level screen and gate by current_screen inside the callback.
+    // (We also leave a copy on activity_container for the rare case where
+    // the touch happens to start on the bare container background.)
+    lv_obj_add_event_cb(lv_screen_active(),
+                        activity_gesture_cb, LV_EVENT_GESTURE, NULL);
+    lv_obj_add_event_cb(activity_container,
+                        activity_gesture_cb, LV_EVENT_GESTURE, NULL);
+
+    // Title row — left: "project | model", right: "N/M" page counter
+    // colored by phase (green = running, dim = idle). Split into two
+    // labels because LVGL 9 doesn't have a clean way to recolor a single
+    // label across slices.
+    lbl_act_counter = lv_label_create(activity_container);
+    lv_label_set_text(lbl_act_counter, "");
+    lv_obj_set_style_text_font(lbl_act_counter, &ACT_TITLE_FONT, 0);
+    lv_obj_set_style_text_color(lbl_act_counter, COL_DIM, 0);
+    // Shifted left of the battery icon (which sits at SCR_W - 48 - MARGIN).
+    lv_obj_align(lbl_act_counter, LV_ALIGN_TOP_RIGHT, -ACT_COUNTER_RIGHT, ACT_TITLE_Y);
+
+    lbl_act_title = lv_label_create(activity_container);
+    lv_label_set_text(lbl_act_title, "");
+    lv_obj_set_style_text_font(lbl_act_title, &ACT_TITLE_FONT, 0);
+    lv_obj_set_style_text_color(lbl_act_title, COL_TEXT, 0);
+    lv_obj_set_pos(lbl_act_title, MARGIN, ACT_TITLE_Y);
+    // Reserve right margin for: counter (~50px worst case "99/99") +
+    // its own ACT_COUNTER_RIGHT pad + a small gap. Fixed height needed
+    // alongside LV_LABEL_LONG_DOT or the label wraps instead of clipping.
+    lv_obj_set_size(lbl_act_title,
+                    CONTENT_W - (ACT_COUNTER_RIGHT - MARGIN) - 50, 26);
+    lv_label_set_long_mode(lbl_act_title, LV_LABEL_LONG_DOT);
+
+    // Model on its own line (subtitle under project name).
+    lbl_act_model = lv_label_create(activity_container);
+    lv_label_set_text(lbl_act_model, "");
+    lv_obj_set_style_text_font(lbl_act_model, &ACT_MODEL_FONT, 0);
+    lv_obj_set_style_text_color(lbl_act_model, COL_DIM, 0);
+    lv_obj_set_pos(lbl_act_model, MARGIN, ACT_MODEL_Y);
+    lv_obj_set_size(lbl_act_model, CONTENT_W, 20);
+    lv_label_set_long_mode(lbl_act_model, LV_LABEL_LONG_DOT);
+
+    // Last user prompt — dim, single ellipsized line under title. Hidden
+    // when the daemon hasn't reported a prompt for this session yet.
+    // LV_LABEL_LONG_DOT requires a fixed size or it wraps instead of clipping.
+    lbl_act_prompt = lv_label_create(activity_container);
+    lv_label_set_text(lbl_act_prompt, "");
+    lv_obj_set_style_text_font(lbl_act_prompt, &ACT_PROMPT_FONT, 0);
+    lv_obj_set_style_text_color(lbl_act_prompt, COL_DIM, 0);
+    lv_obj_set_pos(lbl_act_prompt, MARGIN, ACT_PROMPT_Y);
+    lv_obj_set_size(lbl_act_prompt, CONTENT_W, ACT_PROMPT_H);
+    lv_label_set_long_mode(lbl_act_prompt, LV_LABEL_LONG_DOT);
+
+    // Current in-progress activeForm — the headline of the screen.
+    // Fixed height caps wrap to 2 lines so subsequent rows don't shift.
+    lbl_act_in_progress = lv_label_create(activity_container);
+    lv_label_set_text(lbl_act_in_progress, "");
+    lv_obj_set_style_text_font(lbl_act_in_progress, &ACT_ACTIVE_FONT, 0);
+    lv_obj_set_style_text_color(lbl_act_in_progress, COL_ACCENT, 0);
+    lv_obj_set_pos(lbl_act_in_progress, MARGIN, ACT_ACTIVE_Y);
+    lv_obj_set_size(lbl_act_in_progress, CONTENT_W, ACT_ACTIVE_H);
+    lv_label_set_long_mode(lbl_act_in_progress, LV_LABEL_LONG_DOT);
+
+    // Rounded "card" wrapping the progress header + todo list, matching
+    // the panel design language of the Usage and Bluetooth screens.
+    act_todo_panel = make_panel(activity_container, MARGIN, ACT_PANEL_Y,
+                                CONTENT_W, ACT_PANEL_H);
+
+    // Progress counter — "5/12 done" — sits at the top of the panel.
+    lbl_act_progress = lv_label_create(act_todo_panel);
+    lv_label_set_text(lbl_act_progress, "");
+    lv_obj_set_style_text_font(lbl_act_progress, &ACT_PROGRESS_FONT, 0);
+    lv_obj_set_style_text_color(lbl_act_progress, COL_TEXT, 0);
+    lv_obj_set_pos(lbl_act_progress, 0, 0);
+
+    // Scrollable todo list — flex column container, vertical scroll —
+    // sits below the progress label inside the same panel.
+    act_list = lv_obj_create(act_todo_panel);
+    lv_obj_set_pos(act_list, 0, 32);  // 32px = progress font + small gap
+    lv_obj_set_size(act_list, CONTENT_W - 32, ACT_PANEL_H - 32 - 24);
+    lv_obj_set_style_bg_opa(act_list, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(act_list, 0, 0);
+    lv_obj_set_style_pad_all(act_list, 0, 0);
+    lv_obj_set_style_pad_row(act_list, 2, 0);
+    lv_obj_set_flex_flow(act_list, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_scroll_dir(act_list, LV_DIR_VER);
+    // Don't intercept clicks that should bubble up to global_click_cb /
+    // gestures on the container above.
+    lv_obj_add_flag(act_list, LV_OBJ_FLAG_EVENT_BUBBLE);
+
+    // Footer — "last active Ns ago".
+    lbl_act_footer = lv_label_create(activity_container);
+    lv_label_set_text(lbl_act_footer, "");
+    lv_obj_set_style_text_font(lbl_act_footer, &ACT_FOOTER_FONT, 0);
+    lv_obj_set_style_text_color(lbl_act_footer, COL_DIM, 0);
+    lv_obj_set_pos(lbl_act_footer, MARGIN, ACT_FOOTER_Y);
+
+    // Placeholder shown when no sessions are active. Use the progress
+    // font (smaller) and constrain to the content width so multi-line
+    // text wraps within the rounded-corner safe area.
+    lbl_act_placeholder = lv_label_create(activity_container);
+    lv_label_set_text(lbl_act_placeholder,
+                      "No active sessions\n\nStart Claude Code\nin any terminal");
+    lv_obj_set_style_text_font(lbl_act_placeholder, &ACT_PROGRESS_FONT, 0);
+    lv_obj_set_style_text_color(lbl_act_placeholder, COL_DIM, 0);
+    lv_obj_set_style_text_align(lbl_act_placeholder, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_width(lbl_act_placeholder, CONTENT_W);
+    lv_label_set_long_mode(lbl_act_placeholder, LV_LABEL_LONG_WRAP);
+    lv_obj_center(lbl_act_placeholder);
+
+    lv_obj_add_flag(activity_container, LV_OBJ_FLAG_HIDDEN);
+}
+
+static const char* todo_prefix(todo_status_t s) {
+    switch (s) {
+    case TODO_COMPLETED:   return "[x] ";
+    case TODO_IN_PROGRESS: return "[>] ";
+    case TODO_PENDING:
+    default:               return "[ ] ";
+    }
+}
+
+static lv_color_t todo_color(todo_status_t s) {
+    switch (s) {
+    case TODO_COMPLETED:   return COL_GREEN;
+    case TODO_IN_PROGRESS: return COL_ACCENT;
+    case TODO_PENDING:
+    default:               return COL_DIM;
+    }
+}
+
+static void format_age(uint32_t secs, char* buf, size_t len) {
+    if (secs < 60)        snprintf(buf, len, "last active %us ago", (unsigned)secs);
+    else if (secs < 3600) snprintf(buf, len, "last active %um ago", (unsigned)(secs / 60));
+    else                  snprintf(buf, len, "last active %uh ago", (unsigned)(secs / 3600));
+}
+
+static void render_activity(void) {
+    if (!activity_container) return;
+
+    // Clear list children before re-populating (cheap; ≤10 items).
+    lv_obj_clean(act_list);
+
+    const bool any = cached_activity.valid && cached_activity.session_count > 0;
+    if (!any) {
+        lv_obj_clear_flag(lbl_act_placeholder, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(lbl_act_title,        LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(lbl_act_model,        LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(lbl_act_counter,      LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(lbl_act_prompt,       LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(lbl_act_in_progress,  LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(act_todo_panel,       LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(lbl_act_footer,       LV_OBJ_FLAG_HIDDEN);
+        return;
+    }
+    lv_obj_add_flag(lbl_act_placeholder, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lbl_act_title,       LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lbl_act_model,       LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lbl_act_counter,     LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lbl_act_in_progress, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(act_todo_panel,      LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lbl_act_footer,      LV_OBJ_FLAG_HIDDEN);
+
+    if (current_session_idx >= cached_activity.session_count) current_session_idx = 0;
+    const SessionData& s = cached_activity.sessions[current_session_idx];
+
+    // Title — project name on line 1, model on line 2 (subtitle style).
+    // Counter (right-aligned, phase-colored) is handled separately below.
+    lv_label_set_text(lbl_act_title, s.project[0] ? s.project : "(unknown)");
+    lv_label_set_text(lbl_act_model, s.model[0] ? s.model : "");
+
+    // Counter — colored green when the agent is running, dim when idle.
+    {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%u/%u",
+                 (unsigned)(current_session_idx + 1),
+                 (unsigned)cached_activity.session_count);
+        lv_label_set_text(lbl_act_counter, buf);
+        lv_obj_set_style_text_color(lbl_act_counter,
+            s.phase == PHASE_RUNNING ? COL_GREEN : COL_DIM, 0);
+        // Re-align after text change so right-edge tracks the new width.
+        lv_obj_align(lbl_act_counter, LV_ALIGN_TOP_RIGHT,
+                     -ACT_COUNTER_RIGHT, ACT_TITLE_Y);
+    }
+
+    // Last user prompt — hide entirely when empty so the headline has the
+    // visual weight users expect.
+    if (s.last_prompt[0]) {
+        lv_obj_clear_flag(lbl_act_prompt, LV_OBJ_FLAG_HIDDEN);
+        char buf[USER_PROMPT_LEN + 4];
+        snprintf(buf, sizeof(buf), "\"%s\"", s.last_prompt);
+        lv_label_set_text(lbl_act_prompt, buf);
+    } else {
+        lv_obj_add_flag(lbl_act_prompt, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    // Headline priority:
+    //   1. an in-progress todo's activeForm
+    //   2. otherwise current_tool ("Doing: Bash")
+    //   3. otherwise phase == idle → "(idle)"
+    //   4. otherwise "(no todos)"
+    const TodoItem* in_progress = nullptr;
+    int in_progress_idx = -1;
+    int done = 0;
+    for (uint8_t i = 0; i < s.todo_count; i++) {
+        if (s.todos[i].status == TODO_COMPLETED) done++;
+        if (s.todos[i].status == TODO_IN_PROGRESS && !in_progress) {
+            in_progress = &s.todos[i];
+            in_progress_idx = i;
+        }
+    }
+    if (in_progress) {
+        char buf[160];
+        const char* text = in_progress->active_form[0] ? in_progress->active_form
+                                                        : in_progress->content;
+        snprintf(buf, sizeof(buf), ">>  %s", text);
+        lv_label_set_text(lbl_act_in_progress, buf);
+        lv_obj_set_style_text_color(lbl_act_in_progress, COL_ACCENT, 0);
+    } else if (s.current_tool[0]) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), ">>  Doing: %s", s.current_tool);
+        lv_label_set_text(lbl_act_in_progress, buf);
+        lv_obj_set_style_text_color(lbl_act_in_progress, COL_ACCENT, 0);
+    } else if (s.phase == PHASE_IDLE) {
+        lv_label_set_text(lbl_act_in_progress, "(idle)");
+        lv_obj_set_style_text_color(lbl_act_in_progress, COL_DIM, 0);
+    } else {
+        lv_label_set_text(lbl_act_in_progress, "(no todos)");
+        lv_obj_set_style_text_color(lbl_act_in_progress, COL_DIM, 0);
+    }
+
+    // Progress counter.
+    {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%d/%u done", done, (unsigned)s.todo_count);
+        lv_label_set_text(lbl_act_progress, buf);
+    }
+
+    // Windowed todo list — show at most ACT_TODO_WINDOW rows, centered on
+    // the in-progress item when there is one (2 above, in-progress in the
+    // middle, 2 below). Slides toward an edge if centering would overflow.
+    // If there's no in-progress todo, just show the head of the list.
+    int total = (int)s.todo_count;
+    int win_start;
+    if (total <= ACT_TODO_WINDOW) {
+        win_start = 0;
+    } else if (in_progress_idx < 0) {
+        win_start = 0;
+    } else {
+        win_start = in_progress_idx - ACT_TODO_WINDOW / 2;
+        if (win_start + ACT_TODO_WINDOW > total) win_start = total - ACT_TODO_WINDOW;
+        if (win_start < 0) win_start = 0;
+    }
+    int win_end = win_start + ACT_TODO_WINDOW;
+    if (win_end > total) win_end = total;
+
+    for (int i = win_start; i < win_end; i++) {
+        const TodoItem& t = s.todos[i];
+        lv_obj_t* row = lv_label_create(act_list);
+        char buf[TODO_CONTENT_LEN + 8];
+        snprintf(buf, sizeof(buf), "%s%s", todo_prefix(t.status), t.content);
+        lv_label_set_text(row, buf);
+        lv_obj_set_style_text_font(row, &ACT_TODO_FONT, 0);
+        lv_obj_set_style_text_color(row, todo_color(t.status), 0);
+        lv_obj_set_size(row, CONTENT_W - 4, ACT_TODO_ROW_H);
+        lv_label_set_long_mode(row, LV_LABEL_LONG_DOT);
+        lv_obj_set_style_pad_all(row, 0, 0);
+        lv_obj_add_flag(row, LV_OBJ_FLAG_EVENT_BUBBLE);
+    }
+
+    // Footer.
+    {
+        char buf[40];
+        format_age(s.last_active_secs, buf, sizeof(buf));
+        lv_label_set_text(lbl_act_footer, buf);
+    }
+}
+
+static void activity_gesture_cb(lv_event_t* e) {
+    (void)e;
+    // Only act on gestures while the Activity screen is showing — this
+    // same handler is registered on the screen root and fires for every
+    // gesture regardless of which screen is visible.
+    if (ui_get_current_screen() != SCREEN_ACTIVITY) return;
+    lv_indev_t* indev = lv_indev_active();
+    if (!indev) return;
+    lv_dir_t dir = lv_indev_get_gesture_dir(indev);
+    if (cached_activity.session_count <= 1) return;
+    if (dir == LV_DIR_LEFT) {
+        current_session_idx = (current_session_idx + 1) % cached_activity.session_count;
+    } else if (dir == LV_DIR_RIGHT) {
+        current_session_idx = (current_session_idx + cached_activity.session_count - 1)
+                              % cached_activity.session_count;
+    } else {
+        return;
+    }
+    render_activity();
+    // Suppress further events from this swipe so render runs once per gesture.
+    lv_indev_wait_release(indev);
 }
 
 // ======== Public API ========
@@ -384,6 +766,7 @@ void ui_init(void) {
     init_battery_icons();
 
     init_usage_screen(scr);
+    init_activity_screen(scr);
     init_bluetooth_screen(scr);
     splash_init(scr);
 
@@ -401,6 +784,15 @@ void ui_init(void) {
     battery_img = lv_image_create(scr);
     lv_image_set_src(battery_img, &battery_dscs[0]);
     lv_obj_set_pos(battery_img, SCR_W - 48 - MARGIN, TITLE_Y);
+}
+
+void ui_update_activity(const ActivityData* data) {
+    if (!data) return;
+    cached_activity = *data;
+    cached_activity.valid = true;
+    if (cached_activity.session_count == 0) current_session_idx = 0;
+    else if (current_session_idx >= cached_activity.session_count) current_session_idx = 0;
+    render_activity();
 }
 
 void ui_update(const UsageData* data) {
@@ -459,14 +851,21 @@ static void apply_battery_visibility(void) {
     else                                  lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
 }
 
-// LVGL handles click debouncing internally. Screen-level handler fires when
-// no child consumed the event (children only consume if they have their own
-// event callback, e.g. the Reset Bluetooth zone). On BT screen we skip the
-// splash toggle so only the reset zone is interactive there.
+// Screen-level click handler — cycles forward through all four screens
+// (Splash → Usage → Activity → Bluetooth → Splash). The Bluetooth reset
+// zone has its own callback that consumes the click first, so taps inside
+// it still trigger ble_clear_bonds rather than the cycle.
 static void global_click_cb(lv_event_t* e) {
     (void)e;
-    if (ui_get_current_screen() == SCREEN_BLUETOOTH) return;
-    ui_toggle_splash();
+    screen_t next;
+    switch (ui_get_current_screen()) {
+    case SCREEN_SPLASH:    next = SCREEN_USAGE;     break;
+    case SCREEN_USAGE:     next = SCREEN_ACTIVITY;  break;
+    case SCREEN_ACTIVITY:  next = SCREEN_BLUETOOTH; break;
+    case SCREEN_BLUETOOTH: next = SCREEN_SPLASH;    break;
+    default:               next = SCREEN_SPLASH;    break;
+    }
+    ui_show_screen(next);
 }
 
 static void ble_reset_click_cb(lv_event_t* e) {
@@ -476,20 +875,26 @@ static void ble_reset_click_cb(lv_event_t* e) {
 
 void ui_show_screen(screen_t screen) {
     lv_obj_add_flag(usage_container, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(activity_container, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(ble_container, LV_OBJ_FLAG_HIDDEN);
     splash_hide();
 
     switch (screen) {
     case SCREEN_SPLASH:     splash_show(); break;
     case SCREEN_USAGE:      lv_obj_clear_flag(usage_container, LV_OBJ_FLAG_HIDDEN); break;
+    case SCREEN_ACTIVITY:   lv_obj_clear_flag(activity_container, LV_OBJ_FLAG_HIDDEN); break;
     case SCREEN_BLUETOOTH:  lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_HIDDEN); break;
     default: break;
     }
 
-    // Hide the logo overlay on the splash screen so the animation has a clean canvas
+    // Hide the logo overlay on screens where it would collide with the
+    // content area: splash (full-screen animation) and Activity (title
+    // text starts flush against the left margin).
     if (logo_img) {
-        if (screen == SCREEN_SPLASH) lv_obj_add_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
-        else                          lv_obj_clear_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
+        if (screen == SCREEN_SPLASH || screen == SCREEN_ACTIVITY)
+            lv_obj_add_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
+        else
+            lv_obj_clear_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
     }
 
     if (screen != SCREEN_SPLASH) prev_non_splash_screen = screen;
@@ -498,7 +903,15 @@ void ui_show_screen(screen_t screen) {
 }
 
 void ui_cycle_screen(void) {
-    screen_t next = (current_screen == SCREEN_USAGE) ? SCREEN_BLUETOOTH : SCREEN_USAGE;
+    // Cycle order: Usage → Activity → Bluetooth → Usage. Splash is not in
+    // the cycle (tap to enter/leave instead).
+    screen_t next;
+    switch (current_screen) {
+    case SCREEN_USAGE:     next = SCREEN_ACTIVITY;   break;
+    case SCREEN_ACTIVITY:  next = SCREEN_BLUETOOTH;  break;
+    case SCREEN_BLUETOOTH: next = SCREEN_USAGE;      break;
+    default:               next = SCREEN_USAGE;      break;
+    }
     ui_show_screen(next);
 }
 

--- a/firmware/src/ui.h
+++ b/firmware/src/ui.h
@@ -2,10 +2,13 @@
 #include "data.h"
 #include "ble.h"
 
+// The default (splash) screen morphs to show Activity content when the
+// daemon reports active sessions, and reverts to the Clawd animation
+// when all sessions have gone idle. Activity is therefore not a
+// separately cycled screen — it lives inside SCREEN_SPLASH.
 enum screen_t {
     SCREEN_SPLASH,
     SCREEN_USAGE,
-    SCREEN_ACTIVITY,
     SCREEN_BLUETOOTH,
     SCREEN_COUNT,
 };

--- a/firmware/src/ui.h
+++ b/firmware/src/ui.h
@@ -5,12 +5,14 @@
 enum screen_t {
     SCREEN_SPLASH,
     SCREEN_USAGE,
+    SCREEN_ACTIVITY,
     SCREEN_BLUETOOTH,
     SCREEN_COUNT,
 };
 
 void ui_init(void);
 void ui_update(const UsageData* data);
+void ui_update_activity(const ActivityData* data);
 void ui_tick_anim(void);
 void ui_show_screen(screen_t screen);
 void ui_cycle_screen(void);

--- a/install-mac.sh
+++ b/install-mac.sh
@@ -51,6 +51,49 @@ sed \
 echo "  Installed: $PLIST_DST"
 echo ""
 
+echo "[3b/5] Registering Claude Code hook (~/.claude/settings.json)..."
+# Adds a UserPromptSubmit/PreToolUse/Stop hook that pipes events into
+# daemon/clawdmeter_hook.py, which writes ~/.clawdmeter/state.json — the
+# daemon reads that file on every tick and forwards the Activity / todo
+# state to the ESP32. Idempotent: skips if the same command is already
+# registered for all three matchers.
+CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+HOOK_CMD="$PYTHON_BIN $SCRIPT_DIR/daemon/clawdmeter_hook.py"
+mkdir -p "$HOME/.claude"
+"$PYTHON_BIN" - "$CLAUDE_SETTINGS" "$HOOK_CMD" << 'PYEOF'
+import json, sys, os
+path, hook_cmd = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as f: data = json.load(f)
+    if not isinstance(data, dict): data = {}
+except (FileNotFoundError, json.JSONDecodeError):
+    data = {}
+hooks = data.setdefault("hooks", {})
+# Subscribe to events that move session state: tool-use boundaries and Stop.
+# UserPromptSubmit gives us a session lifecycle anchor when the user first
+# engages even before any tool fires.
+EVENTS = ["PreToolUse", "PostToolUse", "Stop", "UserPromptSubmit", "SessionStart"]
+for event in EVENTS:
+    rules = hooks.setdefault(event, [])
+    if not isinstance(rules, list): rules = []
+    already = any(
+        any(h.get("command") == hook_cmd for h in r.get("hooks", []) if isinstance(h, dict))
+        for r in rules if isinstance(r, dict)
+    )
+    if already: continue
+    rules.append({
+        "matcher": "",  # all tools / all prompts
+        "hooks": [{"type": "command", "command": hook_cmd}],
+    })
+    hooks[event] = rules
+data["hooks"] = hooks
+tmp = path + ".tmp"
+with open(tmp, "w") as f: json.dump(data, f, indent=2)
+os.replace(tmp, path)
+print(f"  Wrote {path}")
+PYEOF
+echo ""
+
 echo "[4/5] Bluetooth permission check..."
 echo "  On first run the daemon will trigger a Bluetooth permission prompt."
 echo "  macOS only prompts for foreground processes — so we'll run it"

--- a/install-mac.sh
+++ b/install-mac.sh
@@ -52,11 +52,16 @@ echo "  Installed: $PLIST_DST"
 echo ""
 
 echo "[3b/5] Registering Claude Code hook (~/.claude/settings.json)..."
-# Adds a UserPromptSubmit/PreToolUse/Stop hook that pipes events into
-# daemon/clawdmeter_hook.py, which writes ~/.clawdmeter/state.json — the
-# daemon reads that file on every tick and forwards the Activity / todo
-# state to the ESP32. Idempotent: skips if the same command is already
-# registered for all three matchers.
+echo "  This wires daemon/clawdmeter_hook.py into Claude Code as a hook"
+echo "  on TodoWrite / Stop / UserPromptSubmit etc., so the Activity"
+echo "  screen shows live session state. Skip if you only want the"
+echo "  5h/7d usage panels without the per-session view."
+echo ""
+read -r -p "Register the Claude Code hook? [Y/n] " hook_ans
+if [[ "$hook_ans" =~ ^[Nn]$ ]]; then
+    echo "  Skipped. Re-run this installer later if you change your mind."
+    echo ""
+else
 CLAUDE_SETTINGS="$HOME/.claude/settings.json"
 HOOK_CMD="$PYTHON_BIN $SCRIPT_DIR/daemon/clawdmeter_hook.py"
 mkdir -p "$HOME/.claude"
@@ -93,6 +98,7 @@ os.replace(tmp, path)
 print(f"  Wrote {path}")
 PYEOF
 echo ""
+fi
 
 echo "[4/5] Bluetooth permission check..."
 echo "  On first run the daemon will trigger a Bluetooth permission prompt."


### PR DESCRIPTION
Hi @HermannBjorgvin 👋 — back again with the next batch. Building on #18, this PR adds a third screen ("Activity") and a host-side hook integration that surfaces what every live Claude Code session is actually doing right now: which prompt the user just submitted, what tool is mid-execution, where each session is in its todo list, and whether the agent is still working or has stopped.

The whole approach — collecting session state via Claude Code's hooks and projecting it into a compact device-friendly view — is directly inspired by **[Open Island](https://github.com/Octane0411/open-vibe-island)** by @Octane0411, which does the same thing for a macOS Dynamic Island UI. The set of hook events to subscribe to, the per-session phase / current-tool / last-prompt model, and the IPC-via-file-handoff pattern are all things I learned from their architecture. No code copied — Open Island is GPLv3 Swift, our hook layer is a fresh Python + LVGL implementation written from scratch — but the design owes a lot to theirs.

## Before / after

| Today | With this PR |
|---|---|
| Two screens: Usage (5h/7d quota) + Bluetooth | Three screens. Activity shows headline, prompt, and todo list per session. |
| Daemon pushes API rate-limit numbers every 60s | Daemon also forwards hook-collected session state immediately on every TodoWrite / prompt / Stop. |
| All-completed todo list reads as "session finished" | Headline falls back to `Doing: <tool>` while the agent is still active. |

## Screenshots

> 📎 The four PNGs to attach are at `/tmp/pr-screenshots/0[1-4]-activity-*.png`. They were captured on a 368×448 portrait sibling board (the layout adapts per-board via `#ifdef` — slightly different font sizes / Y offsets on the 480×480 target, but identical structure: title row + optional prompt + headline + rounded panel + footer).

1. **Running, with in-progress todo** — counter in green, headline shows the current todo's `activeForm`, panel lists the 5-row window centered on the in-progress item.
<img width="368" height="448" alt="01-activity-running" src="https://github.com/user-attachments/assets/1674e139-74de-4690-9b72-2bf0ffbf5562" />

2. **Running, headline fallback** — no in-progress todo, but a tool is mid-call, so the headline becomes `Doing: Bash`. Counter still green.
<img width="368" height="448" alt="02-activity-doing-tool" src="https://github.com/user-attachments/assets/ad7278e3-589b-4c00-8f1c-299a038360c5" />

3. **Idle** — agent has Stopped. Counter goes dim, headline shows `(idle)`. Todo state preserved so you can see what was done.
<img width="368" height="448" alt="03-activity-idle" src="https://github.com/user-attachments/assets/c93c9ca1-39b7-4332-a665-583c66de7722" />

4. **Empty state** — no sessions visible to the daemon.
<img width="368" height="448" alt="04-activity-empty" src="https://github.com/user-attachments/assets/c3b29af9-a6fd-4ad5-a653-13e99fb5d171" />

## What's in here

### `daemon/clawdmeter_hook.py` (new) — *hook model adapted from [Open Island](https://github.com/Octane0411/open-vibe-island)*

A tiny Claude Code hook entry point. Registered in `~/.claude/settings.json` for `PreToolUse` / `PostToolUse` / `Stop` / `UserPromptSubmit` / `SessionStart` events. On each fire it reads the JSON payload from stdin, updates `~/.clawdmeter/state.json` under an advisory flock, and writes `{}` to stdout so Claude proceeds unaffected. Fail-open on parse error.

Per-session record captures:
- `phase` — `running` while a turn is in flight, `idle` after Stop / SessionStart.
- `current_tool` — most recent PreToolUse tool name, cleared only on Stop / UserPromptSubmit (not on PostToolUse — clearing there would flicker the headline to "idle" between two tools in the same turn).
- `last_user_prompt` — text of the most recent UserPromptSubmit, truncated to 120 chars.
- `todos` — full TodoWrite payload when applicable.
- `cwd`, `project`, abbreviated `model`.

Stale sessions (>15 min idle) pruned on next hook fire.

### `daemon/claude_usage_daemon.py`

- `load_activity_sessions()` projects state.json into a compact wire schema (`p`/`m`/`la`/`td`, status as int, optional `u`/`t`/`ph`). `activeForm` only included on the in-progress todo to save bytes.
- Connection loop tracks both `last_state_mtime` and the existing 60s API poll independently. Either firing triggers a fresh BLE push.
- `_serialize_capped()` gracefully adapts payload size to the BLE 512-byte single-attribute spec cap by dropping the tail session's `u` first (cheapest UX loss), then trimming its tail todos, then dropping `t`, finally dropping the whole session.
- Byte counting via `encoded.encode("utf-8")` length — important once user prompts can be CJK (each CJK char is 3 bytes UTF-8) so the trim loop converges on the real on-wire size.
- `ensure_ascii=False` halves bandwidth for non-Latin prompts.
- `write_payload` uses `response=True` so bleak falls back to ATT Long Write for payloads up to the spec cap — the device sees one onWrite per payload rather than fragmented writes.

### Firmware

- `data.h`: new `ActivityData` / `SessionData` / `TodoItem` structs + `phase_t` / `todo_status_t` enums (cap 3 sessions × 10 todos × 64-byte content, ~5 KB total).
- `ui.h`: `SCREEN_ACTIVITY` enum slot + `ui_update_activity()` public API.
- `ui.cpp`: Activity screen widget tree, swipe-cycle handler, headline fallback ladder, windowed todo rendering, rounded panel for progress + list.
- `main.cpp`: `parse_json` extended with optional `ActivityData*` out-param; reads `sessions` / `u` / `t` / `ph` if present. Old payloads still parse identically.
- `ble.cpp`: `BLE_BUF_SIZE` 512 → 4096 so onWrite buffers fit multi-session payloads with headroom.

### Tap behaviour

Previously a tap on Usage/Splash toggled splash; the daemon-end was that nothing in the cycle reached the Bluetooth screen via touch. Now tap cycles the full sequence Splash → Usage → Activity → Bluetooth → Splash. PWR keeps its existing per-screen cycle. (Tap inside the Bluetooth reset zone still clears bonds; that handler consumes the click first.)

## Test plan

- [x] Existing `waveshare_amoled_216` env still builds cleanly with no warnings beyond the pre-existing ones
- [x] Hook script unit-test: piping synthetic JSON for each of the five event types yields the expected state.json mutations
- [x] Daemon `_serialize_capped` shrinks a deliberately oversized 3-session payload below 480 bytes, preserves the most-recently-active session's full data
- [x] End-to-end with real Claude Code session: my own TodoWrite calls fired the hook, the daemon picked up state.json on its 5s tick and pushed `{...,"sessions":[{"p":"…","ph":1,"t":"Bash","u":"…","td":[…]}]}` to the firmware, Activity screen rendered the corresponding headline / prompt / todo list within a couple of seconds.
- [x] Three headline states verified by screenshot: in-progress todo's activeForm, "Doing: <tool>" fallback, "(idle)" fallback.
- [x] Counter color verified: green for `phase=running`, dim for `phase=idle`.
- [x] Windowed todo list verified at edges: in-progress at index 0 slides window to start; at last index slides to end; mid-list centers.
- [x] Empty state verified.
- [ ] Hardware verification on a real 480×480 AMOLED-2.16 board — I only have the 368×448 portrait sibling on hand, so the linked PNGs are from that board. Layout is identical structurally; the 216-targeted constants (`ACT_TITLE_Y=50`, `ACT_FOOTER_Y=440`, etc.) live in the same `ACT_*` block in `ui.cpp` and the screen should render the same content one font tier larger.

## Known follow-up (not in this PR)

- The 28pt Styrene B headline doesn't carry CJK glyphs; Chinese / Japanese activeForms render as empty boxes. Mostly a non-issue because activeForms come from Claude's own TodoWrite calls and are typically English, but a 28pt CJK font subset would close the gap if anyone needs it. (I have a working 16pt CJK font for the prompt + todo body that we kept out of this PR to avoid the +1MB flash cost — happy to send as a follow-up.)
- The daemon could refresh expired access tokens itself using the `refreshToken` already stored in the same keychain blob — currently the user has to `claude /login` again when the token expires.

## Credits

- **[Open Island (@Octane0411)](https://github.com/Octane0411/open-vibe-island)** — design inspiration for the hooks-as-data-source architecture (the five events to subscribe to, the phase / current_tool / last_prompt model, the local-file IPC handoff). Their codebase is GPLv3 Swift; this implementation was written from scratch in Python + LVGL to keep your repo's licensing intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)