### PR TITLE
feat(boards): Add Seeed SenseCap Indicator D1L support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ firmware/.vscode/
 # Claude Code
 .claude/
 
+# Git worktrees
+.worktrees/
+
 # Node tooling deps (npm install --no-save)
 tools/node_modules/
 tools/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,10 @@ firmware/.vscode/
 tools/node_modules/
 tools/package-lock.json
 
-# Mac daemon venv
+# Python venvs
 daemon/.venv/
+firmware/.venv/
+firmware/.pio_home/
 
 # Python bytecode cache
 __pycache__/

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -177,3 +177,50 @@ lib_deps =
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+
+[env:sensecap_indicator_d1l]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_build.partitions = default_16MB.csv
+upload_speed = 921600
+monitor_speed = 115200
+
+build_src_filter =
+    +<*>
+    -<boards/>
+    +<boards/sensecap_indicator_d1l/>
+
+build_flags =
+    -DBOARD_SENSECAP_INDICATOR_D1L
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    moononournation/GFX Library for Arduino@^1.6.4
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -184,9 +184,9 @@ platform = https://github.com/pioarduino/platform-espressif32/releases/download/
 board = esp32-s3-devkitc-1
 framework = arduino
 board_build.arduino.memory_type = qio_opi
-board_upload.flash_size = 16MB
-board_upload.maximum_size = 16777216
-board_build.partitions = default_16MB.csv
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
+board_build.partitions = default_8MB.csv
 upload_speed = 921600
 monitor_speed = 115200
 

--- a/firmware/src/boards/sensecap_indicator_d1l/board.h
+++ b/firmware/src/boards/sensecap_indicator_d1l/board.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// Seeed Studio SenseCap Indicator D1L
+// 480x480 ST7701S RGB parallel + FT6x36 touch + PCA9535 expander.
+// ESP32-S3 with OPI PSRAM. No PMU, no battery, no IMU.
+
 #define BOARD_NAME  "SenseCap Indicator D1L"
 
 #define LCD_WIDTH   480

--- a/firmware/src/boards/sensecap_indicator_d1l/board.h
+++ b/firmware/src/boards/sensecap_indicator_d1l/board.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#define BOARD_NAME  "SenseCap Indicator D1L"
+
+#define LCD_WIDTH   480
+#define LCD_HEIGHT  480
+
+// RGB parallel display pins (ST7701S)
+// PCB routes ESP32-S3 GPIO_n to LCD data bus D[15-n] (bit-reversal)
+#define SENSECAP_LCD_DE     18
+#define SENSECAP_LCD_VSYNC  17
+#define SENSECAP_LCD_HSYNC  16
+#define SENSECAP_LCD_PCLK   21
+#define SENSECAP_LCD_R0      4
+#define SENSECAP_LCD_R1      3
+#define SENSECAP_LCD_R2      2
+#define SENSECAP_LCD_R3      1
+#define SENSECAP_LCD_R4      0
+#define SENSECAP_LCD_G0     10
+#define SENSECAP_LCD_G1      9
+#define SENSECAP_LCD_G2      8
+#define SENSECAP_LCD_G3      7
+#define SENSECAP_LCD_G4      6
+#define SENSECAP_LCD_G5      5
+#define SENSECAP_LCD_B0     15
+#define SENSECAP_LCD_B1     14
+#define SENSECAP_LCD_B2     13
+#define SENSECAP_LCD_B3     12
+#define SENSECAP_LCD_B4     11
+#define SENSECAP_LCD_SPI_SCK  41
+#define SENSECAP_LCD_SPI_MOSI 48
+#define SENSECAP_BACKLIGHT    45
+
+// I2C bus (touch + PCA9535 expander)
+#define IIC_SDA  39
+#define IIC_SCL  40
+
+// Touch (FT6x36, non-standard address on this board)
+#define SENSECAP_TOUCH_ADDR  0x48
+
+// PCA9535 I2C expander
+// P04 = ST7701S SPI CS (active LOW during init sequence)
+// P07 = touch RST (active LOW pulse to reset)
+#define SENSECAP_PCA9535_ADDR  0x20
+#define SENSECAP_LCD_CS_PORT   4
+#define SENSECAP_TP_RST_PIN    7
+
+// Physical button
+// GPIO 38 used as edge-detected PWR button (screen cycle / wake from sleep).
+// NOT wired as INPUT_BTN_PRIMARY — device has no microphone for PTT.
+#define BTN_BACK_GPIO  38
+
+// Capability flags
+#define BOARD_HAS_SECONDARY_BUTTON 0
+#define BOARD_HAS_ROTATION         0
+#define BOARD_HAS_IMU              0
+#define BOARD_HAS_BATTERY          0
+#define BOARD_HAS_IO_EXPANDER      1

