### PR TITLE
Add Waveshare ESP32-S3-Touch-AMOLED-2.06 board port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,13 @@ selected via PlatformIO's `build_src_filter`. Adding a board means dropping in
 a new folder + a new `[env:...]` block — `main.cpp`, `ui.cpp`, and `splash.cpp`
 never see board-specific code. See [`docs/porting/adding-a-board.md`](docs/porting/adding-a-board.md).
 
-Four ports today (two SoC families, two panel sizes):
+Five ports today (two SoC families, three panel sizes):
 
 - `boards/waveshare_amoled_216/` — original Waveshare ESP32-S3-Touch-AMOLED-2.16 (CO5300, 480×480 square, CST9220 touch, IMU rotation). Build env: `waveshare_amoled_216`.
 - `boards/waveshare_amoled_18/` — Waveshare ESP32-S3-Touch-AMOLED-1.8 (368×448 portrait, XCA9554 IO expander). Build env: `waveshare_amoled_18`. **Two panel revisions are auto-detected at boot** (`board_rev()` in `board_init.cpp`, enum in `board_rev.h`): original = SH8601 display + FT3168 touch (0x38); later = CO5300 display + CST816 touch (0x15). One binary drives both.
 - `boards/waveshare_amoled_216_c6/` — Waveshare ESP32-C6-Touch-AMOLED-2.16 (SH8601, 480×480, CST9217 touch). Build env: `waveshare_amoled_216_c6`. ESP32-C6 SoC: single-core RISC-V, **no PSRAM**, BLE 5 only.
 - `boards/waveshare_amoled_18_c6/` — Waveshare ESP32-C6-Touch-AMOLED-1.8 (368×448 portrait, SH8601, FT3168 touch, TCA9554 expander). Build env: `waveshare_amoled_18_c6`. Same panel as the S3 1.8 but on the C6 SoC. All subsystems (display, touch, BOOT + PWR buttons, battery, BLE) verified on hardware.
+- `boards/waveshare_amoled_206/` — Waveshare ESP32-S3-Touch-AMOLED-2.06 (CO5300, 410×502 watch form factor, FT3168 touch, no IO expander, 32 MB flash, PCF85063 RTC, ES8311 codec). Build env: `waveshare_amoled_206`. Display, touch, battery, IMU init, and BLE verified on hardware; the ES8311 chime path is not wired up (`sound.cpp` no-ops).
 
 **C6 ports have no PSRAM** — shared code gates on `BOARD_HAS_PSRAM` (absent on C6) to use `MALLOC_CAP_INTERNAL` for LVGL/splash buffers, and the `screenshot` serial command is disabled (`LV_USE_SNAPSHOT=0`), so UI changes on a C6 board must be eyeballed on hardware, not auto-captured.
 
