### PR TITLE
feat: add Windows PowerShell scripts for flashing and daemon

### DIFF
--- a/flash-windows.ps1
+++ b/flash-windows.ps1
@@ -1,0 +1,51 @@
+# Build and flash Clawdmeter firmware on Windows.
+# Usage:
+#   .\flash-windows.ps1 <board>         # auto-detects ESP32 COM port
+#   .\flash-windows.ps1 <board> COM14   # explicit port
+#
+# <board> is the PlatformIO env name, e.g. waveshare_amoled_216_c6
+param(
+    [Parameter(Position=0)]
+    [string]$Board,
+    [Parameter(Position=1)]
+    [string]$Port
+)
+
+$PIO = "$env:USERPROFILE\.platformio\penv\Scripts\pio.exe"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$FirmwareDir = Join-Path $ScriptDir "firmware"
+
+if (-not $Board) {
+    Write-Host "Error: board env name is required." -ForegroundColor Red
+    Write-Host "Usage: .\flash-windows.ps1 <board> [port]"
+    Write-Host "Available boards:"
+    Select-String -Path "$FirmwareDir\platformio.ini" -Pattern '^\[env:' |
+        ForEach-Object { "  " + ($_.Line -replace '^\[env:', '' -replace '\]', '') }
+    exit 1
+}
+
+if (-not $Port) {
+    $detected = Get-PnpDevice -Class Ports -Status OK |
+        Where-Object { $_.FriendlyName -like '*USB*' -and $_.FriendlyName -notlike '*Bluetooth*' } |
+        Select-Object -First 1
+    if ($detected) {
+        $Port = ($detected.FriendlyName -match 'COM\d+') ? $Matches[0] : $null
+    }
+    if (-not $Port) {
+        Write-Host "Could not auto-detect USB serial port. Specify it manually:" -ForegroundColor Yellow
+        Write-Host "  .\flash-windows.ps1 $Board COM14"
+        exit 1
+    }
+    Write-Host "Auto-detected port: $Port" -ForegroundColor Cyan
+}
+
+Write-Host "=== Flashing Clawdmeter ===" -ForegroundColor Green
+Write-Host "Board: $Board"
+Write-Host "Port:  $Port"
+Write-Host ""
+
+Set-Location $FirmwareDir
+& $PIO run -e $Board -t upload --upload-port $Port
+
+Write-Host ""
+Write-Host "=== Done! ===" -ForegroundColor Green

--- a/flash-windows.ps1
+++ b/flash-windows.ps1
@@ -11,6 +11,10 @@ param(
     [string]$Port
 )
 
+# esptool uses Unicode progress chars (▓░) that break on CP1250 terminals
+chcp 65001 | Out-Null
+$env:PYTHONUTF8 = "1"
+
 $PIO = "$env:USERPROFILE\.platformio\penv\Scripts\pio.exe"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $FirmwareDir = Join-Path $ScriptDir "firmware"

--- a/start-daemon.ps1
+++ b/start-daemon.ps1
@@ -1,0 +1,15 @@
+# Start the Claude usage daemon on Windows.
+# Reads credentials from %USERPROFILE%\.claude\.credentials.json
+# and pushes usage data to the ESP32 over BLE.
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Python = "$ScriptDir\daemon\.venv\Scripts\python.exe"
+$Daemon = "$ScriptDir\daemon\claude_usage_daemon.py"
+
+if (-not (Test-Path $Python)) {
+    Write-Host "venv not found. Run setup first:" -ForegroundColor Red
+    Write-Host "  cd daemon; python -m venv .venv; .venv\Scripts\pip install bleak httpx"
+    exit 1
+}
+
+Write-Host "Starting Claude usage daemon..." -ForegroundColor Green
+& $Python $Daemon


### PR DESCRIPTION
## Summary

- `flash-windows.ps1` — Windows equivalent of `flash.sh`; wraps `pio upload`, auto-detects USB-Serial COM port (skips Bluetooth ports), lists available board envs when called without arguments
- `start-daemon.ps1` — launches the Python daemon from its `.venv`, validates the venv exists and gives setup instructions if not

## Motivation

The existing `flash.sh` and `install.sh` scripts require a POSIX shell (Linux/macOS). Windows users (WSL-less) currently have no first-class path for flashing or starting the daemon. These scripts fill that gap and bring Windows to parity for the two most common setup steps.

## Test plan

- [ ] `.\flash-windows.ps1` with no args prints available board envs
- [ ] `.\flash-windows.ps1 waveshare_amoled_216_c6` auto-detects USB COM port and flashes
- [ ] `.\flash-windows.ps1 waveshare_amoled_216_c6 COM14` flashes to explicit port
- [ ] `.\start-daemon.ps1` with venv present starts the daemon
- [ ] `.\start-daemon.ps1` without venv prints setup instructions and exits cleanly

Tested on Windows 11 Pro with Waveshare ESP32-C6-Touch-AMOLED-2.16.