--- a/firmware/src/boards/sensecap_indicator_d1l/board_init.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/board_init.cpp
@@ -1,7 +1,9 @@
 #include "board.h"
+#include "io_expander.h"
 #include <Arduino.h>
 #include <Wire.h>
 
 extern "C" void board_init(void) {
     Wire.begin(IIC_SDA, IIC_SCL);
+    io_expander_init();
 }

--- a/firmware/src/boards/sensecap_indicator_d1l/board_init.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/board_init.cpp
@@ -1,0 +1,7 @@
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+extern "C" void board_init(void) {
+    Wire.begin(IIC_SDA, IIC_SCL);
+}

--- a/firmware/src/boards/sensecap_indicator_d1l/caps.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/caps.cpp
@@ -1,0 +1,14 @@
+#include "../../hal/board_caps.h"
+#include "board.h"
+
+static const BoardCaps caps = {
+    .name         = BOARD_NAME,
+    .width        = LCD_WIDTH,
+    .height       = LCD_HEIGHT,
+    .button_count = (uint8_t)(1 + BOARD_HAS_SECONDARY_BUTTON),
+    .has_rotation = (bool)BOARD_HAS_ROTATION,
+    .has_battery  = (bool)BOARD_HAS_BATTERY,
+    .has_imu      = (bool)BOARD_HAS_IMU,
+};
+
+const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/sensecap_indicator_d1l/display.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/display.cpp
@@ -1,21 +1,184 @@
 #include "../../hal/display_hal.h"
 #include "board.h"
+#include "io_expander.h"
 #include <Arduino.h>
 #include <Arduino_GFX_Library.h>
+
+// ST7701S init sequence for SenseCap Indicator D1L.
+// Based on Arduino_GFX type9 with two corrections:
+//   1. Register 0xCD: 0x00 → 0x08  (wrong value produces a green tint on all content)
+//   2. Register 0xC0 omitted entirely (LovyanGFX leaves it at default; no regressions)
+static const uint8_t st7701_init_ops[] = {
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x10,
+
+    WRITE_C8_D16, 0xC1, 0x0D, 0x02,
+    WRITE_C8_D16, 0xC2, 0x31, 0x05,
+    WRITE_C8_D8,  0xCD, 0x08,
+
+    WRITE_COMMAND_8, 0xB0,
+    WRITE_BYTES, 16,
+    0x00, 0x11, 0x18, 0x0E,
+    0x11, 0x06, 0x07, 0x08,
+    0x07, 0x22, 0x04, 0x12,
+    0x0F, 0xAA, 0x31, 0x18,
+
+    WRITE_COMMAND_8, 0xB1,
+    WRITE_BYTES, 16,
+    0x00, 0x11, 0x19, 0x0E,
+    0x12, 0x07, 0x08, 0x08,
+    0x08, 0x22, 0x04, 0x11,
+    0x11, 0xA9, 0x32, 0x18,
+
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x11,
+
+    WRITE_C8_D8, 0xB0, 0x60,
+    WRITE_C8_D8, 0xB1, 0x32,
+    WRITE_C8_D8, 0xB2, 0x07,
+    WRITE_C8_D8, 0xB3, 0x80,
+    WRITE_C8_D8, 0xB5, 0x49,
+    WRITE_C8_D8, 0xB7, 0x85,
+    WRITE_C8_D8, 0xB8, 0x21,
+    WRITE_C8_D8, 0xC1, 0x78,
+    WRITE_C8_D8, 0xC2, 0x78,
+
+    WRITE_COMMAND_8, 0xE0,
+    WRITE_BYTES, 3, 0x00, 0x1B, 0x02,
+
+    WRITE_COMMAND_8, 0xE1,
+    WRITE_BYTES, 11,
+    0x08, 0xA0, 0x00, 0x00,
+    0x07, 0xA0, 0x00, 0x00,
+    0x00, 0x44, 0x44,
+
+    WRITE_COMMAND_8, 0xE2,
+    WRITE_BYTES, 12,
+    0x11, 0x11, 0x44, 0x44,
+    0xED, 0xA0, 0x00, 0x00,
+    0xEC, 0xA0, 0x00, 0x00,
+
+    WRITE_COMMAND_8, 0xE3,
+    WRITE_BYTES, 4, 0x00, 0x00, 0x11, 0x11,
+
+    WRITE_C8_D16, 0xE4, 0x44, 0x44,
+
+    WRITE_COMMAND_8, 0xE5,
+    WRITE_BYTES, 16,
+    0x0A, 0xE9, 0xD8, 0xA0,
+    0x0C, 0xEB, 0xD8, 0xA0,
+    0x0E, 0xED, 0xD8, 0xA0,
+    0x10, 0xEF, 0xD8, 0xA0,
+
+    WRITE_COMMAND_8, 0xE6,
+    WRITE_BYTES, 4, 0x00, 0x00, 0x11, 0x11,
+
+    WRITE_C8_D16, 0xE7, 0x44, 0x44,
+
+    WRITE_COMMAND_8, 0xE8,
+    WRITE_BYTES, 16,
+    0x09, 0xE8, 0xD8, 0xA0,
+    0x0B, 0xEA, 0xD8, 0xA0,
+    0x0D, 0xEC, 0xD8, 0xA0,
+    0x0F, 0xEE, 0xD8, 0xA0,
+
+    WRITE_COMMAND_8, 0xEB,
+    WRITE_BYTES, 7,
+    0x02, 0x00, 0xE4, 0xE4,
+    0x88, 0x00, 0x40,
+
+    WRITE_C8_D16, 0xEC, 0x3C, 0x00,
+
+    WRITE_COMMAND_8, 0xED,
+    WRITE_BYTES, 16,
+    0xAB, 0x89, 0x76, 0x54,
+    0x02, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0x20,
+    0x45, 0x67, 0x98, 0xBA,
+
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x13,
+
+    WRITE_C8_D8, 0xE5, 0xE4,
+
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x00,
+
+    WRITE_C8_D8, 0x3A, 0x60,   // COLMOD=0x60 (RGB666, matches RP2040 boot config)
+
+    WRITE_COMMAND_8, 0x11,     // Sleep Out
+    END_WRITE,
+
+    DELAY, 120,
+
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, 0x21,     // Display Inversion ON (IPS panel)
+    WRITE_COMMAND_8, 0x29,     // Display On
+    END_WRITE,
+};
 
 static Arduino_DataBus*       spi_init_bus = nullptr;
 static Arduino_ESP32RGBPanel* rgb_panel    = nullptr;
 static Arduino_RGB_Display*   gfx         = nullptr;
 
