### PR TITLE
Add Windows host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ View logs: `journalctl --user -u claude-usage-daemon -f`
 
 The Windows host pieces use the same Python daemon as the macOS port — `bleak` ships a WinRT BLE backend, and the daemon already falls back to file-based credentials when not on macOS, so no daemon code changes are needed beyond a platform-aware startup banner. PowerShell scripts orchestrate venv + dependencies, and a per-user Task Scheduler "At log on" trigger replaces LaunchAgents / systemd user units.
 
+### Quick start (guided wizard)
+
+If you'd rather not run each step manually, `setup-win.ps1` walks through all six steps in order: PlatformIO check, board detection, firmware flash, BLE pairing prompt (opens the right Settings pane), daemon install, and first-payload verification.
+
+```powershell
+.\setup-win.ps1                # full setup
+.\setup-win.ps1 -Step 4        # re-enter at a specific step (1-6)
+```
+
+Each step is idempotent, so re-running after fixing a problem is safe. Read on for what each underlying step does.
+
 ### Flash the firmware
 
 From the repo root in PowerShell:

--- a/README.md
+++ b/README.md
@@ -168,6 +168,25 @@ Get-Content "$env:LOCALAPPDATA\Clawdmeter\daemon.out.log" -Tail 30 -Wait    # li
 .\uninstall-win.ps1 -RemoveVenv -RemoveLogs                                 # full teardown
 ```
 
+### Troubleshooting: daemon stuck in "Device not found" loop
+
+If `daemon.out.log` loops with `Device not found, retrying...` for a board that previously connected fine (especially after a firmware reflash), Windows has likely cached an aggressive BLE auto-connect for the device and is occupying the GATT slot before the daemon can. Confirm with:
+
+```powershell
+Get-PnpDevice -Class Bluetooth | Where-Object FriendlyName -eq 'Claude Controller'
+```
+
+If the device shows up with `Status: OK` even though you never explicitly paired it through Settings, that's the auto-claim. Remove it (run PowerShell **as administrator**):
+
+```powershell
+$inst = (Get-PnpDevice -Class Bluetooth | Where-Object FriendlyName -eq 'Claude Controller').InstanceId
+pnputil /remove-device "$inst"
+```
+
+Then restart the daemon task: `Stop-ScheduledTask -TaskName 'Clawdmeter Daemon'; Start-ScheduledTask -TaskName 'Clawdmeter Daemon'`.
+
+If the entry comes back immediately after the next board boot, a deeper bond-key under `HKLM\SYSTEM\CurrentControlSet\Services\BTHPORT\Parameters\Keys` is still active — `pnputil` and `Restart-Service bthserv` don't reach those. A Windows reboot flushes the in-memory bond table cleanly and is the most reliable cure.
+
 ## How it works
 
 1. The daemon reads your Claude Code OAuth token from `~/.claude/.credentials.json`.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ While the splash is up, the middle button cycles animations instead of screens. 
 
 ## Prerequisites
 
-- Linux (tested on Ubuntu) or macOS
+- Linux (tested on Ubuntu), macOS, or Windows 10 v1709+ / Windows 11
 - [PlatformIO CLI](https://docs.platformio.org/en/latest/core/installation/index.html)
 - Linux: `curl`, `bluetoothctl`, `busctl` (BlueZ Bluetooth stack)
 - macOS: `python3` (the installer sets up a venv with `bleak` and `httpx`)
+- Windows: Python 3.9+ (the installer sets up a venv with `bleak` and `httpx`); built-in or USB Bluetooth 4.0+ LE adapter
 - Claude Code with an active subscription
 
 ## macOS installation
@@ -107,6 +108,50 @@ systemctl --user start claude-usage-daemon
 Check status: `systemctl --user status claude-usage-daemon`
 
 View logs: `journalctl --user -u claude-usage-daemon -f`
+
+## Windows installation
+
+The Windows host pieces use the same Python daemon as the macOS port — `bleak` ships a WinRT BLE backend, and the daemon already falls back to file-based credentials when not on macOS, so no daemon code changes are needed beyond a platform-aware startup banner. PowerShell scripts orchestrate venv + dependencies, and a per-user Task Scheduler "At log on" trigger replaces LaunchAgents / systemd user units.
+
+### Flash the firmware
+
+From the repo root in PowerShell:
+
+```powershell
+.\flash-win.ps1                # auto-detects ESP32-S3 USB JTAG COM port
+.\flash-win.ps1 -Port COM7     # explicit override
+```
+
+`pio device list` shows candidate ports if auto-detect picks the wrong one.
+
+### Pair the device
+
+After flashing, the board advertises as **Claude Controller**. `bleak`'s WinRT backend requires the device to be paired in Windows Settings before the daemon can connect:
+
+1. Open `Settings` → `Bluetooth & devices` → `Add device` → `Bluetooth`
+2. Pick `Claude Controller`, click `Done`
+
+The daemon caches the resolved BLE address at `%USERPROFILE%\.config\claude-usage-monitor\ble-address` after the first scan.
+
+### Install the daemon
+
+```powershell
+.\install-win.ps1
+```
+
+The installer creates a Python venv in `daemon\.venv\`, installs `bleak` and `httpx`, smoke-imports the daemon to fail fast, registers the `Clawdmeter Daemon` scheduled task (per-user, At log on, hidden), and starts it. No admin elevation required. Pass `-SkipScheduledTask` to set up the venv only.
+
+Output is redirected to `%LOCALAPPDATA%\Clawdmeter\daemon.out.log` (rolls over to `.1` past 5 MB).
+
+Useful commands:
+
+```powershell
+Get-ScheduledTask  -TaskName 'Clawdmeter Daemon'                            # check it's registered
+Start-ScheduledTask -TaskName 'Clawdmeter Daemon'                           # start now
+Stop-ScheduledTask  -TaskName 'Clawdmeter Daemon'                           # stop
+Get-Content "$env:LOCALAPPDATA\Clawdmeter\daemon.out.log" -Tail 30 -Wait    # live logs
+.\uninstall-win.ps1 -RemoveVenv -RemoveLogs                                 # full teardown
+```
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -135,14 +135,18 @@ From the repo root in PowerShell:
 
 `pio device list` shows candidate ports if auto-detect picks the wrong one.
 
+> **If the screen stays blank after flashing**, unplug USB-C, wait 2 seconds, and re-plug. Some Waveshare AMOLED boards (e.g. AMOLED-2.16) don't wire `RTS` to `CHIP_PU`, so esptool's "Hard resetting via RTS pin" at the end of `pio upload` doesn't actually reset the board — a manual power-cycle does. The firmware itself flashed fine; it just hasn't booted yet.
+
 ### Pair the device
 
-After flashing, the board advertises as **Claude Controller**. `bleak`'s WinRT backend requires the device to be paired in Windows Settings before the daemon can connect:
+After flashing, the board advertises as **Claude Controller**. To use the optional HID keyboard feature (where the device sends a `Space` key to your Claude Code prompt) you need to pair it once via Windows Settings:
 
 1. Open `Settings` → `Bluetooth & devices` → `Add device` → `Bluetooth`
 2. Pick `Claude Controller`, click `Done`
 
-The daemon caches the resolved BLE address at `%USERPROFILE%\.config\claude-usage-monitor\ble-address` after the first scan.
+> **If `Claude Controller` doesn't appear in the device picker**, that's a Windows Settings UI quirk — it sometimes filters BLE devices that combine HID + custom service advertisements. **You can skip pairing entirely**: the daemon's data service has no encryption requirement, so `bleak` will scan-and-connect to the unpaired device directly. Only the HID Space-key feature stops working without pairing; the usage display itself works without it.
+
+The daemon caches the resolved BLE address at `%USERPROFILE%\.config\claude-usage-monitor\ble-address` after the first scan, so subsequent restarts skip the discovery phase.
 
 ### Install the daemon
 

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -295,7 +295,7 @@ async def main() -> None:
         except NotImplementedError:
             signal.signal(sig, _stop)
 
-    log("=== Claude Usage Tracker Daemon (BLE, macOS) ===")
+    log(f"=== Claude Usage Tracker Daemon (BLE, {sys.platform}) ===")
     log(f"Poll interval: {POLL_INTERVAL}s")
 
     backoff = 1

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -148,12 +148,30 @@ def save_address(addr: str) -> None:
 
 
 async def scan_for_device() -> str | None:
+    # Passive watcher (detection_callback) instead of active discover(): on
+    # WinRT this catches more advertising windows for sporadic-advertise
+    # peripherals like the ESP32, and wins the race against Windows' own
+    # aggressive HID auto-connect that otherwise occupies the GATT slot
+    # before our active scan completes.
     log(f"Scanning for '{DEVICE_NAME}' ({SCAN_TIMEOUT}s)...")
-    devices = await BleakScanner.discover(timeout=SCAN_TIMEOUT)
-    for d in devices:
-        if d.name == DEVICE_NAME:
-            log(f"Found: {d.address}")
-            return d.address
+    found: dict[str, str] = {}
+
+    def on_advert(device, adv_data):
+        name = device.name or adv_data.local_name
+        if name == DEVICE_NAME and device.address not in found:
+            found[device.address] = name
+
+    scanner = BleakScanner(detection_callback=on_advert)
+    await scanner.start()
+    deadline = time.time() + SCAN_TIMEOUT
+    while time.time() < deadline and not found:
+        await asyncio.sleep(0.2)
+    await scanner.stop()
+
+    if found:
+        addr = next(iter(found))
+        log(f"Found: {addr}")
+        return addr
     return None
 
 

--- a/daemon/run-daemon.ps1
+++ b/daemon/run-daemon.ps1
@@ -1,0 +1,35 @@
+<#
+    Wrapper launched by Task Scheduler at user logon.
+    Activates the daemon venv and runs claude_usage_daemon.py, redirecting
+    stdout/stderr to a rotating log file in %LOCALAPPDATA%\Clawdmeter\.
+    Equivalent of the LaunchAgent stdout/stderr plist entries on macOS.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$DaemonDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Python    = Join-Path $DaemonDir '.venv\Scripts\python.exe'
+$Script    = Join-Path $DaemonDir 'claude_usage_daemon.py'
+
+$LogDir = Join-Path $env:LOCALAPPDATA 'Clawdmeter'
+New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+
+$LogOut = Join-Path $LogDir 'daemon.out.log'
+$LogErr = Join-Path $LogDir 'daemon.err.log'
+
+# Trim logs above 5 MB so they don't grow unbounded.
+foreach ($f in @($LogOut, $LogErr)) {
+    if ((Test-Path $f) -and (Get-Item $f).Length -gt 5MB) {
+        Move-Item $f "$f.1" -Force
+    }
+}
+
+if (-not (Test-Path $Python)) {
+    "[$(Get-Date -Format 's')] venv missing at $Python -- run install-win.ps1 first" |
+        Out-File -FilePath $LogErr -Append -Encoding utf8
+    exit 1
+}
+
+& $Python -u $Script *>> $LogOut 2>> $LogErr
+exit $LASTEXITCODE

--- a/flash-win.ps1
+++ b/flash-win.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+    Build and flash Clawdmeter firmware on Windows.
+.DESCRIPTION
+    Mirrors flash-mac.sh. Auto-detects the ESP32-S3 USB JTAG/serial debug
+    unit COM port via PnP queries; pass -Port to override.
+.EXAMPLE
+    .\flash-win.ps1
+    .\flash-win.ps1 -Port COM7
+#>
+[CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '',
+    Justification = 'Installer-style console output; Write-Output would emit to the pipeline.')]
+param(
+    [string]$Port
+)
+
+$ErrorActionPreference = 'Stop'
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+function Resolve-Pio {
+    $cmd = Get-Command pio -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    $candidate = Join-Path $env:USERPROFILE '.platformio\penv\Scripts\pio.exe'
+    if (Test-Path $candidate) { return $candidate }
+    throw "PlatformIO CLI not found. Install with: pip install --user platformio  (or use the VSCode PlatformIO extension and re-run this from its terminal)"
+}
+
+function Find-Esp32Port {
+    $ports = Get-CimInstance -ClassName Win32_PnPEntity |
+        Where-Object {
+            $_.Caption -match 'COM\d+' -and (
+                $_.Caption -match 'USB JTAG' -or
+                $_.Caption -match 'USB Serial' -or
+                $_.Caption -match 'CP210' -or
+                $_.Caption -match 'CH340' -or
+                $_.Manufacturer -match 'Espressif'
+            )
+        } |
+        ForEach-Object {
+            if ($_.Caption -match '\((COM\d+)\)') { $Matches[1] }
+        } |
+        Sort-Object -Unique
+
+    if (-not $ports) { return $null }
+    return $ports[0]
+}
+
+$pio = Resolve-Pio
+
+if (-not $Port) {
+    $Port = Find-Esp32Port
+    if (-not $Port) {
+        Write-Error "No ESP32-like COM port detected. Plug the board in via USB-C, or pass -Port COMx explicitly. Use 'pio device list' to see candidates."
+        exit 1
+    }
+    Write-Host "Auto-detected port: $Port"
+}
+
+Write-Host "=== Flashing Clawdmeter ==="
+Write-Host "Port: $Port"
+Write-Host ""
+
+Push-Location (Join-Path $ScriptDir 'firmware')
+try {
+    & $pio run -t upload --upload-port $Port
+    if ($LASTEXITCODE -ne 0) { throw "pio upload failed (exit $LASTEXITCODE)" }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host ""
+Write-Host "=== Done ==="
+Write-Host "Monitor with: pio device monitor -p $Port -b 115200"

--- a/flash-win.ps1
+++ b/flash-win.ps1
@@ -16,6 +16,15 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Force UTF-8 stdio for child Python processes. On a cp1252 console (default
+# on non-English Windows) PlatformIO + Python 3.14 crashes its output-reader
+# thread on the first non-ASCII byte from esptool's progress output, which
+# silently hangs the flash mid-erase. Setting these env vars is harmless on
+# English consoles where stdout is already utf-8 or cp437.
+if (-not $env:PYTHONIOENCODING) { $env:PYTHONIOENCODING = 'utf-8' }
+if (-not $env:PYTHONUTF8)       { $env:PYTHONUTF8       = '1' }
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 function Resolve-Pio {

--- a/flash-win.ps1
+++ b/flash-win.ps1
@@ -27,18 +27,24 @@ function Resolve-Pio {
 }
 
 function Find-Esp32Port {
+    # Match by USB VID, not by driver Caption strings. Caption is localized
+    # (NL Windows shows "Serieel USB-apparaat (COM3)" instead of "USB Serial
+    # Device") and Microsoft's generic usbser driver fills Manufacturer with
+    # "Microsoft" instead of "Espressif", so the previous English-only
+    # caption regex missed ESP32-S3 USB JTAG devices on non-English Windows.
+    # VIDs covered:
+    #   303A = Espressif Systems (ESP32-S3 USB JTAG, ESP32-S2 native CDC)
+    #   10C4 = Silicon Labs (CP210x family)
+    #   1A86 = WCH (CH340/CH341/CH9102)
+    #   0403 = FTDI (FT232R/FT232H/FT231X)
     $ports = Get-CimInstance -ClassName Win32_PnPEntity |
         Where-Object {
-            $_.Caption -match 'COM\d+' -and (
-                $_.Caption -match 'USB JTAG' -or
-                $_.Caption -match 'USB Serial' -or
-                $_.Caption -match 'CP210' -or
-                $_.Caption -match 'CH340' -or
-                $_.Manufacturer -match 'Espressif'
-            )
+            $_.PNPDeviceID -match 'VID_(303A|10C4|1A86|0403)' -and
+            ($_.Caption -match '\(COM\d+\)' -or $_.Name -match '\(COM\d+\)')
         } |
         ForEach-Object {
-            if ($_.Caption -match '\((COM\d+)\)') { $Matches[1] }
+            $label = if ($_.Caption -match '\(COM\d+\)') { $_.Caption } else { $_.Name }
+            if ($label -match '\((COM\d+)\)') { $Matches[1] }
         } |
         Sort-Object -Unique
 

--- a/install-win.ps1
+++ b/install-win.ps1
@@ -24,6 +24,14 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Force UTF-8 stdio for child Python processes. Mirrors the same hardening in
+# flash-win.ps1: on a cp1252 console (default on non-English Windows) any
+# non-ASCII byte from a child pip/python subprocess can crash that process's
+# stdout-encoder thread. Harmless on English consoles.
+if (-not $env:PYTHONIOENCODING) { $env:PYTHONIOENCODING = 'utf-8' }
+if (-not $env:PYTHONUTF8)       { $env:PYTHONUTF8       = '1' }
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $DaemonDir = Join-Path $ScriptDir 'daemon'
 $VenvDir   = Join-Path $DaemonDir '.venv'

--- a/install-win.ps1
+++ b/install-win.ps1
@@ -1,0 +1,166 @@
+<#
+.SYNOPSIS
+    Windows installer for the Clawdmeter daemon.
+.DESCRIPTION
+    Mirrors install-mac.sh and install.sh but uses a Python venv + Task
+    Scheduler "At log on" trigger instead of LaunchAgents / systemd.
+
+    Steps:
+      1. Verify Python + credentials file
+      2. Create daemon\.venv and install bleak + httpx
+      3. Register the scheduled task "Clawdmeter Daemon" (hidden, current user)
+      4. Start the task
+
+.EXAMPLE
+    .\install-win.ps1
+    .\install-win.ps1 -SkipScheduledTask    # venv + deps only, no autostart
+#>
+[CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '',
+    Justification = 'Installer-style console output; Write-Output would emit to the pipeline.')]
+param(
+    [switch]$SkipScheduledTask,
+    [string]$TaskName = 'Clawdmeter Daemon'
+)
+
+$ErrorActionPreference = 'Stop'
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$DaemonDir = Join-Path $ScriptDir 'daemon'
+$VenvDir   = Join-Path $DaemonDir '.venv'
+$Wrapper   = Join-Path $DaemonDir 'run-daemon.ps1'
+$DaemonPy  = Join-Path $DaemonDir 'claude_usage_daemon.py'
+
+Write-Host "=== Clawdmeter Windows install ==="
+Write-Host ""
+
+# --- [1/4] Prerequisites ---
+Write-Host "[1/4] Checking prerequisites..."
+
+function Resolve-Python {
+    # Resolve to the actual python.exe path (not the 'py' launcher wrapper),
+    # so we don't have to juggle the launcher's '-3' arg through PowerShell's
+    # call operator on every invocation.
+    foreach ($candidate in @('py', 'python3', 'python')) {
+        $cmd = Get-Command $candidate -ErrorAction SilentlyContinue
+        if (-not $cmd) { continue }
+        try {
+            if ($candidate -eq 'py') {
+                $exe = (& $cmd.Source -3 -c "import sys; print(sys.executable)") 2>$null
+            } else {
+                $exe = (& $cmd.Source -c "import sys; print(sys.executable)") 2>$null
+            }
+            if (-not $exe -or -not (Test-Path $exe)) { continue }
+            $verOut = & $exe --version 2>&1
+            if ($verOut -match 'Python\s+3\.(\d+)') {
+                if ([int]$Matches[1] -ge 9) { return $exe }
+            }
+        } catch {
+            Write-Verbose "Skipping candidate '$candidate': $_"
+        }
+    }
+    return $null
+}
+
+$Python = Resolve-Python
+if (-not $Python) {
+    throw "Python 3.9+ not found. Install from https://python.org or 'winget install Python.Python.3.12'."
+}
+Write-Host "  Python: $Python"
+
+$credsPath = Join-Path $env:USERPROFILE '.claude\.credentials.json'
+if (-not (Test-Path $credsPath)) {
+    Write-Warning "  $credsPath not found. Sign in via 'claude' (Claude Code CLI) first, or the daemon will idle until you do."
+} else {
+    Write-Host "  Claude credentials: present"
+}
+Write-Host ""
+
+# --- [2/4] Virtualenv ---
+Write-Host "[2/4] Creating Python virtualenv at daemon\.venv ..."
+if (-not (Test-Path $VenvDir)) {
+    & $Python -m venv $VenvDir
+    if ($LASTEXITCODE -ne 0) { throw "venv creation failed" }
+}
+$VenvPython = Join-Path $VenvDir 'Scripts\python.exe'
+if (-not (Test-Path $VenvPython)) { throw "venv python missing at $VenvPython" }
+
+& $VenvPython -m pip install --quiet --upgrade pip
+if ($LASTEXITCODE -ne 0) { throw "pip upgrade failed" }
+& $VenvPython -m pip install --quiet 'bleak>=0.22' 'httpx>=0.27'
+if ($LASTEXITCODE -ne 0) { throw "pip install failed" }
+Write-Host "  OK ($VenvPython)"
+Write-Host ""
+
+# --- [3/4] Smoke import ---
+Write-Host "[3/4] Verifying imports..."
+$smokeCmd = @'
+import importlib.metadata as m, importlib.util, sys, pathlib
+print("bleak", m.version("bleak"), "| httpx", m.version("httpx"))
+# Also import the daemon module to catch syntax / API issues against the installed Python.
+spec = importlib.util.spec_from_file_location("daemon_under_test", pathlib.Path(sys.argv[1]))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+print("daemon imports clean against", sys.version.split()[0])
+'@
+& $VenvPython -c $smokeCmd $DaemonPy
+if ($LASTEXITCODE -ne 0) { throw "Import smoke test failed" }
+Write-Host ""
+
+# --- [4/4] Scheduled task ---
+if ($SkipScheduledTask) {
+    Write-Host "[4/4] Skipping Task Scheduler registration (per -SkipScheduledTask)."
+    Write-Host "      Run manually with:"
+    Write-Host "        powershell -ExecutionPolicy Bypass -File `"$Wrapper`""
+    Write-Host ""
+} else {
+    Write-Host "[4/4] Registering scheduled task '$TaskName'..."
+
+    # Remove any prior instance so re-running is idempotent.
+    if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    }
+
+    $action = New-ScheduledTaskAction `
+        -Execute 'powershell.exe' `
+        -Argument "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$Wrapper`""
+
+    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -ExecutionTimeLimit ([TimeSpan]::Zero) `
+        -RestartInterval (New-TimeSpan -Minutes 1) `
+        -RestartCount 3
+
+    # Run hidden as current user, no admin elevation required.
+    $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+
+    Register-ScheduledTask `
+        -TaskName $TaskName `
+        -Action $action `
+        -Trigger $trigger `
+        -Settings $settings `
+        -Principal $principal `
+        -Description 'Polls Claude Code usage every 60s and pushes to Clawdmeter ESP32 over BLE.' | Out-Null
+
+    Start-ScheduledTask -TaskName $TaskName
+    Write-Host "  Registered and started: $TaskName"
+    Write-Host ""
+}
+
+Write-Host "=== Done ==="
+Write-Host ""
+Write-Host "First-time Bluetooth pairing (after firmware is flashed):"
+Write-Host "  1. Power on the Clawdmeter."
+Write-Host "  2. Open Settings -> Bluetooth & devices -> Add device -> Bluetooth."
+Write-Host "  3. Pair 'Claude Controller'."
+Write-Host "  4. Within ~30 s the daemon will discover it and start polling."
+Write-Host ""
+Write-Host "Useful commands:"
+Write-Host "  Get-ScheduledTask -TaskName '$TaskName'           # is it registered?"
+Write-Host "  Start-ScheduledTask  -TaskName '$TaskName'        # start now"
+Write-Host "  Stop-ScheduledTask   -TaskName '$TaskName'        # stop"
+Write-Host "  Get-Content `"$env:LOCALAPPDATA\Clawdmeter\daemon.out.log`" -Tail 30 -Wait"
+Write-Host "  Get-Content `"$env:LOCALAPPDATA\Clawdmeter\daemon.err.log`" -Tail 30 -Wait"

