### PR TITLE
macos uses keychain; remove stale comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ View logs: `journalctl --user -u claude-usage-daemon -f`
 
 ## How it works
 
-1. The daemon reads your Claude Code OAuth token from `~/.claude/.credentials.json`.
+1. The daemon reads your Claude Code OAuth token — from the macOS Keychain (service `Claude Code-credentials`) on macOS, or from `~/.claude/.credentials.json` on Linux.
 2. It makes a minimal API call to `api.anthropic.com/v1/messages` — one token of Haiku, basically free.
 3. The usage numbers come straight out of the response headers (`anthropic-ratelimit-unified-5h-utilization` and friends).
 4. The daemon connects to the ESP32 over BLE and writes a JSON payload to the GATT RX characteristic.

--- a/install-mac.sh
+++ b/install-mac.sh
@@ -20,8 +20,8 @@ echo "[1/5] Checking prerequisites..."
 for cmd in python3 curl; do
     command -v "$cmd" >/dev/null || { echo "Error: $cmd is required"; exit 1; }
 done
-if [ ! -f "$HOME/.claude/.credentials.json" ]; then
-    echo "Warning: ~/.claude/.credentials.json not found."
+if ! security find-generic-password -s "Claude Code-credentials" -a "$USER" -w >/dev/null 2>&1; then
+    echo "Warning: Claude Code OAuth token not found in Keychain (service 'Claude Code-credentials')."
     echo "  Sign in via Claude Code first, then re-run this installer."
     echo "  Continuing anyway — the daemon will retry on each poll."
 fi


### PR DESCRIPTION
on macos, `~/.claude/.credentials.json` doesn't exist, so i replaced that warning in `install-mac.sh`