-void display_hal_init(void) {}
-void display_hal_begin(void) {}
-void display_hal_set_brightness(uint8_t level) { (void)level; }
-void display_hal_fill_screen(uint16_t color) { (void)color; }
+void display_hal_init(void) {
+    spi_init_bus = new Arduino_ESP32SPI(
+        GFX_NOT_DEFINED, GFX_NOT_DEFINED,
+        SENSECAP_LCD_SPI_SCK, SENSECAP_LCD_SPI_MOSI, GFX_NOT_DEFINED);
+
+    rgb_panel = new Arduino_ESP32RGBPanel(
+        SENSECAP_LCD_DE, SENSECAP_LCD_VSYNC, SENSECAP_LCD_HSYNC, SENSECAP_LCD_PCLK,
+        SENSECAP_LCD_R0, SENSECAP_LCD_R1, SENSECAP_LCD_R2, SENSECAP_LCD_R3, SENSECAP_LCD_R4,
+        SENSECAP_LCD_G0, SENSECAP_LCD_G1, SENSECAP_LCD_G2, SENSECAP_LCD_G3,
+        SENSECAP_LCD_G4, SENSECAP_LCD_G5,
+        SENSECAP_LCD_B0, SENSECAP_LCD_B1, SENSECAP_LCD_B2, SENSECAP_LCD_B3, SENSECAP_LCD_B4,
+        1, 10, 8, 50,   // hsync: polarity=1, fp=10, pw=8, bp=50
+        1, 10, 8, 20,   // vsync: polarity=1, fp=10, pw=8, bp=20
+        0, 12000000,    // pclk_active_neg=0, prefer_speed=12 MHz
+        false, 0, 0,    // useBigEndian, de_idle_high, pclk_idle_high
+        480 * 10);      // bounce_buffer_size_px — SRAM relay cuts PSRAM bus contention
+
+    gfx = new Arduino_RGB_Display(
+        LCD_WIDTH, LCD_HEIGHT, rgb_panel,
+        2,    // rotation 2 = 180°; panel is mounted upside-down on this board
+        true, // auto_flush
+        spi_init_bus, GFX_NOT_DEFINED,
+        st7701_init_ops, sizeof(st7701_init_ops));
+}
+
+void display_hal_begin(void) {
+    // Assert LCD SPI CS (P04 LOW) so the ST7701S receives the init sequence.
+    // The PCA9535 output register defaults to HIGH at power-on, so without this
+    // step every SPI command is ignored and the display keeps the RP2040's
+    // boot-time settings (wrong colours).
+    io_expander_set(SENSECAP_LCD_CS_PORT, false);
+    gfx->begin();
+    io_expander_set(SENSECAP_LCD_CS_PORT, true);
+
+    gfx->fillScreen(0x0000);
+
+    // PWM backlight — 8-bit resolution at 1 kHz.
+    ledcAttach(SENSECAP_BACKLIGHT, 1000, 8);
+    ledcWrite(SENSECAP_BACKLIGHT, 200);   // matches DISPLAY_DEFAULT_BRIGHTNESS
+}
+
+void display_hal_set_brightness(uint8_t level) {
+    ledcWrite(SENSECAP_BACKLIGHT, level);
+}
+
+void display_hal_fill_screen(uint16_t color) {
+    if (gfx) gfx->fillScreen(color);
+}
+
 void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
                              const uint16_t* pixels) {
-    (void)x; (void)y; (void)w; (void)h; (void)pixels;
+    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
 }