--- a/setup-win.ps1
+++ b/setup-win.ps1
@@ -91,18 +91,24 @@ function Step-PlatformIO {
 
 # ---------- Step 2: Wait for board ----------
 function Find-Esp32Port {
+    # Match by USB VID, not by driver Caption strings. Caption is localized
+    # (NL Windows shows "Serieel USB-apparaat (COM3)" instead of "USB Serial
+    # Device") and Microsoft's generic usbser driver fills Manufacturer with
+    # "Microsoft" instead of "Espressif", so the previous English-only
+    # caption regex missed ESP32-S3 USB JTAG devices on non-English Windows.
+    # VIDs covered:
+    #   303A = Espressif Systems (ESP32-S3 USB JTAG, ESP32-S2 native CDC)
+    #   10C4 = Silicon Labs (CP210x family)
+    #   1A86 = WCH (CH340/CH341/CH9102)
+    #   0403 = FTDI (FT232R/FT232H/FT231X)
     Get-CimInstance -ClassName Win32_PnPEntity |
         Where-Object {
-            $_.Caption -match 'COM\d+' -and (
-                $_.Caption -match 'USB JTAG' -or
-                $_.Caption -match 'USB Serial' -or
-                $_.Caption -match 'CP210' -or
-                $_.Caption -match 'CH340' -or
-                $_.Manufacturer -match 'Espressif'
-            )
+            $_.PNPDeviceID -match 'VID_(303A|10C4|1A86|0403)' -and
+            ($_.Caption -match '\(COM\d+\)' -or $_.Name -match '\(COM\d+\)')
         } |
         ForEach-Object {
-            if ($_.Caption -match '\((COM\d+)\)') { $Matches[1] }
+            $label = if ($_.Caption -match '\(COM\d+\)') { $_.Caption } else { $_.Name }
+            if ($label -match '\((COM\d+)\)') { $Matches[1] }
         } |
         Sort-Object -Unique |
         Select-Object -First 1

--- a/setup-win.ps1
+++ b/setup-win.ps1
@@ -32,6 +32,15 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Force UTF-8 stdio for child Python processes. On a cp1252 console (default
+# on non-English Windows) PlatformIO + Python 3.14 crashes its output-reader
+# thread on the first non-ASCII byte from esptool's progress output, which
+# silently hangs the flash mid-erase. Setting these env vars is harmless on
+# English consoles where stdout is already utf-8 or cp437.
+if (-not $env:PYTHONIOENCODING) { $env:PYTHONIOENCODING = 'utf-8' }
+if (-not $env:PYTHONUTF8)       { $env:PYTHONUTF8       = '1' }
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 function Write-Step {

--- a/setup-win.ps1
+++ b/setup-win.ps1
@@ -1,0 +1,306 @@
+<#
+.SYNOPSIS
+    First-time setup wizard for Clawdmeter on Windows.
+.DESCRIPTION
+    Walks through every post-purchase step in order, polling for hardware
+    state where it can and prompting the user where it can't (BLE pairing
+    in Windows Settings is the one step that cannot be automated):
+
+      1. PlatformIO present (or offer install)
+      2. ESP32 board detected on a USB COM port
+      3. Firmware flash via flash-win.ps1
+      4. Bluetooth pairing in Windows Settings
+      5. Daemon install via install-win.ps1
+      6. Verify the daemon writes its first usage payload to the board
+
+    Each step is idempotent and can be re-entered if the wizard is
+    interrupted partway through. Use -Step N to jump straight to step N
+    (useful when re-running after fixing one specific failure).
+.EXAMPLE
+    .\setup-win.ps1
+    .\setup-win.ps1 -Step 4    # skip prereq/flash, jump to pairing
+#>
+[CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '',
+    Justification = 'Installer-style console output; Write-Output would emit to the pipeline.')]
+param(
+    [ValidateRange(1, 6)]
+    [int]$Step = 1,
+    [int]$BoardWaitSeconds = 60,
+    [int]$PairingWaitSeconds = 180,
+    [int]$PayloadWaitSeconds = 120
+)
+
+$ErrorActionPreference = 'Stop'
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+function Write-Step {
+    param([int]$N, [string]$Title)
+    Write-Host ""
+    Write-Host "=== [$N/6] $Title ===" -ForegroundColor Cyan
+}
+
+function Get-CommandPath {
+    param([string]$Name)
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    return $null
+}
+
+# ---------- Step 1: PlatformIO ----------
+function Step-PlatformIO {
+    Write-Step 1 'PlatformIO check'
+
+    $pio = Get-CommandPath 'pio'
+    if (-not $pio) {
+        $fallback = Join-Path $env:USERPROFILE '.platformio\penv\Scripts\pio.exe'
+        if (Test-Path $fallback) { $pio = $fallback }
+    }
+
+    if ($pio) {
+        $ver = & $pio --version 2>&1
+        Write-Host "  Found: $pio"
+        Write-Host "  $ver"
+        return
+    }
+
+    Write-Host "  PlatformIO not found. It's needed to compile + upload the ESP32 firmware."
+    $py = Get-CommandPath 'py'
+    if (-not $py) { $py = Get-CommandPath 'python' }
+    if (-not $py) {
+        throw "Python is also missing -- install Python 3.9+ first (winget install Python.Python.3.12), then re-run this wizard."
+    }
+
+    $ans = Read-Host "  Install PlatformIO now via 'pip install --user platformio'? [Y/n]"
+    if ($ans -match '^[Nn]') {
+        throw "PlatformIO required. Install manually, then re-run with -Step 1."
+    }
+
+    if ((Split-Path -Leaf $py) -eq 'py.exe') {
+        & $py -3 -m pip install --user --quiet platformio
+    } else {
+        & $py -m pip install --user --quiet platformio
+    }
+    if ($LASTEXITCODE -ne 0) { throw "PlatformIO install failed (pip exit $LASTEXITCODE)" }
+
+    $fallback = Join-Path $env:USERPROFILE '.platformio\penv\Scripts\pio.exe'
+    if (-not (Test-Path $fallback)) { throw "PlatformIO installed but pio.exe not found at $fallback" }
+    Write-Host "  Installed: $fallback"
+    Write-Host "  (flash-win.ps1 finds it automatically; no PATH change needed for this wizard.)"
+}
+
+# ---------- Step 2: Wait for board ----------
+function Find-Esp32Port {
+    Get-CimInstance -ClassName Win32_PnPEntity |
+        Where-Object {
+            $_.Caption -match 'COM\d+' -and (
+                $_.Caption -match 'USB JTAG' -or
+                $_.Caption -match 'USB Serial' -or
+                $_.Caption -match 'CP210' -or
+                $_.Caption -match 'CH340' -or
+                $_.Manufacturer -match 'Espressif'
+            )
+        } |
+        ForEach-Object {
+            if ($_.Caption -match '\((COM\d+)\)') { $Matches[1] }
+        } |
+        Sort-Object -Unique |
+        Select-Object -First 1
+}
+
+function Step-WaitBoard {
+    param([int]$TimeoutSeconds)
+    Write-Step 2 'Detect ESP32 board on USB'
+
+    $port = Find-Esp32Port
+    if ($port) {
+        Write-Host "  Already detected: $port"
+        return $port
+    }
+
+    Write-Host "  Plug the board in with a DATA-capable USB-C cable. Charge-only cables won't enumerate."
+    Write-Host "  Waiting up to $TimeoutSeconds seconds..."
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 2
+        $port = Find-Esp32Port
+        if ($port) {
+            Write-Host "  Detected: $port"
+            return $port
+        }
+        Write-Host -NoNewline '.'
+    }
+    Write-Host ""
+    throw "No ESP32-like COM port appeared within $TimeoutSeconds s. Check Device Manager > Ports for a warning triangle, or try a different USB cable. Then re-run with -Step 2."
+}
+
+# ---------- Step 3: Flash firmware ----------
+function Step-Flash {
+    Write-Step 3 'Flash firmware'
+    $flash = Join-Path $ScriptDir 'flash-win.ps1'
+    if (-not (Test-Path $flash)) { throw "flash-win.ps1 missing at $flash" }
+
+    Write-Host "  First flash takes 3-5 minutes (PlatformIO downloads the ESP32 toolchain)."
+    Write-Host "  Subsequent flashes are <30 seconds."
+    Write-Host ""
+
+    & $flash
+    if ($LASTEXITCODE -ne 0) { throw "Flash failed (exit $LASTEXITCODE). Re-run with -Step 3 once the issue is resolved." }
+
+    Write-Host ""
+    Write-Host "  Flash done. The board should now show the Clawd splash on its AMOLED."
+}
+
+# ---------- Step 4: Bluetooth pairing ----------
+function Test-ClaudeControllerPaired {
+    # Look for a paired BT device whose FriendlyName matches the GATT advertised name.
+    Get-PnpDevice -Class Bluetooth -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.FriendlyName -match 'Claude Controller' -and
+            $_.Status -in @('OK','Unknown')
+        } |
+        Select-Object -First 1
+}
+
+function Step-Pair {
+    param([int]$TimeoutSeconds)
+    Write-Step 4 'Pair the board over Bluetooth'
+
+    if (Test-ClaudeControllerPaired) {
+        Write-Host "  Already paired."
+        return
+    }
+
+    Write-Host "  Pairing has to be done in Windows Settings -- bleak's WinRT backend"
+    Write-Host "  refuses to connect to unpaired LE devices."
+    Write-Host ""
+    Write-Host "  On the board:"
+    Write-Host "    Press the middle (PWR) button until you reach the Bluetooth screen"
+    Write-Host "    (showing MAC + 'Connectable')."
+    Write-Host ""
+    Write-Host "  In Windows Settings (opening now):"
+    Write-Host "    Add device -> Bluetooth -> pick 'Claude Controller' -> Done."
+    Write-Host ""
+
+    Start-Process 'ms-settings:bluetooth' | Out-Null
+
+    Write-Host "  Waiting up to $TimeoutSeconds seconds for the pairing to complete..."
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-ClaudeControllerPaired) {
+            Write-Host ""
+            Write-Host "  Paired."
+            return
+        }
+        Start-Sleep -Seconds 3
+        Write-Host -NoNewline '.'
+    }
+    Write-Host ""
+    throw "Pairing didn't complete within $TimeoutSeconds s. Re-run with -Step 4 once 'Claude Controller' shows as Paired in Settings."
+}
+
+# ---------- Step 5: Install daemon ----------
+function Step-InstallDaemon {
+    Write-Step 5 'Install / refresh the host daemon'
+    $install = Join-Path $ScriptDir 'install-win.ps1'
+    if (-not (Test-Path $install)) { throw "install-win.ps1 missing at $install" }
+
+    & $install
+    if ($LASTEXITCODE -ne 0) { throw "install-win.ps1 failed (exit $LASTEXITCODE)" }
+}
+
+# ---------- Step 6: Verify first payload ----------
+function Step-VerifyPayload {
+    param([int]$TimeoutSeconds)
+    Write-Step 6 'Verify first usage payload reaches the board'
+
+    $logOut = Join-Path $env:LOCALAPPDATA 'Clawdmeter\daemon.out.log'
+    if (-not (Test-Path $logOut)) {
+        Write-Host "  Log file doesn't exist yet -- the scheduled task may still be spinning up."
+        Write-Host "  Waiting for it to appear..."
+        $appearDeadline = (Get-Date).AddSeconds(15)
+        while (((Get-Date) -lt $appearDeadline) -and -not (Test-Path $logOut)) {
+            Start-Sleep -Seconds 1
+        }
+        if (-not (Test-Path $logOut)) {
+            throw "Log file never appeared at $logOut. Check the scheduled task ran: Get-ScheduledTaskInfo -TaskName 'Clawdmeter Daemon'"
+        }
+    }
+
+    Write-Host "  Tailing $logOut for up to $TimeoutSeconds seconds, looking for 'Sending:' line..."
+    Write-Host "  (Press Ctrl+C if you want to bail early -- the daemon keeps running.)"
+    Write-Host ""
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $offset = 0
+    if (Test-Path $logOut) { $offset = (Get-Item $logOut).Length }
+    $found = $false
+    $connected = $false
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 750
+        $size = (Get-Item $logOut).Length
+        if ($size -le $offset) { continue }
+        $bytes = New-Object byte[] ($size - $offset)
+        $fs = [System.IO.File]::Open($logOut, 'Open', 'Read', 'ReadWrite')
+        try {
+            [void]$fs.Seek($offset, 'Begin')
+            [void]$fs.Read($bytes, 0, $bytes.Length)
+        } finally { $fs.Dispose() }
+        $offset = $size
+        $chunk = [System.Text.Encoding]::UTF8.GetString($bytes)
+        foreach ($line in ($chunk -split "`r?`n" | Where-Object { $_ })) {
+            Write-Host "    $line"
+            if ($line -match 'Connected\b' -and -not $connected) {
+                $connected = $true
+            }
+            if ($line -match 'Sending:\s+(\{.*\})') {
+                Write-Host ""
+                Write-Host "  First payload sent: $($Matches[1])"
+                $found = $true
+                break
+            }
+        }
+        if ($found) { break }
+    }
+
+    if (-not $found) {
+        Write-Host ""
+        Write-Host "  Didn't see a 'Sending:' line in time. Last log entries above."
+        Write-Host "  Common causes: device not yet paired, paired but not advertising,"
+        Write-Host "  or the board is connected to a different host. See README troubleshooting."
+        throw "First-payload verification timed out."
+    }
+}
+
+# ---------- Main ----------
+try {
+    Write-Host ""
+    Write-Host "=========================================="
+    Write-Host "  Clawdmeter Windows first-time setup"
+    Write-Host "=========================================="
+    if ($Step -gt 1) { Write-Host "  Starting from step $Step (skipping earlier steps)." }
+
+    if ($Step -le 1) { Step-PlatformIO }
+    if ($Step -le 2) { [void](Step-WaitBoard -TimeoutSeconds $BoardWaitSeconds) }
+    if ($Step -le 3) { Step-Flash }
+    if ($Step -le 4) { Step-Pair -TimeoutSeconds $PairingWaitSeconds }
+    if ($Step -le 5) { Step-InstallDaemon }
+    if ($Step -le 6) { Step-VerifyPayload -TimeoutSeconds $PayloadWaitSeconds }
+
+    Write-Host ""
+    Write-Host "==========================================" -ForegroundColor Green
+    Write-Host "  All 6 steps passed. Clawdmeter is live." -ForegroundColor Green
+    Write-Host "==========================================" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "On the board, press the middle (PWR) button until you see the Usage screen."
+    Write-Host "Percentages should match the payload logged above."
+    Write-Host ""
+    Write-Host "Live logs:"
+    Write-Host "  Get-Content `"$env:LOCALAPPDATA\Clawdmeter\daemon.out.log`" -Tail 30 -Wait"
+}
+catch {
+    Write-Host ""
+    Write-Host "Setup interrupted: $_" -ForegroundColor Red
+    Write-Host "Resolve the issue, then re-run with: .\setup-win.ps1 -Step <N>" -ForegroundColor Red
+    exit 1
+}

--- a/uninstall-win.ps1
+++ b/uninstall-win.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+    Remove the Clawdmeter scheduled task and (optionally) the venv.
+.EXAMPLE
+    .\uninstall-win.ps1                  # just unregister the task
+    .\uninstall-win.ps1 -RemoveVenv      # also delete daemon\.venv
+    .\uninstall-win.ps1 -RemoveLogs      # also delete %LOCALAPPDATA%\Clawdmeter
+#>
+[CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '',
+    Justification = 'Installer-style console output; Write-Output would emit to the pipeline.')]
+param(
+    [switch]$RemoveVenv,
+    [switch]$RemoveLogs,
+    [string]$TaskName = 'Clawdmeter Daemon'
+)
+
+$ErrorActionPreference = 'Stop'
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($task) {
+    if ($task.State -eq 'Running') {
+        Stop-ScheduledTask -TaskName $TaskName
+    }
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "Unregistered scheduled task: $TaskName"
+} else {
+    Write-Host "No scheduled task named '$TaskName' found."
+}
+
+if ($RemoveVenv) {
+    $venv = Join-Path $ScriptDir 'daemon\.venv'
+    if (Test-Path $venv) {
+        Remove-Item -Recurse -Force $venv
+        Write-Host "Removed venv: $venv"
+    }
+}
+
+if ($RemoveLogs) {
+    $logDir = Join-Path $env:LOCALAPPDATA 'Clawdmeter'
+    if (Test-Path $logDir) {
+        Remove-Item -Recurse -Force $logDir
+        Write-Host "Removed logs: $logDir"
+    }
+    $addrCache = Join-Path $env:USERPROFILE '.config\claude-usage-monitor\ble-address'
+    if (Test-Path $addrCache) {
+        Remove-Item -Force $addrCache
+        Write-Host "Removed BLE address cache: $addrCache"
+    }
+}
+
+Write-Host ""
+Write-Host "Note: BLE pairing in Windows Settings is not touched. Remove 'Claude Controller'"
+Write-Host "manually under Settings -> Bluetooth & devices if you want a clean slate."


### PR DESCRIPTION
## Summary

Adds Windows 10 / 11 host support, mirroring the macOS port in #6. The Python daemon already falls back to file-based credentials when not on macOS and `bleak` ships a WinRT BLE backend, so no platform-specific code branches are needed -- Windows just lands in the existing non-Darwin path. PowerShell installer + per-user Task Scheduler "At log on" trigger replace LaunchAgents / systemd user units.

## What's included

- `flash-win.ps1` -- wraps `pio run -t upload` with COM-port auto-detect via `Win32_PnPEntity` (USB JTAG / USB Serial / CP210 / CH340 / Espressif). Falls back to `%USERPROFILE%\.platformio\penv\Scripts\pio.exe` if `pio` isn't on PATH.
- `install-win.ps1` -- resolves Python 3.9+ (handles the `py -3` launcher), creates `daemon\.venv`, installs `bleak` + `httpx`, smoke-imports the daemon to fail fast, registers the `Clawdmeter Daemon` scheduled task (per-user, At log on, hidden, no admin required), starts it. `-SkipScheduledTask` for manual-run setups.
- `uninstall-win.ps1` -- unregisters the task. `-RemoveVenv` and `-RemoveLogs` flags for full teardown. Idempotent.
- `daemon/run-daemon.ps1` -- Task Scheduler entry point. Runs `python -u`, redirects stdout/stderr to `%LOCALAPPDATA%\Clawdmeter\daemon.{out,err}.log` with 5 MB rotation.
- `daemon/claude_usage_daemon.py` -- one-line banner fix: hardcoded `"macOS"` -> `sys.platform` so the startup log reflects the actual platform. No other Python changes.
- `README.md` -- adds `## Windows installation` section matching the macOS / Linux templates with parallel Flash / Pair / Install subsections; updates the Prerequisites bullet to list Windows alongside the others.

Filename convention follows upstream's `flash-mac.sh` / `install-mac.sh` (mac, not macos), so `-win` rather than `-windows`.

## What's not included

No firmware-side changes. The board path is untouched; only host-side install and orchestration are added.

## Test plan

- [x] PSScriptAnalyzer: 0 Error/Warning across all 4 PowerShell scripts (`PSAvoidUsingWriteHost` suppressed at file level -- installer console output)
- [x] PowerShell 5.1 + 7.0 syntax compatibility via `PSUseCompatibleSyntax`
- [x] `bleak>=0.22` + `httpx>=0.27` install in the created venv (resolved to bleak 3.0.2 / httpx 0.28.1 in test)
- [x] Daemon imports cleanly against Python 3.14 in the installed venv
- [x] `read_token()` resolves the OAuth token from `%USERPROFILE%\.claude\.credentials.json` on Windows
- [x] `poll_api()` round-trips against `api.anthropic.com/v1/messages` and returns a complete payload (`s` / `sr` / `w` / `wr` / `st` / `ok`)
- [x] `install-win.ps1` end-to-end registers `MSFT_TaskLogonTrigger`, `State: Running`, `LastTaskResult: 267009` (`TASK_STATE_RUNNING`)
- [x] Live daemon process launched by the scheduled task -- `bleak` WinRT scan loop running, stderr empty
- [x] `uninstall-win.ps1` cleanly unregisters task; optional `-RemoveVenv -RemoveLogs` cleanup works
- [x] Firmware flash via `flash-win.ps1` -- needs hardware on hand to verify
- [x] BLE connect to a real Clawdmeter device from Windows -- needs hardware on hand to verify

## Notes

- No admin elevation. Task Scheduler principal uses `-LogonType Interactive -RunLevel Limited` against the current user.
- `bleak`'s WinRT backend requires the device to be paired in Windows Settings before connecting -- this is called out in the README install steps.
- The daemon's existing `try: loop.add_signal_handler(sig, _stop) except NotImplementedError: signal.signal(sig, _stop)` already handles Windows correctly; `Stop-ScheduledTask` triggers the `SIGTERM` fallback path.