### PR TITLE
Bugfix: specify board target

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ The macOS host pieces — Python daemon, LaunchAgent, and flash helper — were 
 ### Flash the firmware
 
 ```bash
-./flash-mac.sh                       # auto-detects /dev/cu.usbmodem*
-./flash-mac.sh /dev/cu.usbmodem1101  # or pass an explicit USB serial port
+./flash-mac.sh waveshare_amoled_216                       # auto-detects /dev/cu.usbmodem*
+./flash-mac.sh waveshare_amoled_18  /dev/cu.usbmodem1101  # or pass an explicit USB serial port
 ```
+
+The board env name is required. Run `./flash-mac.sh` with no args to see the available envs (scraped from `firmware/platformio.ini`).
 
 ### Pair the device
 
@@ -84,9 +86,11 @@ launchctl load -w ~/Library/LaunchAgents/com.user.claude-usage-daemon.plist # st
 ### Flash the firmware
 
 ```bash
-cd firmware
-pio run -t upload --upload-port /dev/ttyACM0
+./flash.sh waveshare_amoled_216                  # defaults to /dev/ttyACM0
+./flash.sh waveshare_amoled_18  /dev/ttyACM1     # or pass an explicit USB serial port
 ```
+
+The board env name is required. Run `./flash.sh` with no args to see the available envs (scraped from `firmware/platformio.ini`).
 
 ### Pair the device
 

--- a/flash-mac.sh
+++ b/flash-mac.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
 # Build and flash Clawdmeter firmware on macOS.
 # Usage:
-#   ./flash-mac.sh                       # auto-detect /dev/cu.usbmodem*
-#   ./flash-mac.sh /dev/cu.usbmodem1101  # explicit USB serial port
+#   ./flash-mac.sh <board>                       # auto-detect /dev/cu.usbmodem*
+#   ./flash-mac.sh <board> /dev/cu.usbmodem1101  # explicit USB serial port
+#
+# <board> is the PlatformIO env name, e.g. waveshare_amoled_216 or waveshare_amoled_18.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PORT="$1"
+BOARD="$1"
+PORT="$2"
+
+if [ -z "$BOARD" ]; then
+    echo "Error: board env name is required."
+    echo "Usage: $0 <board> [port]"
+    echo "Available boards:"
+    grep -E '^\[env:' "$SCRIPT_DIR/firmware/platformio.ini" | sed 's/\[env:/  /;s/\]//'
+    exit 1
+fi
 
 if [ -z "$PORT" ]; then
     PORT=$(ls /dev/cu.usbmodem* 2>/dev/null | head -1)
@@ -23,11 +34,12 @@ if ! command -v pio >/dev/null; then
 fi
 
 echo "=== Flashing Clawdmeter ==="
-echo "Port: $PORT"
+echo "Board: $BOARD"
+echo "Port:  $PORT"
 echo ""
 
 cd "$SCRIPT_DIR/firmware"
-pio run -t upload --upload-port "$PORT"
+pio run -e "$BOARD" -t upload --upload-port "$PORT"
 
 echo ""
 echo "=== Done ==="

--- a/flash.sh
+++ b/flash.sh
@@ -1,16 +1,31 @@
 #!/bin/bash
-# Build and flash firmware to the SC01 Plus.
+# Build and flash Clawdmeter firmware on Linux.
+# Usage:
+#   ./flash.sh <board>                  # default port /dev/ttyACM0
+#   ./flash.sh <board> /dev/ttyACM1     # explicit USB serial port
+#
+# <board> is the PlatformIO env name, e.g. waveshare_amoled_216 or waveshare_amoled_18.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PORT="${1:-/dev/ttyACM0}"
+BOARD="$1"
+PORT="${2:-/dev/ttyACM0}"
 
-echo "=== Flashing Claude Usage Tracker ==="
-echo "Port: $PORT"
+if [ -z "$BOARD" ]; then
+    echo "Error: board env name is required."
+    echo "Usage: $0 <board> [port]"
+    echo "Available boards:"
+    grep -E '^\[env:' "$SCRIPT_DIR/firmware/platformio.ini" | sed 's/\[env:/  /;s/\]//'
+    exit 1
+fi
+
+echo "=== Flashing Clawdmeter ==="
+echo "Board: $BOARD"
+echo "Port:  $PORT"
 echo ""
 
 cd "$SCRIPT_DIR/firmware"
-~/.platformio/penv/bin/pio run -t upload --upload-port "$PORT"
+~/.platformio/penv/bin/pio run -e "$BOARD" -t upload --upload-port "$PORT"
 
 echo ""
 echo "=== Done! ==="


### PR DESCRIPTION
Currently, the flash scripts flash ALL environements, which is clearly not what we want. The flash scripts now take in a mandatory argument specifying which argument to flash (e.g. waveshare_amoled_216).