-void display_hal_tick(void) {}
+
+void display_hal_tick(void) {}   // no rotation, no brightness ramp needed
+
 void display_hal_round_area(int32_t* x1, int32_t* y1, int32_t* x2, int32_t* y2) {
+    // RGB parallel panel has no even-alignment requirement; no-op.
     (void)x1; (void)y1; (void)x2; (void)y2;
 }

--- a/firmware/src/boards/sensecap_indicator_d1l/display.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/display.cpp
@@ -105,7 +105,9 @@ static const uint8_t st7701_init_ops[] = {
     WRITE_COMMAND_8, 0xFF,
     WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x00,
 
-    WRITE_C8_D8, 0x3A, 0x60,   // COLMOD=0x60 (RGB666, matches RP2040 boot config)
+    WRITE_C8_D8, 0x3A, 0x60,   // COLMOD: upper nibble 0x6 = 18-bit DPI mode; preserved from
+                               // Seeed RP2040 vendor firmware. Bus is physically 5+6+5 (RGB565);
+                               // panel auto-converts. Do not change to 0x55.
 
     WRITE_COMMAND_8, 0x11,     // Sleep Out
     END_WRITE,

--- a/firmware/src/boards/sensecap_indicator_d1l/display.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/display.cpp
@@ -1,0 +1,21 @@
+#include "../../hal/display_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+static Arduino_DataBus*       spi_init_bus = nullptr;
+static Arduino_ESP32RGBPanel* rgb_panel    = nullptr;
+static Arduino_RGB_Display*   gfx         = nullptr;
+
+void display_hal_init(void) {}
+void display_hal_begin(void) {}
+void display_hal_set_brightness(uint8_t level) { (void)level; }
+void display_hal_fill_screen(uint16_t color) { (void)color; }
+void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
+                             const uint16_t* pixels) {
+    (void)x; (void)y; (void)w; (void)h; (void)pixels;
+}
+void display_hal_tick(void) {}
+void display_hal_round_area(int32_t* x1, int32_t* y1, int32_t* x2, int32_t* y2) {
+    (void)x1; (void)y1; (void)x2; (void)y2;
+}

--- a/firmware/src/boards/sensecap_indicator_d1l/imu.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/imu.cpp
@@ -1,0 +1,5 @@
+#include "../../hal/imu_hal.h"
+
+void    imu_hal_init(void) {}
+void    imu_hal_tick(void) {}
+uint8_t imu_hal_rotation_quadrant(void) { return 0; }

--- a/firmware/src/boards/sensecap_indicator_d1l/input.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/input.cpp
@@ -1,0 +1,9 @@
+#include "../../hal/input_hal.h"
+#include "board.h"
+
+void input_hal_init(void) {}
+
+bool input_hal_is_held(InputButton btn) {
+    (void)btn;
+    return false;
+}

--- a/firmware/src/boards/sensecap_indicator_d1l/io_expander.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/io_expander.cpp
@@ -1,0 +1,8 @@
+#include "io_expander.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+bool io_expander_init(void) { return true; }
+void io_expander_set(uint8_t pin, bool high) { (void)pin; (void)high; }
+bool io_expander_get(uint8_t pin) { (void)pin; return false; }

