### PR TITLE
Add brightness adjustment screen (AMOLED-2.16)

### DIFF
--- a/firmware/src/boards/waveshare_amoled_216/display.cpp
+++ b/firmware/src/boards/waveshare_amoled_216/display.cpp
@@ -14,6 +14,10 @@ static uint16_t* rot_buf = nullptr;
 static Arduino_DataBus* bus = nullptr;
 static Arduino_CO5300*  gfx = nullptr;
 
+// Last brightness idle asked for; the rotation ramp restores this instead of
+// jumping to full bright, so a dimmed screen stays dimmed across a rotate.
+static uint8_t target_brightness = 200;
+
 void display_hal_init(void) {
     bus = new Arduino_ESP32QSPI(
         LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
@@ -33,6 +37,7 @@ void display_hal_begin(void) {
 }
 
 void display_hal_set_brightness(uint8_t level) {
+    target_brightness = level;
     if (gfx) gfx->setBrightness(level);
 }
 
@@ -107,7 +112,7 @@ void display_hal_tick(void) {
 
     uint8_t rot = imu_hal_rotation_quadrant();
     if (rot != last_rotation) {
-        display_hal_set_brightness(0);
+        if (gfx) gfx->setBrightness(0);  // blank directly; keep target intact
         last_rotation = rot;
         lv_obj_invalidate(lv_screen_active());
         ramp_step = 1;
@@ -119,8 +124,9 @@ void display_hal_tick(void) {
     if (now - ramp_last < 25) return;
     ramp_last = now;
 
-    static const uint8_t levels[] = {60, 120, 170, 200};
-    display_hal_set_brightness(levels[ramp_step - 1]);
+    // Ramp 0 → target over 4 steps (scaled, so a dimmed screen stays dimmed).
+    static const uint8_t pct[] = {30, 60, 85, 100};
+    if (gfx) gfx->setBrightness((uint8_t)((uint16_t)target_brightness * pct[ramp_step - 1] / 100));
     if (ramp_step >= 4) ramp_step = 0;
     else                ramp_step++;
 }

--- a/firmware/src/boards/waveshare_amoled_216/touch.cpp
+++ b/firmware/src/boards/waveshare_amoled_216/touch.cpp
@@ -1,4 +1,5 @@
 #include "../../hal/touch_hal.h"
+#include "../../hal/imu_hal.h"
 #include "board.h"
 #include <Arduino.h>
 #include <Wire.h>
@@ -42,7 +43,18 @@ void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
             touch_pressed = false;
         }
     }
-    *x = touch_x;
-    *y = touch_y;
+
+    // The panel is rotated in software (see display.cpp), so raw touches need
+    // the matching transform or taps miss their target when rotated. It isn't
+    // the clean inverse of the display rotation (controller swap/mirror
+    // calibration) — measured on-device as transform = 3 - quadrant.
+    const int S = LCD_WIDTH;  // square panel: width == height
+    uint16_t px = touch_x, py = touch_y;
+    switch (3 - (imu_hal_rotation_quadrant() & 3)) {
+    case 1: *x = S - 1 - py; *y = px;          break;
+    case 2: *x = S - 1 - px; *y = S - 1 - py;  break;
+    case 3: *x = py;         *y = S - 1 - px;  break;
+    default: *x = px;        *y = py;          break;
+    }
     *pressed = touch_pressed;
 }

--- a/firmware/src/idle.cpp
+++ b/firmware/src/idle.cpp
@@ -17,13 +17,14 @@ static uint32_t fade_started_ms  = 0;
 static uint32_t fade_last_step_ms = 0;
 static uint8_t  fade_from = DISPLAY_DEFAULT_BRIGHTNESS;
 static uint8_t  fade_to   = 0;
+static uint8_t  active_brightness = DISPLAY_DEFAULT_BRIGHTNESS;
 
 static void apply_brightness(uint8_t b) {
     display_hal_set_brightness(b);
 }
 
 static void begin_fade(uint8_t to, uint32_t now) {
-    fade_from = (to == 0) ? DISPLAY_DEFAULT_BRIGHTNESS : 0;
+    fade_from = (to == 0) ? active_brightness : 0;
     fade_to   = to;
     fade_started_ms = now;
     fade_last_step_ms = now;
@@ -32,7 +33,17 @@ static void begin_fade(uint8_t to, uint32_t now) {
 void idle_init(void) {
     state = STATE_AWAKE;
     last_activity_ms = millis();
-    apply_brightness(DISPLAY_DEFAULT_BRIGHTNESS);
+    apply_brightness(active_brightness);
+}
+
+void idle_set_active_brightness(uint8_t level) {
+    active_brightness = level;
+    last_activity_ms = millis();
+    if (state == STATE_AWAKE) apply_brightness(active_brightness);
+}
+
+uint8_t idle_get_active_brightness(void) {
+    return active_brightness;
 }
 
 void idle_note_activity(void) {
@@ -41,7 +52,7 @@ void idle_note_activity(void) {
     if (state == STATE_AWAKE) return;
     // Asleep/fading-out shouldn't reach here in normal flow (callers gate via
     // idle_consume_wake_press first), but if it does: trigger a wake.
-    begin_fade(DISPLAY_DEFAULT_BRIGHTNESS, last_activity_ms);
+    begin_fade(active_brightness, last_activity_ms);
     state = STATE_FADING_IN;
 }
 
@@ -49,7 +60,7 @@ bool idle_consume_wake_press(void) {
     if (state == STATE_ASLEEP || state == STATE_FADING_OUT) {
         uint32_t now = millis();
         last_activity_ms = now;
-        begin_fade(DISPLAY_DEFAULT_BRIGHTNESS, now);
+        begin_fade(active_brightness, now);
         state = STATE_FADING_IN;
         return true;
     }
@@ -75,7 +86,7 @@ void idle_tick(void) {
     if (!IDLE_SLEEP_WHEN_CHARGING && power_hal_is_vbus_in()) {
         last_activity_ms = now;
         if (state == STATE_ASLEEP || state == STATE_FADING_OUT) {
-            begin_fade(DISPLAY_DEFAULT_BRIGHTNESS, now);
+            begin_fade(active_brightness, now);
             state = STATE_FADING_IN;
         }
     }

--- a/firmware/src/idle.h
+++ b/firmware/src/idle.h
@@ -14,3 +14,8 @@ bool idle_consume_wake_press(void);
 // sleeves, etc.). Callers use this to silently drop touch events while the
 // panel is dark.
 bool idle_is_asleep(void);
+
+// Active-screen brightness (0..255), restored by idle on every wake. Setting
+// it while awake applies the change live and counts as activity.
+void idle_set_active_brightness(uint8_t level);
+uint8_t idle_get_active_brightness(void);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -241,7 +241,7 @@ void loop() {
 
     // ---- Physical buttons ----
     //   PRIMARY   → HID Space  (Claude Code voice-mode PTT)
-    //   SECONDARY → HID Shift+Tab  (mode toggle; only if the board has one)
+    //   SECONDARY → toggle the brightness screen (only if the board has one)
     //   PWR       → cycle screens; on splash, cycle animations
     // First press from sleep is consumed as a wake-only event by
     // idle_consume_wake_press(); the normal action fires from the second
@@ -264,18 +264,13 @@ void loop() {
 
         if (board_caps().button_count >= 2) {
             static bool secondary_was = false;
-            static bool secondary_wake_swallowed = false;
             bool secondary_now = input_hal_is_held(INPUT_BTN_SECONDARY);
-            if (secondary_now != secondary_was) {
-                if (secondary_now) {
-                    if (idle_consume_wake_press()) secondary_wake_swallowed = true;
-                    else                            ble_keyboard_press(0x2B, 0x02);  // HID Tab + LEFT_SHIFT
-                } else {
-                    if (secondary_wake_swallowed) secondary_wake_swallowed = false;
-                    else                          ble_keyboard_release();
-                }
-                secondary_was = secondary_now;
+            if (secondary_now && !secondary_was) {
+                // Press edge: first press from sleep is consumed as wake-only;
+                // otherwise toggle the brightness screen in/out.
+                if (!idle_consume_wake_press()) ui_toggle_brightness();
             }
+            secondary_was = secondary_now;
         }
 
         if (power_hal_pwr_pressed()) {

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -3,6 +3,7 @@
 #include <lvgl.h>
 #include "logo.h"
 #include "icons.h"
+#include "idle.h"
 #include "hal/board_caps.h"
 
 // Custom fonts (scaled for 314 PPI, ~1.9x from original 165 PPI)
@@ -118,6 +119,11 @@ static lv_obj_t* lbl_ble_status;
 static lv_obj_t* lbl_ble_device;
 static lv_obj_t* lbl_ble_mac;
 
+// ---- Brightness screen widgets ----
+static lv_obj_t* brightness_container;
+static lv_obj_t* lbl_brightness_pct;
+static lv_obj_t* bar_brightness;
+
 // ---- Battery indicator (shared, on top) ----
 static lv_obj_t* battery_img;
 static lv_obj_t* logo_img;
@@ -202,6 +208,13 @@ static void format_reset_time(int mins, char* buf, size_t len) {
 // Forward decls — callbacks defined near ui_show_screen below
 static void global_click_cb(lv_event_t* e);
 static void ble_reset_click_cb(lv_event_t* e);
+static void brightness_minus_cb(lv_event_t* e);
+static void brightness_plus_cb(lv_event_t* e);
+static void ui_brightness_refresh(void);
+
+// Step 5%/tap; floor at 10% so the screen never goes fully dark.
+#define BRIGHTNESS_MIN_PCT  10
+#define BRIGHTNESS_STEP_PCT 5
 
 static lv_obj_t* make_panel(lv_obj_t* parent, int x, int y, int w, int h) {
     lv_obj_t* panel = lv_obj_create(parent);
@@ -417,6 +430,89 @@ static void init_bluetooth_screen(lv_obj_t* scr) {
     lv_obj_add_flag(ble_container, LV_OBJ_FLAG_HIDDEN);
 }
 
+// ======== Brightness Screen ========
+
+static lv_obj_t* make_step_button(lv_obj_t* parent, const char* sym,
+                                  lv_event_cb_t cb, int w, int h) {
+    lv_obj_t* btn = lv_button_create(parent);
+    lv_obj_set_size(btn, w, h);
+    lv_obj_set_style_bg_color(btn, COL_PANEL, 0);
+    lv_obj_set_style_bg_opa(btn, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(btn, 12, 0);
+    lv_obj_set_style_border_width(btn, 0, 0);
+    lv_obj_add_event_cb(btn, cb, LV_EVENT_CLICKED, NULL);
+
+    lv_obj_t* lbl = lv_label_create(btn);
+    lv_label_set_text(lbl, sym);
+    lv_obj_set_style_text_font(lbl, &font_styrene_48, 0);
+    lv_obj_set_style_text_color(lbl, COL_TEXT, 0);
+    lv_obj_center(lbl);
+    return btn;
+}
+
+static void init_brightness_screen(lv_obj_t* scr) {
+    brightness_container = lv_obj_create(scr);
+    lv_obj_set_size(brightness_container, L.scr_w, L.scr_h);
+    lv_obj_set_pos(brightness_container, 0, 0);
+    lv_obj_set_style_bg_opa(brightness_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(brightness_container, 0, 0);
+    lv_obj_set_style_pad_all(brightness_container, 0, 0);
+    lv_obj_clear_flag(brightness_container, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* title = lv_label_create(brightness_container);
+    lv_label_set_text(title, "Brightness");
+    lv_obj_set_style_text_font(title, L.bt_title_font, 0);
+    lv_obj_set_style_text_color(title, COL_TEXT, 0);
+    lv_obj_align(title, LV_ALIGN_TOP_MID, 16, L.title_y);
+
+    lbl_brightness_pct = lv_label_create(brightness_container);
+    lv_label_set_text(lbl_brightness_pct, "---%");
+    lv_obj_set_style_text_font(lbl_brightness_pct, &font_styrene_48, 0);
+    lv_obj_set_style_text_color(lbl_brightness_pct, COL_TEXT, 0);
+    lv_obj_align(lbl_brightness_pct, LV_ALIGN_TOP_MID, 0, L.content_y + 10);
+
+    bar_brightness = make_bar(brightness_container, L.margin,
+                              L.content_y + 90, L.content_w, 24);
+    lv_obj_set_style_bg_color(bar_brightness, COL_ACCENT, LV_PART_INDICATOR);
+
+    int gap   = 16;
+    int btn_h = (L.scr_h >= 460) ? 120 : 96;
+    int btn_w = (L.content_w - gap) / 2;
+    int row_y = L.scr_h - L.margin - btn_h;
+
+    lv_obj_t* minus = make_step_button(brightness_container, "-",
+                                       brightness_minus_cb, btn_w, btn_h);
+    lv_obj_set_pos(minus, L.margin, row_y);
+
+    lv_obj_t* plus = make_step_button(brightness_container, "+",
+                                      brightness_plus_cb, btn_w, btn_h);
+    lv_obj_set_pos(plus, L.margin + btn_w + gap, row_y);
+
+    lv_obj_add_flag(brightness_container, LV_OBJ_FLAG_HIDDEN);
+}
+
+static int brightness_pct(void) {
+    return (idle_get_active_brightness() * 100 + 127) / 255;
+}
+
+static void ui_brightness_refresh(void) {
+    if (!brightness_container) return;
+    int pct = brightness_pct();
+    lv_label_set_text_fmt(lbl_brightness_pct, "%d%%", pct);
+    lv_bar_set_value(bar_brightness, pct, LV_ANIM_OFF);
+}
+
+static void brightness_step(int delta_pct) {
+    int pct = brightness_pct() + delta_pct;
+    if (pct < BRIGHTNESS_MIN_PCT) pct = BRIGHTNESS_MIN_PCT;
+    if (pct > 100)                pct = 100;
+    idle_set_active_brightness((uint8_t)((pct * 255 + 50) / 100));
+    ui_brightness_refresh();
+}
+
+static void brightness_minus_cb(lv_event_t* e) { (void)e; brightness_step(-BRIGHTNESS_STEP_PCT); }
+static void brightness_plus_cb(lv_event_t* e)  { (void)e; brightness_step(+BRIGHTNESS_STEP_PCT); }
+
 // ======== Public API ========
 
 void ui_init(void) {
@@ -431,6 +527,7 @@ void ui_init(void) {
 
     init_usage_screen(scr);
     init_bluetooth_screen(scr);
+    init_brightness_screen(scr);
     splash_init(scr);
 
     if (splash_get_root()) {
@@ -513,12 +610,17 @@ static void ble_reset_click_cb(lv_event_t* e) {
 void ui_show_screen(screen_t screen) {
     lv_obj_add_flag(usage_container, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(ble_container, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(brightness_container, LV_OBJ_FLAG_HIDDEN);
     splash_hide();
 
     switch (screen) {
     case SCREEN_SPLASH:     splash_show(); break;
     case SCREEN_USAGE:      lv_obj_clear_flag(usage_container, LV_OBJ_FLAG_HIDDEN); break;
     case SCREEN_BLUETOOTH:  lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_HIDDEN); break;
+    case SCREEN_BRIGHTNESS:
+        ui_brightness_refresh();
+        lv_obj_clear_flag(brightness_container, LV_OBJ_FLAG_HIDDEN);
+        break;
     default: break;
     }
 
@@ -527,7 +629,10 @@ void ui_show_screen(screen_t screen) {
         else                          lv_obj_clear_flag(logo_img, LV_OBJ_FLAG_HIDDEN);
     }
 
-    if (screen != SCREEN_SPLASH) prev_non_splash_screen = screen;
+    // Brightness is a transient overlay — don't let it become the screen
+    // splash returns to.
+    if (screen != SCREEN_SPLASH && screen != SCREEN_BRIGHTNESS)
+        prev_non_splash_screen = screen;
     current_screen = screen;
     apply_battery_visibility();
 }
@@ -545,6 +650,17 @@ void ui_cycle_screen(void) {
 void ui_toggle_splash(void) {
     if (current_screen == SCREEN_SPLASH) ui_show_screen(prev_non_splash_screen);
     else                                  ui_show_screen(SCREEN_SPLASH);
+}
+
+void ui_toggle_brightness(void) {
+    static screen_t before_brightness = SCREEN_USAGE;
+    if (current_screen == SCREEN_BRIGHTNESS) {
+        ui_show_screen(before_brightness);
+    } else {
+        before_brightness = (current_screen == SCREEN_SPLASH)
+                              ? prev_non_splash_screen : current_screen;
+        ui_show_screen(SCREEN_BRIGHTNESS);
+    }
 }
 
 screen_t ui_get_current_screen(void) {

--- a/firmware/src/ui.h
+++ b/firmware/src/ui.h
@@ -6,6 +6,7 @@ enum screen_t {
     SCREEN_SPLASH,
     SCREEN_USAGE,
     SCREEN_BLUETOOTH,
+    SCREEN_BRIGHTNESS,
     SCREEN_COUNT,
 };
 
@@ -15,6 +16,7 @@ void ui_tick_anim(void);
 void ui_show_screen(screen_t screen);
 void ui_cycle_screen(void);
 void ui_toggle_splash(void);
+void ui_toggle_brightness(void);
 screen_t ui_get_current_screen(void);
 void ui_update_ble_status(ble_state_t state, const char* name, const char* mac);
 void ui_update_battery(int percent, bool charging);


### PR DESCRIPTION
## Summary

Adds a **Brightness** screen to the AMOLED-2.16, opened with the SECONDARY (GPIO18) button, with on-screen −/+ touch controls (5% per tap, 10% floor). Brightness is now a runtime value owned by the idle module, so it survives sleep/wake and screen rotation instead of snapping back to the compile-time default.

<table>
  <tr>
    <td>
      <img width="480" height="480" alt="brightness-78" src="https://github.com/user-attachments/assets/f61f9bfa-56ec-477e-ae0c-edbecce3a6ac"width="300" />
    </td>
    <td>
      <img width="480" height="480" alt="brightness-40" src="https://github.com/user-attachments/assets/7bdc1b5c-8e55-412a-b834-82afd942201c" width="300" />
    </td>
  </tr>
</table>

## Changes

- **idle.cpp / idle.h** — brightness becomes a runtime value (`idle_set_active_brightness` / `idle_get_active_brightness`); idle restores this on wake instead of the fixed constant.
- **ui.cpp / ui.h** — new `SCREEN_BRIGHTNESS` with a percentage readout, bar, and two −/+ touch buttons; the SECONDARY button toggles it open/closed.
- **main.cpp** — SECONDARY button now opens the brightness screen (was HID Shift+Tab).
- **display.cpp** — the rotation brightness ramp restores the active brightness rather than jumping back to a hardcoded full-bright value.
- **touch.cpp** — fix touch coordinates not following the software display rotation; per-quadrant transform (`3 − rotation`) measured on-device.

## Testing

- Builds clean for both `waveshare_amoled_216` and `waveshare_amoled_18`.
- −/+ buttons verified working on hardware in all four IMU rotation orientations.

## Notes

- Brightness is RAM-only — it resets to the default on a full power-cycle (NVS persistence not included in this PR).