@@ -49,6 +50,17 @@ ESP32-C6 sibling of the S3 1.8: same 368×448 SH8601 panel + FocalTech touch, di
 - Orientation: **fixed at 0°**, no rotation (no PSRAM headroom).
 - Buttons: **GPIO 9** (BOOT → Space/voice-mode, active LOW — *not* the docs' GPIO 0/9 guess; confirmed by scan), **AXP2101 PKEY** (PWR → cycle screens; on splash → cycle animations). The PKEY **SHORT-press IRQ fires on release** — that's the edge `power.cpp` acts on. No secondary button.
 
+### AMOLED-2.06 (watch form factor) — `waveshare_amoled_206`
+- Display: **CO5300** AMOLED via QSPI (CS=12, **SCLK=11** ← same as 1.8, SDIO0..3=4..7, RST=8 direct GPIO). 410×502 portrait. Requires **`col_offset1 = 23`** in the `Arduino_CO5300` constructor — the panel's visible viewport sits at a 22–23 column offset inside the controller's internal RAM. Without it, a vertical strip of stale/garbage content shows through on the right edge (23 was picked empirically for centering; Waveshare's reference library uses 22). The 2.16 dodges this because its 480×480 viewport fills the controller's RAM.
+- Touch: **FT3168** via I2C (SDA=15, SCL=14, **INT=38, RST=9** direct GPIO, addr=0x38). Same inline FocalTech reader as the 1.8 port (no GPLv3 `Arduino_DriveBus` dependency). Coordinates verified end-to-end with the BLE reset zone.
+- PMU: AXP2101 @ 0x34 (same chip as 2.16/1.8 — `XPowersLib` reused). PWR button routes through AXP PKEY IRQs (short / long / positive), same path as the 2.16 — no IO expander.
+- IMU: QMI8658 @ 0x6B (initialized for I2C bus health; rotation logic disabled — fixed watch enclosure orientation).
+- RTC: **PCF85063** on the same I2C bus, powered through AXP2101 for retention. Not used by Clawdmeter but present for future features.
+- Audio codec: **ES8311** + ES7210 ADC on the same I2C bus. The amp path is unverified on this board, so `sound.cpp` no-ops (same posture as the C6 1.8) — the shared `chime.cpp` engine is ready to wire up once it's tested on hardware.
+- **No IO expander** despite the Waveshare wiki FAQ implying one. The schematic shows Key3/PWR wired directly to AXP2101 PWRON; touch reset and display reset are direct GPIOs. `board_init()` pulses LCD_RESET (GPIO 8) and TP_RESET (GPIO 9) before display/touch HAL init.
+- Buttons: GPIO 0 (BOOT → Space/voice-mode), AXP PKEY (PWR → cycle screens; hold-to-pair). **No third button**.
+- Flash: 32 MB. Uses `default_32MB.csv` partition table.
+
 ## Architecture
 
 ```text
@@ -65,6 +77,7 @@ firmware/src/
     waveshare_amoled_18/    — SH8601 + FT3168 + AXP + XCA9554 (PWR via EXIO4), no rotation
     waveshare_amoled_216_c6/— C6: SH8601 + CST9217 + AXP PKEY, no PSRAM
     waveshare_amoled_18_c6/ — C6: SH8601 + FT3168 + AXP PKEY + TCA9554 (gates power), no PSRAM
+    waveshare_amoled_206/   — CO5300 + FT3168 + AXP PKEY, no IO expander, 32 MB, no rotation
     template/               — copy this to bootstrap a new port
   main.cpp                  — setup() + loop(): HAL calls only, zero #ifdef BOARD_*
   ui.{h,cpp}                — 3-screen UI (splash, usage, bluetooth). compute_layout() picks fonts/positions from board_caps() (responsive — current breakpoint: H >= 460 → large, else compact)
@@ -91,6 +104,7 @@ pio run -d firmware -e waveshare_amoled_216                                     
 pio run -d firmware -e waveshare_amoled_18                                      # build 1.8 (S3)
 pio run -d firmware -e waveshare_amoled_216_c6                                  # build 2.16 (C6)
 pio run -d firmware -e waveshare_amoled_18_c6                                   # build 1.8 (C6)
+pio run -d firmware -e waveshare_amoled_206                                     # build 2.06 (S3, watch)
 pio run -d firmware -e waveshare_amoled_18 -t upload --upload-port /dev/cu.usbmodem101   # flash 1.8 on macOS
 pio run -d firmware -e waveshare_amoled_216 -t upload --upload-port /dev/ttyACM0         # flash 2.16 on Linux
 # C6 boards: same native USB-JTAG flashing; flag a chip mismatch ("This chip is ESP32-C6,

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Boards supported out of the box:
 - [Waveshare ESP32-C6-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-c6-touch-amoled-2.16.htm?&aff_id=149786) 
 - [Waveshare ESP32-S3-Touch-AMOLED-1.8](https://www.waveshare.com/esp32-s3-touch-amoled-1.8.htm?&aff_id=149786)
 - [Waveshare ESP32-C6-Touch-AMOLED-1.8](https://www.waveshare.com/esp32-c6-touch-amoled-1.8.htm?&aff_id=149786)
+- [Waveshare ESP32-S3-Touch-AMOLED-2.06](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm?&aff_id=149786)
 
 > Please check if a pull request exists for your alternative hardware port before opening a new one, providing QA feedback and testing on the same hardware is more valuable than duplicate pull requests.
 

--- a/docs/porting/adding-a-board.md
+++ b/docs/porting/adding-a-board.md
@@ -97,7 +97,16 @@ Optional:
   in platformio.ini (check `board_build.arduino.memory_type = qio_opi`);
   IO expander not released before `gfx->begin()` (run `io_expander_init()`
   from `board_init()`); GFX library version too old to know about your
-  panel chip.
+  panel chip; reset line not pulsed before `gfx->begin()` (do it in
+  `board_init()` for direct-GPIO resets, or via the IO expander otherwise).
+- **Display works but a vertical strip of garbage/stale content shows on
+  one edge.** CO5300-based panels expose their visible viewport at a
+  horizontal offset inside the controller's internal RAM, and the offset
+  varies per physical panel size. The 2.16" port uses `col_offset1 = 0`,
+  the 2.06" uses `col_offset1 = 23`. When adding a new CO5300 board,
+  grab Waveshare's reference value from their `Mylibrary/pin_config.h`
+  (or equivalent) and fine-tune ±1 if centering looks off. SH8601 panels
+  don't have this issue.
 - **Touch reads zeros / wrong coordinates.** The HAL hands LVGL whatever
   the controller reports — apply any axis swap / mirror inside your
   `touch.cpp`. CST9220 needs `setSwapXY(true)` + `setMirrorXY(true,

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -275,3 +275,69 @@ lib_deps =
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+
+[env:waveshare_amoled_206]
+; Waveshare ESP32-S3-Touch-AMOLED-2.06 — 410x502 watch form factor.
+; CO5300 panel (as on the S3 2.16) + FT3168 touch (as on the S3 1.8), AXP2101
+; PKEY for PWR, no IO expander. Ships with 32 MB flash.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+board_upload.flash_size = 32MB
+board_upload.maximum_size = 33554432
+board_build.partitions = default_32MB.csv
+upload_speed = 921600
+monitor_speed = 115200
+
+build_src_filter =
+    +<*>
+    -<boards/>
+    +<boards/waveshare_amoled_206/>
+
+build_flags =
+    -DBOARD_AMOLED_206
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    ; AXP2101 PMU
+    -DXPOWERS_CHIP_AXP2101
+    ; NimBLE config — peripheral, 2 simultaneous connections so the OS can
+    ; hold the HID link (Space key from BOOT button) while the daemon holds
+    ; its own connection for the custom data service.
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    ; Peripheral Preferred Connection Parameters — see the waveshare_amoled_216
+    ; env for the full rationale (Windows supervision-timeout churn fix).
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MIN_CONN_INTERVAL=12
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MAX_CONN_INTERVAL=24
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SLAVE_LATENCY=0
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SUPERVISION_TMO=600
+    ; LVGL config via build flags
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    ; 1.6.4+ is required by Arduino ESP32 Core 3.x (spiFrequencyToClockDiv
+    ; signature changed); 1.5.x fails to compile against this platform.
+    moononournation/GFX Library for Arduino@^1.6.4
+    lewisxhe/SensorLib@^0.2.6
+    lewisxhe/XPowersLib@^0.2.7
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/src/boards/waveshare_amoled_206/board.h
+++ b/firmware/src/boards/waveshare_amoled_206/board.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// Waveshare ESP32-S3-Touch-AMOLED-2.06 — watch-form-factor AMOLED kit.
+// 410x502 CO5300 + FT3168 touch + AXP2101 PMU + QMI8658 IMU + PCF85063 RTC
+// + ES8311 codec. No IO expander; LCD and touch resets are direct GPIOs.
+// IMU is present but rotation is disabled (watch enclosure is fixed-orientation).
+
+#define BOARD_NAME           "Waveshare AMOLED 2.06"
+
+// ---- Display geometry ----
+#define LCD_WIDTH            410
+#define LCD_HEIGHT           502
+
+// ---- QSPI display pins (CO5300) — from Waveshare's pin_config.h ----
+#define LCD_CS               12
+#define LCD_SCLK             11        // differs from 2.16 (GPIO 38)
+#define LCD_SDIO0            4
+#define LCD_SDIO1            5
+#define LCD_SDIO2            6
+#define LCD_SDIO3            7
+#define LCD_RESET            8         // direct GPIO, not via expander
+
+// ---- I2C bus (PMU + IMU + RTC + codec share this bus) ----
+#define IIC_SDA              15
+#define IIC_SCL              14
+
+// ---- Touch (FT3168 via vendored minimal I2C reader; shares I2C with PMU) ----
+#define TP_INT               38
+#define TP_RESET             9
+#define FT3168_ADDR          0x38
+
+// ---- PMU ----
+#define AXP2101_ADDR         0x34
+
+// ---- Buttons ----
+#define BTN_BACK_GPIO        0     // BOOT — primary, Space (PTT)
+// PWR button uses AXP2101 PKEY short-press IRQ (no IO expander on this board,
+// despite what the wiki FAQ implies — see schematic, Key3 wires to AXP PWRON).
+// There is no third button on this board.
+
+// ---- Capability flags ----
+#define BOARD_HAS_SECONDARY_BUTTON 0
+#define BOARD_HAS_ROTATION         0   // watch form factor: fixed orientation
+#define BOARD_HAS_IMU              1   // present + initialized, but rotation off
+#define BOARD_HAS_BATTERY          1
+#define BOARD_HAS_IO_EXPANDER      0

--- a/firmware/src/boards/waveshare_amoled_206/board_init.cpp
+++ b/firmware/src/boards/waveshare_amoled_206/board_init.cpp
@@ -1,0 +1,19 @@
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// AMOLED-2.06 has no IO expander. LCD_RESET and TP_RESET are direct GPIOs,
+// pulsed here before display_hal_init / touch_hal_init run so the CO5300
+// and FT3168 are both out of reset by the time their drivers probe them.
+extern "C" void board_init(void) {
+    pinMode(LCD_RESET, OUTPUT);
+    pinMode(TP_RESET,  OUTPUT);
+    digitalWrite(LCD_RESET, LOW);
+    digitalWrite(TP_RESET,  LOW);
+    delay(10);
+    digitalWrite(LCD_RESET, HIGH);
+    digitalWrite(TP_RESET,  HIGH);
+    delay(50);  // CO5300 needs ~10ms post-reset before first command
+
+    Wire.begin(IIC_SDA, IIC_SCL);
+}

--- a/firmware/src/boards/waveshare_amoled_206/caps.cpp
+++ b/firmware/src/boards/waveshare_amoled_206/caps.cpp
@@ -1,0 +1,14 @@
+#include "../../hal/board_caps.h"
+#include "board.h"
+
+static const BoardCaps caps = {
+    .name = BOARD_NAME,
+    .width = LCD_WIDTH,
+    .height = LCD_HEIGHT,
+    .button_count = 1,
+    .has_rotation = false,
+    .has_battery = true,
+    .has_imu = true,
+};
+
+const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_amoled_206/display.cpp
+++ b/firmware/src/boards/waveshare_amoled_206/display.cpp
@@ -1,0 +1,55 @@
+#include "../../hal/display_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+// AMOLED-2.06 is fixed at 0° (watch enclosure). No CPU rotation, no rot_buf.
+// LCD_RESET is a direct GPIO; board_init() pulses it before this driver runs,
+// so we hand the GFX driver GFX_NOT_DEFINED.
+
+static Arduino_DataBus* bus = nullptr;
+static Arduino_CO5300*  gfx = nullptr;
+
+void display_hal_init(void) {
+    bus = new Arduino_ESP32QSPI(
+        LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
+    // CO5300 constructor: (bus, rst, rotation, w, h, col_off1, row_off1, col_off2, row_off2)
+    // col_offset1 = 22: the 2.06" panel exposes its 410-wide viewport at a 22-pixel
+    // horizontal offset inside the controller's internal 454-wide RAM. Without this,
+    // writes land at the wrong columns and a vertical strip of stale content shows
+    // through on the right. Value matches Waveshare's reference Mylibrary.
+    gfx = new Arduino_CO5300(
+        bus, GFX_NOT_DEFINED /* reset pulsed in board_init */, 0,
+        LCD_WIDTH, LCD_HEIGHT, 23, 0, 0, 0);
+}
+
+void display_hal_begin(void) {
+    gfx->begin();
+    gfx->fillScreen(0x0000);
+    gfx->setBrightness(200);
+}
+
+void display_hal_set_brightness(uint8_t level) {
+    if (gfx) gfx->setBrightness(level);
+}
+
+void display_hal_fill_screen(uint16_t color) {
+    if (gfx) gfx->fillScreen(color);
+}
+
+void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
+                             const uint16_t* pixels) {
+    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+}
+
+void display_hal_tick(void) {
+    // No rotation handling needed on this board.
+}
+
+// CO5300 requires even-aligned flush regions.
+void display_hal_round_area(int32_t* x1, int32_t* y1, int32_t* x2, int32_t* y2) {
+    *x1 = *x1 & ~1;
+    *y1 = *y1 & ~1;
+    *x2 = *x2 | 1;
+    *y2 = *y2 | 1;
+}

--- a/firmware/src/boards/waveshare_amoled_206/imu.cpp
+++ b/firmware/src/boards/waveshare_amoled_206/imu.cpp
@@ -1,0 +1,27 @@
+#include "../../hal/imu_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <SensorQMI8658.hpp>
+
+// QMI8658 is present on this board, but rotation is disabled in the
+// watch enclosure. We still initialize the chip so the I2C bus is
+// healthy and future features (step counting, tap detect) can use it.
+
+static SensorQMI8658 imu;
+static bool imu_ok = false;
+
+void imu_hal_init(void) {
+    if (!imu.begin(Wire, QMI8658_L_SLAVE_ADDRESS, IIC_SDA, IIC_SCL)) {
+        Serial.println("QMI8658 init failed");
+        return;
+    }
+    Serial.println("QMI8658 init OK");
+    imu_ok = true;
+}
+
+void imu_hal_tick(void) {
+    (void)imu_ok;  // nothing to poll while rotation is disabled
+}
+
+uint8_t imu_hal_rotation_quadrant(void) { return 0; }

--- a/firmware/src/boards/waveshare_amoled_206/input.cpp
+++ b/firmware/src/boards/waveshare_amoled_206/input.cpp
@@ -1,0 +1,14 @@
+#include "../../hal/input_hal.h"
+#include "board.h"
+#include <Arduino.h>
+
+void input_hal_init(void) {
+    pinMode(BTN_BACK_GPIO, INPUT_PULLUP);
+}
+
+bool input_hal_is_held(InputButton btn) {
+    if (btn == INPUT_BTN_PRIMARY) {
+        return digitalRead(BTN_BACK_GPIO) == LOW;
+    }
+    return false;  // no secondary button on this board
+}

--- a/firmware/src/boards/waveshare_amoled_206/power.cpp
+++ b/firmware/src/boards/waveshare_amoled_206/power.cpp
@@ -1,0 +1,93 @@
+#include "../../hal/power_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <XPowersLib.h>
+
+// PWR button comes from AXP2101 PKEY IRQs (same path as 2.16):
+//   SHORT    — quick tap (cycle splash animations)
+//   LONG     — ~1.5s mark, starts the hold-to-pair countdown
+//   POSITIVE — release edge, completes/cancels the gesture
+
+#define BATTERY_POLL_MS  2000
+#define CHARGING_POLL_MS 500
+#define PWR_POLL_MS      50
+
+static XPowersPMU pmu;
+
+static int      cached_pct        = -1;
+static bool     cached_charging   = false;
+static bool     cached_vbus       = false;
+static bool     pwr_pressed_flag  = false;
+static bool     pwr_long_flag     = false;
+static bool     pwr_released_flag = false;
+static uint32_t last_battery_ms   = 0;
+static uint32_t last_charging_ms  = 0;
+static uint32_t last_pwr_ms       = 0;
+
+void power_hal_init(void) {
+    if (!pmu.begin(Wire, AXP2101_ADDR, IIC_SDA, IIC_SCL)) {
+        Serial.println("AXP2101 init failed");
+        return;
+    }
+    Serial.println("AXP2101 init OK");
+
+    pmu.enableBattDetection();
+    pmu.enableBattVoltageMeasure();
+
+    pmu.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
+    pmu.clearIrqStatus();
+    pmu.enableIRQ(XPOWERS_AXP2101_PKEY_SHORT_IRQ
+                | XPOWERS_AXP2101_PKEY_LONG_IRQ
+                | XPOWERS_AXP2101_PKEY_POSITIVE_IRQ);
+
+    // Default press-off (force-shutdown) is 6s, only 2s after the pair gesture
+    // arms at ~3s and disarms at ~6s. Bump to 8s so a slightly-too-long hold
+    // doesn't shut the device down mid-gesture.
+    pmu.setPowerKeyPressOffTime(XPOWERS_POWEROFF_8S);
+
+    cached_charging = pmu.isCharging();
+    cached_vbus     = pmu.isVbusIn();
+    cached_pct = pmu.getBatteryPercent();
+}
+
+void power_hal_tick(void) {
+    uint32_t now = millis();
+
+    if (now - last_charging_ms >= CHARGING_POLL_MS) {
+        last_charging_ms = now;
+        cached_charging = pmu.isCharging();
+        cached_vbus     = pmu.isVbusIn();
+    }
+    if (now - last_battery_ms >= BATTERY_POLL_MS) {
+        last_battery_ms = now;
+        cached_pct = pmu.getBatteryPercent();
+    }
+    if (now - last_pwr_ms >= PWR_POLL_MS) {
+        last_pwr_ms = now;
+        pmu.getIrqStatus();
+        if (pmu.isPekeyShortPressIrq())    pwr_pressed_flag  = true;
+        if (pmu.isPekeyLongPressIrq())     pwr_long_flag     = true;
+        if (pmu.isPekeyPositiveIrq())      pwr_released_flag = true;
+        pmu.clearIrqStatus();
+    }
+}
+
+int  power_hal_battery_pct(void) { return cached_pct; }
+bool power_hal_is_charging(void) { return cached_charging; }
+bool power_hal_is_vbus_in(void)  { return cached_vbus; }
+
+bool power_hal_pwr_pressed(void) {
+    if (pwr_pressed_flag) { pwr_pressed_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_long_pressed(void) {
+    if (pwr_long_flag) { pwr_long_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_released(void) {
+    if (pwr_released_flag) { pwr_released_flag = false; return true; }
+    return false;
+}

--- a/firmware/src/boards/waveshare_amoled_206/sound.cpp
+++ b/firmware/src/boards/waveshare_amoled_206/sound.cpp
@@ -1,0 +1,11 @@
+#include "../../hal/sound_hal.h"
+
+// AMOLED-2.06: an ES8311 codec (plus an ES7210 ADC) sits on the shared I2C bus,
+// but this port never brings that path up and it's unverified on hardware — so
+// sound output is a no-op. The real ES8311 chime engine lives in ../../chime.cpp
+// and is wired up by the 2.16 and S3 1.8 ports behind BOARD_HAS_SOUND; enable it
+// here once the amp pin and codec wiring are confirmed on this board.
+
+void sound_hal_init(void) {}
+void sound_hal_tick(void) {}
+void sound_hal_play_reset(void) {}

--- a/firmware/src/boards/waveshare_amoled_206/touch.cpp
+++ b/firmware/src/boards/waveshare_amoled_206/touch.cpp
@@ -1,0 +1,71 @@
+#include "../../hal/touch_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// Minimal FT3168 reader (FocalTech standard register layout). Shared
+// verbatim with the AMOLED-1.8 port — same chip, different INT/RESET pins.
+//   reg 0x02:        low nibble = active finger count
+//   reg 0x03 / 0x04: X1 high (low nibble) + X1 low
+//   reg 0x05 / 0x06: Y1 high (low nibble) + Y1 low
+
+static volatile bool     touch_data_ready = false;
+static volatile bool     touch_pressed = false;
+static volatile uint16_t touch_x = 0;
+static volatile uint16_t touch_y = 0;
+
+static void IRAM_ATTR touch_isr(void) {
+    touch_data_ready = true;
+}
+
+static void ft3168_read_into_shared_state(void) {
+    Wire.beginTransmission(FT3168_ADDR);
+    Wire.write(0x02);
+    if (Wire.endTransmission(false) != 0) { touch_pressed = false; return; }
+    if (Wire.requestFrom(FT3168_ADDR, (uint8_t)5) != 5) { touch_pressed = false; return; }
+    uint8_t fingers = Wire.read() & 0x0F;
+    uint8_t xH = Wire.read();
+    uint8_t xL = Wire.read();
+    uint8_t yH = Wire.read();
+    uint8_t yL = Wire.read();
+    if (fingers == 0 || fingers > 5) {
+        touch_pressed = false;
+        return;
+    }
+    touch_x = ((uint16_t)(xH & 0x0F) << 8) | xL;
+    touch_y = ((uint16_t)(yH & 0x0F) << 8) | yL;
+    touch_pressed = true;
+}
+
+void touch_hal_init(void) {
+    // TP_RESET was already pulsed in board_init(). Just configure the chip.
+    // Power-mode register 0xA5 = 0x00: active scanning.
+    Wire.beginTransmission(FT3168_ADDR);
+    Wire.write(0xA5);
+    Wire.write(0x00);
+    Wire.endTransmission();
+
+    // Log device ID for diagnostics (0xA0). Don't fail if it reads weird —
+    // Waveshare's FT3168 variants sometimes report unexpected IDs.
+    Wire.beginTransmission(FT3168_ADDR);
+    Wire.write(0xA0);
+    if (Wire.endTransmission(false) == 0 && Wire.requestFrom(FT3168_ADDR, (uint8_t)1) == 1) {
+        Serial.printf("FT3168 ID=0x%02X\n", Wire.read());
+    } else {
+        Serial.println("FT3168 ID read failed");
+    }
+
+    pinMode(TP_INT, INPUT_PULLUP);
+    attachInterrupt(TP_INT, touch_isr, FALLING);
+    Serial.println("FT3168 attached on INT pin");
+}
+
+void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
+    if (touch_data_ready) {
+        touch_data_ready = false;
+        ft3168_read_into_shared_state();
+    }
+    *x = touch_x;
+    *y = touch_y;
+    *pressed = touch_pressed;
+}


### PR DESCRIPTION
## Summary

Adds a board port for the [Waveshare ESP32-S3-Touch-AMOLED-2.06](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm) — a 410×502 watch-form-factor AMOLED kit. The port is a hybrid of the existing ports:

- **CO5300 display + AXP PKEY for PWR** (like the 2.16 port)
- **FT3168 touch + fixed orientation** (like the 1.8 port)
- **No IO expander** — LCD_RESET and TP_RESET are direct GPIOs pulsed in `board_init()`
- **32 MB flash** with `default_32MB.csv` partition table

Pin assignments were taken from Waveshare's reference `Mylibrary/pin_config.h` in their [demo repo](https://github.com/waveshareteam/ESP32-S3-Touch-AMOLED-2.06).

## CO5300 col_offset gotcha (worth highlighting)

The 2.06 panel exposes its visible 410-wide viewport at a horizontal offset inside the CO5300's internal RAM. Without passing the right `col_offset1` to the `Arduino_CO5300` constructor, framebuffer writes land at the wrong columns and a vertical strip of stale boot content shows through on the right edge. Waveshare's library uses `col_offset1 = 22`; this port uses `23` after fine-tuning for centering on one unit. The 2.16" port doesn't have this issue because its 480×480 viewport fills the controller's RAM. I've added a note to `docs/porting/adding-a-board.md` so the next CO5300 porter doesn't lose an afternoon to this.

## Rebased onto current main

This branch was originally cut before the sound HAL, the hold-to-pair gesture, and the BLE supervision-timeout fix landed. It's now rebased onto current `main`, which required three additions to the port beyond the original hardware bring-up:

- **`sound.cpp`** — `main.cpp` now calls `sound_hal_init/tick/play_reset` unconditionally, so the port wouldn't link without it. The 2.06 does have an ES8311 codec on the shared I2C bus, but the amp path is unverified on this board, so this no-ops (same posture as the C6 1.8 port). The shared `chime.cpp` engine is ready to wire up once someone tests it on this hardware.
- **`power.cpp`** — added `power_hal_pwr_long_pressed()` / `power_hal_pwr_released()` for hold-to-pair, mirroring the 2.16's AXP PKEY implementation (LONG + POSITIVE IRQs, plus the 8s press-off bump).
- **`platformio.ini`** — picked up the PPCP connection-parameter flags from #106 so this board doesn't ship with the Windows supervision-timeout churn.

An earlier revision of this PR also tweaked `flash-mac.sh` to take an optional env argument. #30 fixed that same footgun more strictly on `main`, so that change is dropped — this PR no longer touches `flash-mac.sh`.

## Test plan

Verified on hardware (pre-rebase build):

- [x] Display renders correctly with `col_offset1 = 23` — splash animation centered, no edge artifacts
- [x] AXP2101 PMU init OK, battery percent reads correctly
- [x] QMI8658 IMU init OK (rotation disabled — watch enclosure is fixed orientation)
- [x] FT3168 touch — basic events fire (tap-to-toggle splash) and coordinates are accurate (BLE reset zone hit-area works)
- [x] BLE pairs as "Clawdmeter", daemon (macOS) connects and pushes usage data successfully

Verified post-rebase:

- [x] `pio run -e waveshare_amoled_206` builds clean (1.34 MB, 10.2% of the app partition, 31.6% RAM)
- [x] All four existing envs still build (216, 18, 216_c6, 18_c6)

Not yet exercised on hardware:

- [ ] **Hold-to-pair on the 2.06.** The gesture postdates the original bring-up, so the PKEY LONG/POSITIVE IRQ path hasn't been run on this board. The AXP2101 is the same part at the same address as the 2.16 and the button wires straight to PWRON, so I'd expect it to behave identically — but flagging it rather than implying it was tested. Happy to confirm once I have the device in front of me again.

Photo of the working device available on request.