--- a/firmware/src/boards/sensecap_indicator_d1l/io_expander.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/io_expander.cpp
@@ -3,6 +3,59 @@
 #include <Arduino.h>
 #include <Wire.h>
 
-bool io_expander_init(void) { return true; }
-void io_expander_set(uint8_t pin, bool high) { (void)pin; (void)high; }
-bool io_expander_get(uint8_t pin) { (void)pin; return false; }
+// PCA9535 register map (port 0):
+//   0x00 = input port 0   (read)
+//   0x02 = output port 0  (write)
+//   0x06 = config port 0  (1 = input, 0 = output)
+#define IOX_REG_INPUT   0x00
+#define IOX_REG_OUTPUT  0x02
+#define IOX_REG_CONFIG  0x06
+
+// P04 and P07 are outputs (0); all other pins are inputs (1).
+// 0b01101111 = 0x6F: bits 4 and 7 cleared, rest set.
+#define IOX_CONFIG_MASK    0x6F
+// All outputs HIGH at init: CS deasserted, touch RST released.
+#define IOX_OUTPUT_DEFAULT 0xFF
+
+static uint8_t output_state = IOX_OUTPUT_DEFAULT;
+
+static bool write_reg(uint8_t reg, uint8_t val) {
+    Wire.beginTransmission(SENSECAP_PCA9535_ADDR);
+    Wire.write(reg);
+    Wire.write(val);
+    return Wire.endTransmission() == 0;
+}
+
+static bool read_reg(uint8_t reg, uint8_t& val) {
+    Wire.beginTransmission(SENSECAP_PCA9535_ADDR);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return false;
+    if (Wire.requestFrom(SENSECAP_PCA9535_ADDR, (uint8_t)1) != 1) return false;
+    val = Wire.read();
+    return true;
+}
+
+bool io_expander_init(void) {
+    if (!write_reg(IOX_REG_CONFIG, IOX_CONFIG_MASK)) {
+        Serial.println("PCA9535 init failed");
+        return false;
+    }
+    output_state = IOX_OUTPUT_DEFAULT;
+    write_reg(IOX_REG_OUTPUT, output_state);
+    Serial.println("PCA9535 init OK");
+    return true;
+}
+
+void io_expander_set(uint8_t pin, bool high) {
+    if (pin > 7) return;
+    if (high) output_state |=  (1u << pin);
+    else      output_state &= ~(1u << pin);
+    write_reg(IOX_REG_OUTPUT, output_state);
+}
+
+bool io_expander_get(uint8_t pin) {
+    if (pin > 7) return false;
+    uint8_t v = 0;
+    if (!read_reg(IOX_REG_INPUT, v)) return false;
+    return (v & (1u << pin)) != 0;
+}

--- a/firmware/src/boards/sensecap_indicator_d1l/io_expander.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/io_expander.cpp
@@ -41,7 +41,10 @@ bool io_expander_init(void) {
         return false;
     }
     output_state = IOX_OUTPUT_DEFAULT;
-    write_reg(IOX_REG_OUTPUT, output_state);
+    if (!write_reg(IOX_REG_OUTPUT, output_state)) {
+        Serial.println("PCA9535 init failed (output)");
+        return false;
+    }
     Serial.println("PCA9535 init OK");
     return true;
 }

--- a/firmware/src/boards/sensecap_indicator_d1l/io_expander.h
+++ b/firmware/src/boards/sensecap_indicator_d1l/io_expander.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <stdint.h>
+
+bool io_expander_init(void);
+void io_expander_set(uint8_t pin, bool high);
+bool io_expander_get(uint8_t pin);

--- a/firmware/src/boards/sensecap_indicator_d1l/io_expander.h
+++ b/firmware/src/boards/sensecap_indicator_d1l/io_expander.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <stdint.h>
 
+// PCA9535 16-bit I2C IO expander — minimal driver, port 0 only.
+// Must be initialized before display_hal_init() so the LCD SPI CS and
+// touch RST lines are configured before gfx->begin() runs.
+
 bool io_expander_init(void);
 void io_expander_set(uint8_t pin, bool high);
 bool io_expander_get(uint8_t pin);

--- a/firmware/src/boards/sensecap_indicator_d1l/power.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/power.cpp
@@ -2,10 +2,38 @@
 #include "board.h"
 #include <Arduino.h>
 
-void power_hal_init(void) {}
-void power_hal_tick(void) {}
+#define PWR_POLL_MS 50
+
+static bool     pwr_pressed_flag = false;
+static bool     last_btn_high    = true;   // INPUT_PULLUP → HIGH when released
+static uint32_t last_pwr_ms      = 0;
+
+void power_hal_init(void) {
+    pinMode(BTN_BACK_GPIO, INPUT_PULLUP);
+    last_btn_high = (digitalRead(BTN_BACK_GPIO) == HIGH);
+}
+
+void power_hal_tick(void) {
+    uint32_t now = millis();
+    if (now - last_pwr_ms < PWR_POLL_MS) return;
+    last_pwr_ms = now;
+
+    bool high_now = (digitalRead(BTN_BACK_GPIO) == HIGH);
+    if (!high_now && last_btn_high) {
+        // Falling edge = button pressed (active-LOW, INPUT_PULLUP)
+        pwr_pressed_flag = true;
+    }
+    last_btn_high = high_now;
+}
 
 int  power_hal_battery_pct(void) { return -1; }
 bool power_hal_is_charging(void) { return false; }
 bool power_hal_is_vbus_in(void)  { return false; }
-bool power_hal_pwr_pressed(void) { return false; }
+
+bool power_hal_pwr_pressed(void) {
+    if (pwr_pressed_flag) {
+        pwr_pressed_flag = false;
+        return true;
+    }
+    return false;
+}

--- a/firmware/src/boards/sensecap_indicator_d1l/power.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/power.cpp
@@ -1,0 +1,11 @@
+#include "../../hal/power_hal.h"
+#include "board.h"
+#include <Arduino.h>
+
+void power_hal_init(void) {}
+void power_hal_tick(void) {}
+
+int  power_hal_battery_pct(void) { return -1; }
+bool power_hal_is_charging(void) { return false; }
+bool power_hal_is_vbus_in(void)  { return false; }
+bool power_hal_pwr_pressed(void) { return false; }

--- a/firmware/src/boards/sensecap_indicator_d1l/touch.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/touch.cpp
@@ -1,10 +1,72 @@
 #include "../../hal/touch_hal.h"
 #include "board.h"
+#include "io_expander.h"
 #include <Arduino.h>
 #include <Wire.h>
 
-void touch_hal_init(void) {}
+// Minimal FT6x36 I2C reader (FocalTech standard register layout):
+//   reg 0x02: low nibble = active finger count
+//   reg 0x03 / 0x04: X1 high (low nibble) + X1 low
+//   reg 0x05 / 0x06: Y1 high (low nibble) + Y1 low
+// Panel mounted 180° — both axes flipped in touch_hal_read().
+
+static bool     touch_init_ok = false;
+static bool     touch_pressed = false;
+static uint16_t touch_x       = 0;
+static uint16_t touch_y       = 0;
+static uint32_t last_read_ms  = 0;
+
+static void ft6x36_read(void) {
+    Wire.beginTransmission(SENSECAP_TOUCH_ADDR);
+    Wire.write(0x02);
+    if (Wire.endTransmission(false) != 0) { touch_pressed = false; return; }
+    if (Wire.requestFrom(SENSECAP_TOUCH_ADDR, (uint8_t)5) != 5) { touch_pressed = false; return; }
+
+    uint8_t fingers = Wire.read() & 0x0F;
+    uint8_t xH = Wire.read();
+    uint8_t xL = Wire.read();
+    uint8_t yH = Wire.read();
+    uint8_t yL = Wire.read();
+
+    if (fingers == 0 || fingers > 5) { touch_pressed = false; return; }
+
+    uint16_t raw_x = ((uint16_t)(xH & 0x0F) << 8) | xL;
+    uint16_t raw_y = ((uint16_t)(yH & 0x0F) << 8) | yL;
+    // Flip both axes: panel mounted 180° relative to logical (0,0) top-left.
+    touch_x = (LCD_WIDTH  - 1) - raw_x;
+    touch_y = (LCD_HEIGHT - 1) - raw_y;
+    touch_pressed = true;
+}
+
+void touch_hal_init(void) {
+    // RST pulse: pull LOW for 50 ms, release, wait 300 ms for controller to boot.
+    io_expander_set(SENSECAP_TP_RST_PIN, false);
+    delay(50);
+    io_expander_set(SENSECAP_TP_RST_PIN, true);
+    delay(300);
+
+    // Set active scanning mode (register 0xA5 = 0x00).
+    Wire.beginTransmission(SENSECAP_TOUCH_ADDR);
+    Wire.write(0xA5);
+    Wire.write(0x00);
+    if (Wire.endTransmission() == 0) {
+        touch_init_ok = true;
+        Serial.println("FT6x36 touch init OK");
+    } else {
+        Serial.printf("FT6x36 not found at 0x%02X — touch disabled\n",
+                      SENSECAP_TOUCH_ADDR);
+    }
+}
 
 void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
-    *x = 0; *y = 0; *pressed = false;
+    if (!touch_init_ok) { *x = 0; *y = 0; *pressed = false; return; }
+
+    uint32_t now = millis();
+    if (now - last_read_ms >= 20) {   // 50 Hz poll — stays well under 5 ms budget
+        last_read_ms = now;
+        ft6x36_read();
+    }
+    *x = touch_x;
+    *y = touch_y;
+    *pressed = touch_pressed;
 }

--- a/firmware/src/boards/sensecap_indicator_d1l/touch.cpp
+++ b/firmware/src/boards/sensecap_indicator_d1l/touch.cpp
@@ -1,0 +1,10 @@
+#include "../../hal/touch_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+void touch_hal_init(void) {}
+
+void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
+    *x = 0; *y = 0; *pressed = false;
+}

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -204,7 +204,7 @@ static void global_click_cb(lv_event_t* e);
 static void ble_reset_click_cb(lv_event_t* e);
 static void screen_swipe_cb(lv_event_t* e);
 
-static uint32_t last_gesture_ms = 0;
+static uint32_t last_gesture_ms = UINT32_MAX - 1000u;
 
 static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     lv_obj_t* panel = lv_obj_create(parent);
@@ -393,6 +393,7 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_set_flex_flow(reset_zone, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(reset_zone, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_clear_flag(reset_zone, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(reset_zone, LV_OBJ_FLAG_GESTURE_BUBBLE);
     lv_obj_add_event_cb(reset_zone, ble_reset_click_cb, LV_EVENT_CLICKED, NULL);
 
     static lv_image_dsc_t icon_trash_dsc;

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -202,6 +202,9 @@ static void format_reset_time(int mins, char* buf, size_t len) {
 // Forward decls — callbacks defined near ui_show_screen below
 static void global_click_cb(lv_event_t* e);
 static void ble_reset_click_cb(lv_event_t* e);
+static void screen_swipe_cb(lv_event_t* e);
+
+static uint32_t last_gesture_ms = 0;
 
 static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     lv_obj_t* panel = lv_obj_create(parent);
@@ -444,6 +447,13 @@ void ui_init(void) {
     battery_img = lv_image_create(scr);
     lv_image_set_src(battery_img, &battery_dscs[0]);
     lv_obj_set_pos(battery_img, L.scr_w - 48 - L.margin, L.title_y);
+
+    // Enable swipe-gesture navigation on all screens.
+    // Gesture events must bubble from containers up to the screen root.
+    lv_obj_add_flag(usage_container, LV_OBJ_FLAG_GESTURE_BUBBLE);
+    lv_obj_add_flag(ble_container,   LV_OBJ_FLAG_GESTURE_BUBBLE);
+    if (splash_get_root()) lv_obj_add_flag(splash_get_root(), LV_OBJ_FLAG_GESTURE_BUBBLE);
+    lv_obj_add_event_cb(scr, screen_swipe_cb, LV_EVENT_GESTURE, NULL);
 }
 
 void ui_update(const UsageData* data) {
@@ -495,12 +505,16 @@ void ui_tick_anim(void) {
 static screen_t prev_non_splash_screen = SCREEN_USAGE;
 static void apply_battery_visibility(void) {
     if (!battery_img) return;
-    if (current_screen == SCREEN_SPLASH) lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
-    else                                  lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+    if (!board_caps().has_battery || current_screen == SCREEN_SPLASH)
+        lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+    else
+        lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
 }
 
 static void global_click_cb(lv_event_t* e) {
     (void)e;
+    // Suppress the spurious LV_EVENT_CLICKED that LVGL fires at the end of a swipe.
+    if (lv_tick_get() - last_gesture_ms < 400) return;
     if (current_screen == SCREEN_SPLASH) ui_show_screen(prev_non_splash_screen);
     else                                  ui_show_screen(SCREEN_SPLASH);
 }
@@ -508,6 +522,20 @@ static void global_click_cb(lv_event_t* e) {
 static void ble_reset_click_cb(lv_event_t* e) {
     (void)e;
     ble_clear_bonds();
+}
+
+static void screen_swipe_cb(lv_event_t* e) {
+    (void)e;
+    lv_indev_t* indev = lv_indev_active();
+    if (!indev) return;
+    lv_dir_t dir = lv_indev_get_gesture_dir(indev);
+    if (dir != LV_DIR_LEFT && dir != LV_DIR_RIGHT) return;
+    last_gesture_ms = lv_tick_get();
+    if (current_screen == SCREEN_SPLASH) {
+        splash_next();
+    } else {
+        ui_cycle_screen();
+    }
 }
 
 void ui_show_screen(screen_t screen) {

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -220,6 +220,7 @@ static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     lv_obj_set_style_pad_bottom(panel, 12, 0);
     lv_obj_clear_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_flag(panel, LV_OBJ_FLAG_EVENT_BUBBLE);
+    lv_obj_add_flag(panel, LV_OBJ_FLAG_GESTURE_BUBBLE);
     return panel;
 }
 


### PR DESCRIPTION
## Summary

This PR adds firmware support for the [Seeed Studio SenseCap Indicator D1L](https://wiki.seeedstudio.com/SenseCAP_Indicator_Get_Started/), following the HAL abstraction introduced in PR #25. It supersedes the earlier PR #13 which used `#ifdef TARGET_SENSECAP` throughout shared code.

## Hardware

| Component | Details |
|---|---|
| SoC | ESP32-S3, OPI PSRAM, 8 MB flash |
| Display | 480×480 ST7701S, RGB parallel interface |
| Touch | FT6x36 at I2C 0x48 (non-standard address), panel mounted 180° |
| IO expander | PCA9535 at I2C 0x20 — gates LCD SPI CS (P04) and touch RST (P07) |
| Button | GPIO 38, active-LOW, drives screen cycle / wake via `power_hal_pwr_pressed` |
| Battery / PMU | None |
| IMU | None |

## New files

All board-specific code lives in `firmware/src/boards/sensecap_indicator_d1l/`:

- `board.h` — pin definitions, I2C addresses, `BOARD_HAS_*` flags
- `io_expander.h` / `io_expander.cpp` — minimal PCA9535 raw-I2C driver (port 0 only, no external library)
- `board_init.cpp` — `Wire.begin` + `io_expander_init` (must run before `display_hal_init`)
- `caps.cpp` — `BoardCaps` instance
- `display.cpp` — `Arduino_RGB_Display` driver; ST7701S init sequence over SPI gated by PCA9535 CS; PWM backlight on GPIO 45
- `touch.cpp` — vendored minimal FT6x36 reader; 50 Hz poll (no INT pin); both axes flipped for 180° mount
- `power.cpp` — edge-detected GPIO 38 PWR button at 50 Hz; all battery stubs return -1/false
- `input.cpp` — stubs returning false (device has no microphone; PTT not applicable)
- `imu.cpp` — no-op stubs

## Shared-code changes (`firmware/src/ui.cpp`)

Two board-agnostic fixes proposed for upstream:

1. **Battery icon respects `board_caps().has_battery`** — `apply_battery_visibility()` was documented to hide the battery widget on boards without a battery, but the check was never implemented. Fixed.

2. **Swipe gesture navigation** — left/right swipes cycle screens; tap still toggles splash. Works on all boards. Also fixes a LVGL 9 quirk where a swipe fires a spurious `LV_EVENT_CLICKED` at lift-off (400 ms debounce guard in `global_click_cb`). `make_panel()` now explicitly sets `LV_OBJ_FLAG_GESTURE_BUBBLE` alongside `EVENT_BUBBLE`.

## Hardware notes

- **ST7701S colour register**: `0xCD = 0x08` (not `0x00` as in the Arduino_GFX type9 default — wrong value produces a permanent green tint).
- **No `INPUT_BTN_PRIMARY`**: the D1L has no BOOT/GPIO0 button available as a general input. GPIO 38 is repurposed as the PWR button via `power_hal_pwr_pressed`; voice-mode PTT is permanently false, which is correct since the device has no microphone.
- **`power_hal_is_vbus_in()` returns false**: the device has no USB VBUS detection. This intentionally allows the idle system to sleep the display after the timeout — desirable for a desk device that may run 24/7.
- **RGB parallel (non-QSPI) display**: the porting guide mentions QSPI AMOLED panels, but the HAL contract is interface-only and accommodates the RGB parallel driver without any HAL changes.

## Test plan

- [x] All three envs compile (`sensecap_indicator_d1l`, `waveshare_amoled_216`, `waveshare_amoled_18`)
- [x] Flashed and booted on hardware — splash animation visible, PCA9535 init OK, FT6x36 touch init OK
- [x] Button (GPIO 38) cycles screens and wakes from sleep
- [x] Touch swipe navigates screens; tap toggles splash
- [x] Battery icon hidden (no battery on this board)
- [x] No regressions on existing board envs