### PR TITLE
Feature: display multiple Claude accounts with auto-rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Clawd animations come from [claudepix](https://claudepix.vercel.app), [@amaa
 
 ## Screens
 
-The device boots into the splash and stays there until you press the middle (PWR) button, which cycles between Usage and Bluetooth. Tap the screen anywhere (except the Reset zone on the Bluetooth screen) to flip back to the splash; tap again to dismiss it.
+The device boots into the splash and stays there until you press the middle (PWR) button, which cycles between Usage and Bluetooth. With more than one account configured (see [Multiple accounts](#multiple-accounts)), the Usage screen auto-rotates through each account and the middle button steps through them before moving on to Bluetooth. Tap the screen anywhere (except the Reset zone on the Bluetooth screen) to flip back to the splash; tap again to dismiss it.
 
 |              Splash               |              Usage              |                Bluetooth                |
 | :-------------------------------: | :-----------------------------: | :-------------------------------------: |
@@ -128,6 +128,38 @@ View logs: `journalctl --user -u claude-usage-daemon -f`
 6. The firmware also tracks the rate of change of session % over a 5-minute window and picks splash animations from the matching mood group.
 7. The two side buttons are independent of all of this — they send Space and Shift+Tab as BLE HID keyboard input to the paired host directly.
 
+## Multiple accounts
+
+If you run more than one Claude subscription (e.g. a personal login plus a
+work one under a separate `CLAUDE_CONFIG_DIR`), the daemon can track them all
+and the device rotates through them automatically — each account gets its own
+usage page, titled with its label, with a row of page dots showing how many
+there are. Pressing the middle (PWR) button steps through them manually.
+
+Create `~/.config/claude-usage-monitor/accounts.json` listing each account
+(see [`daemon/accounts.example.json`](daemon/accounts.example.json)):
+
+```json
+{
+  "accounts": [
+    { "label": "main", "config_dir": null },
+    { "label": "work", "config_dir": "~/.claude-ux" }
+  ]
+}
+```
+
+- `label` — short name shown on the device (≤ 12 chars).
+- `config_dir` — the account's Claude Code config dir. Use `null` for the
+  default profile; use the path you pass as `CLAUDE_CONFIG_DIR` for the others
+  (e.g. an alias like `alias claude-work='CLAUDE_CONFIG_DIR=~/.claude-ux claude'`).
+
+The daemon resolves each account's token from that profile — on macOS from its
+per-profile Keychain item (`Claude Code-credentials` for the default, or
+`Claude Code-credentials-<hash>` where `<hash>` is the first 8 hex of
+`sha256(<absolute config_dir>)`), and on Linux from `<config_dir>/.credentials.json`.
+Up to 8 accounts are supported (bounded by the BLE payload size). Omit the file
+entirely and the daemon tracks just the default account, exactly as before.
+
 ## Physical buttons
 
 The board has three side buttons. Left and right do the same thing on every screen; the middle button is screen-aware.
@@ -151,13 +183,13 @@ The device advertises a custom GATT service alongside the standard HID keyboard 
 | TX Characteristic (notify) | `4c41555a-4465-7669-6365-000000000003` |
 | **HID Service**            | `00001812-0000-1000-8000-00805f9b34fb` |
 
-JSON payload format (written to RX):
+JSON payload format (written to RX) — an array of accounts under `a`:
 
 ```json
-{ "s": 45, "sr": 120, "w": 28, "wr": 7200, "st": "allowed", "ok": true }
+{ "a": [ { "n": "main", "s": 45, "sr": 120, "w": 28, "wr": 7200, "st": "allowed", "ok": true } ] }
 ```
 
-Fields: `s` = session %, `sr` = session reset (minutes), `w` = weekly %, `wr` = weekly reset (minutes), `st` = status, `ok` = success flag.
+Per-account fields: `n` = account label, `s` = session %, `sr` = session reset (minutes), `w` = weekly %, `wr` = weekly reset (minutes), `st` = status, `ok` = success flag (an account that failed to poll is sent as `{ "n": "...", "ok": false }` and shown as offline). For backward compatibility the firmware also accepts a single bare object without the `a` wrapper.
 
 ## Recompiling fonts
 

--- a/daemon/accounts.example.json
+++ b/daemon/accounts.example.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Copy to ~/.config/claude-usage-monitor/accounts.json to show multiple Claude accounts on the device. Omit the file entirely to track just the default account (original single-account behavior).",
+  "accounts": [
+    {
+      "label": "main",
+      "config_dir": null
+    },
+    {
+      "label": "work",
+      "config_dir": "~/.claude-ux"
+    }
+  ]
+}

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -8,6 +8,7 @@ bleak (CoreBluetooth backend on macOS).
 
 import asyncio
 import getpass
+import hashlib
 import json
 import os
 import re
@@ -30,11 +31,19 @@ POLL_INTERVAL = 60
 TICK = 5
 SCAN_TIMEOUT = 8.0
 
-# macOS: token lives in Keychain (service "Claude Code-credentials").
-# Linux: token lives in ~/.claude/.credentials.json.
-KEYCHAIN_SERVICE = "Claude Code-credentials"
-CREDENTIALS_PATH = Path.home() / ".claude" / ".credentials.json"
-SAVED_ADDR_FILE = Path.home() / ".config" / "claude-usage-monitor" / "ble-address"
+CONFIG_DIR = Path.home() / ".config" / "claude-usage-monitor"
+SAVED_ADDR_FILE = CONFIG_DIR / "ble-address"
+ACCOUNTS_FILE = CONFIG_DIR / "accounts.json"
+
+# Per-account label cap (keeps the BLE array payload inside BLE_BUF_SIZE=512
+# and the device's display width sane). Daemon truncates longer labels.
+LABEL_MAX = 12
+
+# Default Claude Code config dir (the profile used when CLAUDE_CONFIG_DIR is
+# unset). Its token lives in Keychain service "Claude Code-credentials"
+# (macOS) or ~/.claude/.credentials.json (Linux).
+DEFAULT_CONFIG_DIR = Path.home() / ".claude"
+KEYCHAIN_SERVICE_BASE = "Claude Code-credentials"
 
 API_URL = "https://api.anthropic.com/v1/messages"
 API_HEADERS_TEMPLATE = {
@@ -86,14 +95,35 @@ def _extract_access_token(blob: str) -> str | None:
     return None
 
 
-def _read_token_keychain() -> str | None:
+def keychain_service_for(config_dir: Path | None) -> str:
+    """Keychain service name for a Claude Code profile.
+
+    Claude Code namespaces the macOS Keychain item by config dir:
+      - default profile (CLAUDE_CONFIG_DIR unset): "Claude Code-credentials"
+      - a CLAUDE_CONFIG_DIR profile: that base + "-" + sha256(abspath)[:8]
+    Verified empirically (e.g. ~/.claude-ux -> ...-b8b10a65).
+    """
+    if config_dir is None:
+        return KEYCHAIN_SERVICE_BASE
+    abspath = str(config_dir.expanduser().resolve())
+    suffix = hashlib.sha256(abspath.encode()).hexdigest()[:8]
+    return f"{KEYCHAIN_SERVICE_BASE}-{suffix}"
+
+
+def credentials_path_for(config_dir: Path | None) -> Path:
+    """File-based credentials path for a profile (Linux / fallback)."""
+    base = config_dir.expanduser() if config_dir else DEFAULT_CONFIG_DIR
+    return base / ".credentials.json"
+
+
+def _read_token_keychain(service: str) -> str | None:
     try:
         out = subprocess.run(
             [
                 "security",
                 "find-generic-password",
                 "-s",
-                KEYCHAIN_SERVICE,
+                service,
                 "-a",
                 getpass.getuser(),
                 "-w",
@@ -104,7 +134,7 @@ def _read_token_keychain() -> str | None:
             timeout=10,
         )
     except subprocess.CalledProcessError as e:
-        log(f"Keychain read failed (rc={e.returncode}): {e.stderr.strip()}")
+        log(f"Keychain read failed for {service!r} (rc={e.returncode}): {e.stderr.strip()}")
         return None
     except (FileNotFoundError, subprocess.TimeoutExpired) as e:
         log(f"Keychain access error: {e}")
@@ -112,19 +142,75 @@ def _read_token_keychain() -> str | None:
     return _extract_access_token(out.stdout)
 
 
-def _read_token_file() -> str | None:
+def _read_token_file(path: Path) -> str | None:
     try:
-        raw = CREDENTIALS_PATH.read_text()
+        raw = path.read_text()
     except OSError as e:
-        log(f"Error reading credentials: {e}")
+        log(f"Error reading credentials at {path}: {e}")
         return None
     return _extract_access_token(raw)
 
 
-def read_token() -> str | None:
+def read_token(account: dict) -> str | None:
+    """Resolve the OAuth token for one account.
+
+    ``account`` is {"label": str, "config_dir": Path|None}. On macOS the token
+    is read from the per-profile Keychain item; a file credential (if present)
+    is tried as a fallback. On other platforms the file is authoritative.
+    """
+    config_dir = account.get("config_dir")
     if sys.platform == "darwin":
-        return _read_token_keychain()
-    return _read_token_file()
+        tok = _read_token_keychain(keychain_service_for(config_dir))
+        if tok:
+            return tok
+        # Fallback: some setups still keep a file credential.
+        path = credentials_path_for(config_dir)
+        return _read_token_file(path) if path.exists() else None
+    return _read_token_file(credentials_path_for(config_dir))
+
+
+def load_accounts() -> list[dict]:
+    """Load the account list, or default to the single default profile.
+
+    Config file ~/.config/claude-usage-monitor/accounts.json:
+        {"accounts": [
+            {"label": "main"},                       # default profile
+            {"label": "ux", "config_dir": "~/.claude-ux"}
+        ]}
+
+    Absent/empty/malformed → one default account (backward compatible with the
+    original single-account daemon). ``config_dir`` may be null/omitted (the
+    default profile) or a path string (a CLAUDE_CONFIG_DIR profile).
+    """
+    default = [{"label": "claude", "config_dir": None}]
+    if not ACCOUNTS_FILE.exists():
+        return default
+    try:
+        data = json.loads(ACCOUNTS_FILE.read_text())
+        raw = data.get("accounts") if isinstance(data, dict) else data
+        if not isinstance(raw, list) or not raw:
+            raise ValueError("no accounts")
+    except (json.JSONDecodeError, OSError, ValueError) as e:
+        log(f"accounts.json unusable ({e}); using default single account")
+        return default
+
+    accounts = []
+    for i, entry in enumerate(raw):
+        if isinstance(entry, str):  # bare path or "default"
+            entry = {"config_dir": None if entry in ("", "default") else entry}
+        cd = entry.get("config_dir")
+        label = str(entry.get("label") or "").strip()
+        if not label:
+            # Derive from config_dir basename, else index.
+            label = Path(cd).name.lstrip(".") if cd else "claude"
+            label = label or f"acct{i+1}"
+        accounts.append(
+            {
+                "label": label[:LABEL_MAX],
+                "config_dir": Path(cd) if cd else None,
+            }
+        )
+    return accounts
 
 
 def load_cached_address() -> str | None:
@@ -271,18 +357,32 @@ async def discover_target(skip_addr: str | None = None):
     return address
 
 
-async def poll_api(token: str) -> dict | None:
+async def poll_api(account: dict) -> dict:
+    """Poll one account's rate-limit headers.
+
+    Always returns a per-account object carrying the label under "n". On any
+    failure (no token, network, HTTP error) returns {"n": label, "ok": false}
+    so the device can show the account as offline instead of dropping it.
+    """
+    label = account["label"]
+    offline = {"n": label, "ok": False}
+
+    token = read_token(account)
+    if not token:
+        log(f"[{label}] no token; marking offline")
+        return offline
+
     headers = dict(API_HEADERS_TEMPLATE)
     headers["Authorization"] = f"Bearer {token}"
     try:
         async with httpx.AsyncClient(timeout=20.0) as http:
             resp = await http.post(API_URL, headers=headers, json=API_BODY)
     except httpx.HTTPError as e:
-        log(f"API call failed: {e}")
-        return None
+        log(f"[{label}] API call failed: {e}")
+        return offline
     if resp.status_code >= 400:
-        log(f"API HTTP {resp.status_code}: {resp.text[:200]}")
-        return None
+        log(f"[{label}] API HTTP {resp.status_code}: {resp.text[:160]}")
+        return offline
 
     def hdr(name: str, default: str = "0") -> str:
         return resp.headers.get(name, default)
@@ -303,7 +403,8 @@ async def poll_api(token: str) -> dict | None:
         except ValueError:
             return 0
 
-    payload = {
+    return {
+        "n": label,
         "s": pct(hdr("anthropic-ratelimit-unified-5h-utilization")),
         "sr": reset_minutes(hdr("anthropic-ratelimit-unified-5h-reset")),
         "w": pct(hdr("anthropic-ratelimit-unified-7d-utilization")),
@@ -311,7 +412,18 @@ async def poll_api(token: str) -> dict | None:
         "st": hdr("anthropic-ratelimit-unified-5h-status", "unknown"),
         "ok": True,
     }
-    return payload
+
+
+async def poll_all(accounts: list[dict]) -> dict | None:
+    """Poll every account concurrently and build the BLE array payload.
+
+    Returns {"a": [per-account, ...]} or None if there's nothing to send.
+    Accounts are polled in parallel; order is preserved to match the config.
+    """
+    if not accounts:
+        return None
+    results = await asyncio.gather(*(poll_api(a) for a in accounts))
+    return {"a": list(results)}
 
 
 class Session:
@@ -331,21 +443,29 @@ class Session:
 
     async def write_payload(self, payload: dict) -> bool:
         data = json.dumps(payload, separators=(",", ":")).encode()
-        log(f"Sending: {data.decode()}")
+        n = len(payload.get("a", [])) if isinstance(payload, dict) else 0
+        log(f"Sending ({len(data)}B, {n} acct): {data.decode()}")
+        if len(data) > 512:
+            log(f"WARNING: payload {len(data)}B exceeds device BLE_BUF_SIZE=512; "
+                "it will be truncated. Reduce accounts or label lengths.")
         try:
-            await self.client.write_gatt_char(RX_CHAR_UUID, data, response=False)
+            # response=True (ATT write-with-response): CoreBluetooth performs a
+            # long write for payloads above the MTU, so multi-account arrays up
+            # to 512B arrive intact, and a clean return confirms delivery.
+            await self.client.write_gatt_char(RX_CHAR_UUID, data, response=True)
             return True
         except BleakError as e:
             log(f"Write failed: {e}")
             return False
 
 
-async def connect_and_run(target, stop_event: asyncio.Event) -> bool:
+async def connect_and_run(target, accounts: list[dict], stop_event: asyncio.Event) -> bool:
     """Connect to a target and poll until disconnected or stopped.
 
     ``target`` is either an address string (Linux) or a BLEDevice carrying
-    live CoreBluetooth details (macOS). Returns True if the connection was
-    used successfully (so the caller keeps the cached address), False if the
+    live CoreBluetooth details (macOS). ``accounts`` is the list of Claude
+    profiles to poll each cycle. Returns True if the connection was used
+    successfully (so the caller keeps the cached address), False if the
     connection failed and the cache should be invalidated.
     """
     display = target if isinstance(target, str) else target.address
@@ -373,15 +493,11 @@ async def connect_and_run(target, stop_event: asyncio.Event) -> bool:
             elapsed = now - last_poll
             if session.refresh_requested.is_set() or elapsed >= POLL_INTERVAL:
                 session.refresh_requested.clear()
-                token = read_token()
-                if not token:
-                    log("No token; skipping poll")
-                else:
-                    payload = await poll_api(token)
-                    if payload is not None:
-                        if await session.write_payload(payload):
-                            last_poll = time.time()
-                            used_successfully = True
+                payload = await poll_all(accounts)
+                if payload is not None:
+                    if await session.write_payload(payload):
+                        last_poll = time.time()
+                        used_successfully = True
 
             try:
                 await asyncio.wait_for(session.refresh_requested.wait(), timeout=TICK)
@@ -414,6 +530,10 @@ async def main() -> None:
     log("=== Claude Usage Tracker Daemon (BLE, macOS) ===")
     log(f"Poll interval: {POLL_INTERVAL}s")
 
+    accounts = load_accounts()
+    log(f"Accounts ({len(accounts)}): " + ", ".join(
+        f"{a['label']}[{a['config_dir'] or 'default'}]" for a in accounts))
+
     backoff = 1
     skip_addr: str | None = None  # macOS: a peripheral to skip for one cycle
     while not stop_event.is_set():
@@ -431,7 +551,7 @@ async def main() -> None:
             continue
 
         addr = target if isinstance(target, str) else target.address
-        ok = await connect_and_run(target, stop_event)
+        ok = await connect_and_run(target, accounts, stop_event)
         if not ok:
             if sys.platform == "darwin":
                 # No string cache to drop; instead skip this stale handle on

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -157,6 +157,120 @@ async def scan_for_device() -> str | None:
     return None
 
 
+# --- macOS: recover a device the OS already holds as an HID keyboard --------
+#
+# The firmware advertises as a BLE HID keyboard so its buttons type into the
+# Mac. macOS auto-connects to that HID, and CoreBluetooth then EXCLUDES the
+# peripheral from BleakScanner.discover() results (already-connected devices
+# never appear in scans). bleak's connect-by-address path also scans
+# internally, so a cached address can't help either. The documented escape
+# hatch is retrieveConnectedPeripheralsWithServices_, which returns
+# peripherals the system is already connected to. We wrap the result in a
+# BLEDevice carrying the live (peripheral, manager) details so BleakClient
+# connects to it directly without scanning. CoreBluetooth shares the single
+# physical link, so this rides the existing HID connection — the keyboard
+# keeps working.
+_cb_manager = None  # reused CentralManagerDelegate (CoreBluetooth)
+
+
+async def _get_cb_manager():
+    """Lazily create and ready a shared CoreBluetooth central manager."""
+    global _cb_manager
+    if _cb_manager is None:
+        from bleak.backends.corebluetooth.CentralManagerDelegate import (
+            CentralManagerDelegate,
+        )
+
+        mgr = CentralManagerDelegate()
+        await mgr.wait_until_ready()  # raises if Bluetooth is unauthorized/off
+        _cb_manager = mgr
+    return _cb_manager
+
+
+async def retrieve_connected_macos(skip_addr: str | None = None):
+    """Return a BLEDevice for a system-connected 'Claude Controller', or None.
+
+    Two-step lookup, strongest signal first:
+
+    1. Peripherals connected under our CUSTOM service UUID. Membership in
+       that service is unambiguous (no other device exposes it), so we accept
+       by service alone — the peripheral's name can be None on macOS.
+    2. Fall back to the generic HID service 0x1812, but ONLY trust a
+       peripheral whose name matches DEVICE_NAME. 0x1812 also matches
+       unrelated keyboards/mice, so picking blindly here could grab the
+       wrong device.
+
+    ``skip_addr`` skips a peripheral whose UUID just failed to connect, so a
+    stale CoreBluetooth handle can't trap us into never trying a fresh scan.
+    """
+    from CoreBluetooth import CBUUID
+    from bleak.backends.device import BLEDevice
+
+    try:
+        manager = await _get_cb_manager()
+    except Exception as e:  # BleakBluetoothNotAvailableError etc.
+        log(f"CoreBluetooth unavailable: {e}")
+        return None
+
+    cm = manager.central_manager
+
+    def _wrap(p):
+        addr = p.identifier().UUIDString()
+        log(f"Found system-connected peripheral: {p.name()!r} [{addr}]")
+        return BLEDevice(addr, p.name(), (p, manager))
+
+    def _ok(p) -> bool:
+        return not (skip_addr and p.identifier().UUIDString() == skip_addr)
+
+    # 1. Custom service — accept by service membership alone.
+    custom = cm.retrieveConnectedPeripheralsWithServices_(
+        [CBUUID.UUIDWithString_(SERVICE_UUID)]
+    )
+    for p in custom or []:
+        if _ok(p):
+            return _wrap(p)
+
+    # 2. Generic HID service — require an exact name match.
+    hid = cm.retrieveConnectedPeripheralsWithServices_(
+        [CBUUID.UUIDWithString_("1812")]
+    )
+    for p in hid or []:
+        if _ok(p) and p.name() == DEVICE_NAME:
+            return _wrap(p)
+
+    return None
+
+
+async def discover_target(skip_addr: str | None = None):
+    """Return a connectable target, or None.
+
+    macOS: prefer the system-connected peripheral (HID-grabbed devices are
+    invisible to scans); fall back to a normal scan that yields a BLEDevice
+    so the subsequent connect doesn't have to re-scan. ``skip_addr`` is
+    forwarded so a just-failed peripheral is skipped, making the scan
+    fallback reachable.
+
+    Other platforms: keep the original cached-address / scan-by-name flow.
+    A freshly scanned address is cached here (the only place it's saved).
+    """
+    if sys.platform == "darwin":
+        dev = await retrieve_connected_macos(skip_addr=skip_addr)
+        if dev is not None:
+            return dev
+        log(f"Not held by OS; scanning for '{DEVICE_NAME}' ({SCAN_TIMEOUT}s)...")
+        dev = await BleakScanner.find_device_by_name(DEVICE_NAME, timeout=SCAN_TIMEOUT)
+        if dev:
+            log(f"Found: {dev.address}")
+        return dev
+
+    address = load_cached_address()
+    if not address:
+        address = await scan_for_device()
+        if address:
+            save_address(address)  # cache only freshly-scanned addresses
+    return address
+
+
 async def poll_api(token: str) -> dict | None:
     headers = dict(API_HEADERS_TEMPLATE)
     headers["Authorization"] = f"Bearer {token}"
@@ -226,15 +340,17 @@ class Session:
             return False
 
 
-async def connect_and_run(address: str, stop_event: asyncio.Event) -> bool:
-    """Connect to a known address and poll until disconnected or stopped.
+async def connect_and_run(target, stop_event: asyncio.Event) -> bool:
+    """Connect to a target and poll until disconnected or stopped.
 
-    Returns True if the connection was used successfully (so the caller
-    keeps the cached address), False if the connection failed and the
-    cache should be invalidated.
+    ``target`` is either an address string (Linux) or a BLEDevice carrying
+    live CoreBluetooth details (macOS). Returns True if the connection was
+    used successfully (so the caller keeps the cached address), False if the
+    connection failed and the cache should be invalidated.
     """
-    log(f"Connecting to {address}...")
-    client = BleakClient(address)
+    display = target if isinstance(target, str) else target.address
+    log(f"Connecting to {display}...")
+    client = BleakClient(target)
     try:
         await client.connect()
     except (BleakError, asyncio.TimeoutError) as e:
@@ -299,25 +415,31 @@ async def main() -> None:
     log(f"Poll interval: {POLL_INTERVAL}s")
 
     backoff = 1
+    skip_addr: str | None = None  # macOS: a peripheral to skip for one cycle
     while not stop_event.is_set():
-        address = load_cached_address()
-        if not address:
-            address = await scan_for_device()
-            if address:
-                save_address(address)
-            else:
-                log(f"Device not found, retrying in {backoff}s...")
-                try:
-                    await asyncio.wait_for(stop_event.wait(), timeout=backoff)
-                except asyncio.TimeoutError:
-                    pass
-                backoff = min(backoff * 2, 60)
-                continue
+        # Apply any pending skip exactly once, then clear it so the next
+        # cycle re-tries retrieveConnected (the device may have recovered).
+        target = await discover_target(skip_addr=skip_addr)
+        skip_addr = None
+        if not target:
+            log(f"Device not found, retrying in {backoff}s...")
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=backoff)
+            except asyncio.TimeoutError:
+                pass
+            backoff = min(backoff * 2, 60)
+            continue
 
-        ok = await connect_and_run(address, stop_event)
+        addr = target if isinstance(target, str) else target.address
+        ok = await connect_and_run(target, stop_event)
         if not ok:
-            log("Invalidating cached address")
-            SAVED_ADDR_FILE.unlink(missing_ok=True)
+            if sys.platform == "darwin":
+                # No string cache to drop; instead skip this stale handle on
+                # the next retrieveConnected so the scan fallback is reachable.
+                skip_addr = addr
+            else:
+                log("Invalidating cached address")
+                SAVED_ADDR_FILE.unlink(missing_ok=True)
             try:
                 await asyncio.wait_for(stop_event.wait(), timeout=backoff)
             except asyncio.TimeoutError:

--- a/daemon/test_macos_connect.py
+++ b/daemon/test_macos_connect.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Quick end-to-end test of the macOS connected-peripheral path.
+
+Discovers the HID-held 'Claude Controller', connects without scanning,
+finds the custom GATT characteristics, and writes one test payload.
+Run from Terminal.app (which has Bluetooth permission):
+
+    cd daemon && ./.venv/bin/python ./test_macos_connect.py
+"""
+import asyncio
+
+from bleak import BleakClient
+
+import claude_usage_daemon as d
+
+
+async def main() -> None:
+    d.log("Discovering target via macOS connected-peripheral path...")
+    target = await d.discover_target()
+    if not target:
+        d.log("FAIL: no target found (device powered on and showing splash?)")
+        return
+
+    display = target if isinstance(target, str) else f"{target.name} [{target.address}]"
+    d.log(f"Target: {display}")
+
+    client = BleakClient(target)
+    d.log("Connecting (should NOT scan)...")
+    await client.connect()
+    if not client.is_connected:
+        d.log("FAIL: connected=False")
+        return
+    d.log("Connected. Enumerating services...")
+
+    # List services/chars so we can confirm the custom service is reachable.
+    found_rx = False
+    for service in client.services:
+        for ch in service.characteristics:
+            if ch.uuid.lower() == d.RX_CHAR_UUID.lower():
+                found_rx = True
+    d.log(f"RX characteristic present: {found_rx}")
+
+    if found_rx:
+        payload = '{"s":42,"sr":120,"w":17,"wr":4320,"st":"ok_test","ok":true}'
+        d.log(f"Writing test payload: {payload}")
+        await client.write_gatt_char(d.RX_CHAR_UUID, payload.encode(), response=False)
+        d.log("PASS: wrote test payload — check the device screen.")
+    else:
+        d.log("FAIL: custom RX characteristic not found on the peripheral.")
+
+    await client.disconnect()
+    d.log("Disconnected. Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/firmware/src/data.h
+++ b/firmware/src/data.h
@@ -1,12 +1,18 @@
 #pragma once
 #include <Arduino.h>
 
+// Max accounts the device will display. Bounded by the BLE buffer
+// (BLE_BUF_SIZE=512, ~60 JSON bytes/account) and the daemon, which sends a
+// {"a":[...]} array. Keep in sync with the daemon's expectations.
+#define MAX_ACCOUNTS 8
+
 struct UsageData {
+    char name[16];           // account label (empty for legacy single-account)
     float session_pct;       // 5-hour window utilization (0-100)
     int session_reset_mins;  // minutes until session resets
     float weekly_pct;        // 7-day window utilization (0-100)
     int weekly_reset_mins;   // minutes until weekly resets
     char status[16];         // "allowed" or "limited"
-    bool ok;                 // data parse succeeded
+    bool ok;                 // this account polled successfully
     bool valid;              // false until first successful parse
 };

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -19,7 +19,8 @@
 #include "hal/power_hal.h"
 #include "hal/imu_hal.h"
 
-static UsageData usage = {};
+static UsageData accounts[MAX_ACCOUNTS] = {};
+static int account_count = 0;
 
 // ---- LVGL draw buffers (partial render mode) ----
 // PSRAM-equipped boards (S3) can comfortably hold larger strips. PSRAM-free
@@ -95,23 +96,45 @@ static void my_touch_cb(lv_indev_t* indev, lv_indev_data_t* data) {
     }
 }
 
-// Parse a JSON line into UsageData.
-static bool parse_json(const char* json, UsageData* out) {
+// Fill one UsageData from a JSON account object {n,s,sr,w,wr,st,ok}.
+static void parse_account(JsonObjectConst o, UsageData* out) {
+    strlcpy(out->name, o["n"] | "", sizeof(out->name));
+    out->session_pct = o["s"] | 0.0f;
+    out->session_reset_mins = o["sr"] | -1;
+    out->weekly_pct = o["w"] | 0.0f;
+    out->weekly_reset_mins = o["wr"] | -1;
+    strlcpy(out->status, o["st"] | "unknown", sizeof(out->status));
+    // Default missing "ok" to true so legacy single-object payloads (which
+    // never carried "ok") render their numbers; only an explicit "ok":false
+    // (a daemon-reported failed poll) marks an account offline.
+    out->ok = o["ok"] | true;
+    out->valid = true;
+}
+
+// Parse a JSON line into the accounts[] array. Accepts the multi-account
+// array form {"a":[{...},...]} and, for backward compatibility, a single
+// bare object {...}. Returns the number of accounts parsed (0 on error).
+static int parse_json(const char* json, UsageData* out, int max_out) {
     JsonDocument doc;
     DeserializationError err = deserializeJson(doc, json);
     if (err) {
         Serial.printf("JSON parse error: %s\n", err.c_str());
-        return false;
+        return 0;
     }
 
-    out->session_pct = doc["s"] | 0.0f;
-    out->session_reset_mins = doc["sr"] | -1;
-    out->weekly_pct = doc["w"] | 0.0f;
-    out->weekly_reset_mins = doc["wr"] | -1;
-    strlcpy(out->status, doc["st"] | "unknown", sizeof(out->status));
-    out->ok = doc["ok"] | false;
-    out->valid = true;
-    return true;
+    JsonArrayConst arr = doc["a"].as<JsonArrayConst>();
+    if (!arr.isNull()) {
+        int n = 0;
+        for (JsonObjectConst o : arr) {
+            if (n >= max_out) break;
+            parse_account(o, &out[n++]);
+        }
+        return n;
+    }
+
+    // Legacy single-object payload.
+    parse_account(doc.as<JsonObjectConst>(), &out[0]);
+    return 1;
 }
 
 // ---- Serial command buffer ----
@@ -305,16 +328,19 @@ void loop() {
     check_serial_cmd();
 
     if (ble_has_data()) {
-        if (parse_json(ble_get_data(), &usage)) {
+        int n = parse_json(ble_get_data(), accounts, MAX_ACCOUNTS);
+        if (n > 0) {
+            account_count = n;
+            // Splash animation tracks the first (primary) account's rate.
             int g_before = usage_rate_group();
-            usage_rate_sample(usage.session_pct);
+            usage_rate_sample(accounts[0].session_pct);
             int g_after = usage_rate_group();
             if (g_after != g_before) {
                 Serial.printf("usage rate: group %d -> %d (s=%.2f%%)\n",
-                    g_before, g_after, usage.session_pct);
+                    g_before, g_after, accounts[0].session_pct);
                 if (splash_is_active()) splash_pick_for_current_rate();
             }
-            ui_update(&usage);
+            ui_update_accounts(accounts, n);
             ble_send_ack();
         } else {
             ble_send_nack();

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -112,6 +112,15 @@ static lv_obj_t* lbl_weekly_label;
 static lv_obj_t* lbl_weekly_reset;
 static lv_obj_t* lbl_anim;
 
+// ---- Multi-account state + page indicator ----
+#define ACCOUNT_ROTATE_MS 5000     // auto-advance to the next account every 5s
+static UsageData ui_accounts[MAX_ACCOUNTS];
+static int ui_account_count = 0;   // 0 until first payload
+static int ui_account_idx = 0;     // which account the usage screen shows
+static uint32_t last_account_rotate_ms = 0;  // auto-rotate timer (lv_tick)
+static lv_obj_t* page_dots_cont;            // container, hidden when <2 accounts
+static lv_obj_t* page_dots[MAX_ACCOUNTS];   // one circle per account
+
 // ---- Bluetooth screen widgets ----
 static lv_obj_t* ble_container;
 static lv_obj_t* lbl_ble_status;
@@ -330,6 +339,30 @@ static void init_usage_screen(lv_obj_t* scr) {
     lv_obj_set_style_text_font(lbl_anim, &font_mono_32, 0);
     lv_obj_set_style_text_color(lbl_anim, COL_ACCENT, 0);
     lv_obj_align(lbl_anim, LV_ALIGN_BOTTOM_MID, 0, -15);
+
+    // Page indicator: a centered row of small dots, one per account. Drawn as
+    // LVGL circles (not glyphs) since the custom bitmap fonts lack ●/○. Hidden
+    // when there's a single account so the single-account UI is unchanged.
+    page_dots_cont = lv_obj_create(usage_container);
+    lv_obj_set_style_bg_opa(page_dots_cont, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(page_dots_cont, 0, 0);
+    lv_obj_set_style_pad_all(page_dots_cont, 0, 0);
+    lv_obj_set_style_pad_column(page_dots_cont, 10, 0);
+    lv_obj_set_flex_flow(page_dots_cont, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(page_dots_cont, LV_FLEX_ALIGN_CENTER,
+                          LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(page_dots_cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page_dots_cont, LV_SIZE_CONTENT, 18);
+    lv_obj_align(page_dots_cont, LV_ALIGN_BOTTOM_MID, 0, -58);
+    for (int i = 0; i < MAX_ACCOUNTS; i++) {
+        page_dots[i] = lv_obj_create(page_dots_cont);
+        lv_obj_set_size(page_dots[i], 12, 12);
+        lv_obj_set_style_radius(page_dots[i], LV_RADIUS_CIRCLE, 0);
+        lv_obj_set_style_border_width(page_dots[i], 0, 0);
+        lv_obj_set_style_bg_opa(page_dots[i], LV_OPA_COVER, 0);
+        lv_obj_clear_flag(page_dots[i], LV_OBJ_FLAG_SCROLLABLE);
+    }
+    lv_obj_add_flag(page_dots_cont, LV_OBJ_FLAG_HIDDEN);
 }
 
 // ======== Bluetooth Screen ========
@@ -446,32 +479,100 @@ void ui_init(void) {
     lv_obj_set_pos(battery_img, L.scr_w - 48 - L.margin, L.title_y);
 }
 
-void ui_update(const UsageData* data) {
+// Recolor the page dots to reflect count + current index. Hidden for <2.
+static void update_page_dots(void) {
+    if (ui_account_count < 2) {
+        lv_obj_add_flag(page_dots_cont, LV_OBJ_FLAG_HIDDEN);
+        return;
+    }
+    lv_obj_clear_flag(page_dots_cont, LV_OBJ_FLAG_HIDDEN);
+    for (int i = 0; i < MAX_ACCOUNTS; i++) {
+        if (i < ui_account_count) {
+            lv_obj_clear_flag(page_dots[i], LV_OBJ_FLAG_HIDDEN);
+            bool cur = (i == ui_account_idx);
+            lv_obj_set_style_bg_color(page_dots[i], cur ? COL_TEXT : COL_DIM, 0);
+        } else {
+            lv_obj_add_flag(page_dots[i], LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+}
+
+// Render whichever account ui_account_idx points at onto the usage screen.
+static void render_current_account(void) {
+    if (ui_account_count <= 0) return;
+    if (ui_account_idx >= ui_account_count) ui_account_idx = 0;
+    const UsageData* data = &ui_accounts[ui_account_idx];
     if (!data->valid) return;
 
-    int s_pct = (int)(data->session_pct + 0.5f);
-
-    lv_label_set_text_fmt(lbl_session_pct, "%d%%", s_pct);
-    lv_bar_set_value(bar_session, s_pct, LV_ANIM_ON);
-    lv_obj_set_style_bg_color(bar_session, pct_color(data->session_pct), LV_PART_INDICATOR);
+    // Title shows the account name when there's more than one; otherwise the
+    // original "Usage" so single-account screens look exactly as before.
+    if (ui_account_count > 1 && data->name[0] != '\0')
+        lv_label_set_text(lbl_title, data->name);
+    else
+        lv_label_set_text(lbl_title, "Usage");
 
     char buf[48];
-    format_reset_time(data->session_reset_mins, buf, sizeof(buf));
-    lv_label_set_text(lbl_session_reset, buf);
 
-    int w_pct = (int)(data->weekly_pct + 0.5f);
-    lv_label_set_text_fmt(lbl_weekly_pct, "%d%%", w_pct);
-    lv_bar_set_value(bar_weekly, w_pct, LV_ANIM_ON);
-    lv_obj_set_style_bg_color(bar_weekly, pct_color(data->weekly_pct), LV_PART_INDICATOR);
+    if (data->ok) {
+        int s_pct = (int)(data->session_pct + 0.5f);
+        lv_label_set_text_fmt(lbl_session_pct, "%d%%", s_pct);
+        lv_bar_set_value(bar_session, s_pct, LV_ANIM_ON);
+        lv_obj_set_style_bg_color(bar_session, pct_color(data->session_pct), LV_PART_INDICATOR);
+        format_reset_time(data->session_reset_mins, buf, sizeof(buf));
+        lv_label_set_text(lbl_session_reset, buf);
 
-    format_reset_time(data->weekly_reset_mins, buf, sizeof(buf));
-    lv_label_set_text(lbl_weekly_reset, buf);
+        int w_pct = (int)(data->weekly_pct + 0.5f);
+        lv_label_set_text_fmt(lbl_weekly_pct, "%d%%", w_pct);
+        lv_bar_set_value(bar_weekly, w_pct, LV_ANIM_ON);
+        lv_obj_set_style_bg_color(bar_weekly, pct_color(data->weekly_pct), LV_PART_INDICATOR);
+        format_reset_time(data->weekly_reset_mins, buf, sizeof(buf));
+        lv_label_set_text(lbl_weekly_reset, buf);
+    } else {
+        // Account failed to poll (e.g. logged out) — show it as offline
+        // instead of stale numbers.
+        lv_label_set_text(lbl_session_pct, "--%");
+        lv_bar_set_value(bar_session, 0, LV_ANIM_OFF);
+        lv_label_set_text(lbl_session_reset, "offline");
+        lv_label_set_text(lbl_weekly_pct, "--%");
+        lv_bar_set_value(bar_weekly, 0, LV_ANIM_OFF);
+        lv_label_set_text(lbl_weekly_reset, "offline");
+    }
+
+    update_page_dots();
+}
+
+void ui_update_accounts(const UsageData* accounts, int n) {
+    if (n < 0) n = 0;
+    if (n > MAX_ACCOUNTS) n = MAX_ACCOUNTS;
+    int prev_count = ui_account_count;
+    for (int i = 0; i < n; i++) ui_accounts[i] = accounts[i];
+    ui_account_count = n;
+    if (ui_account_idx >= n) ui_account_idx = 0;
+    // Give the shown account a full interval when multi-account rotation first
+    // becomes active (or the index was just clamped), so it can't be skipped
+    // on the very next tick by a stale timer.
+    if ((prev_count <= 1 && n > 1) || ui_account_idx == 0)
+        last_account_rotate_ms = lv_tick_get();
+    render_current_account();
+}
+
+void ui_update(const UsageData* data) {
+    ui_update_accounts(data, 1);
 }
 
 void ui_tick_anim(void) {
     if (current_screen != SCREEN_USAGE) return;
 
     uint32_t now = lv_tick_get();
+
+    // Auto-rotate through accounts (loops the accounts only; the Bluetooth
+    // screen is reached manually). A manual cycle / screen entry resets the
+    // timer so the chosen account stays up for a full interval.
+    if (ui_account_count > 1 && now - last_account_rotate_ms >= ACCOUNT_ROTATE_MS) {
+        last_account_rotate_ms = now;
+        ui_account_idx = (ui_account_idx + 1) % ui_account_count;
+        render_current_account();
+    }
 
     if (now - anim_msg_start >= ANIM_MSG_MS) {
         anim_msg_idx = (anim_msg_idx + 1) % ANIM_MSG_COUNT;
@@ -517,7 +618,10 @@ void ui_show_screen(screen_t screen) {
 
     switch (screen) {
     case SCREEN_SPLASH:     splash_show(); break;
-    case SCREEN_USAGE:      lv_obj_clear_flag(usage_container, LV_OBJ_FLAG_HIDDEN); break;
+    case SCREEN_USAGE:
+        lv_obj_clear_flag(usage_container, LV_OBJ_FLAG_HIDDEN);
+        last_account_rotate_ms = lv_tick_get();  // full interval on entry
+        break;
     case SCREEN_BLUETOOTH:  lv_obj_clear_flag(ble_container, LV_OBJ_FLAG_HIDDEN); break;
     default: break;
     }
@@ -533,13 +637,24 @@ void ui_show_screen(screen_t screen) {
 }
 
 void ui_cycle_screen(void) {
-    screen_t next;
-    switch (current_screen) {
-    case SCREEN_USAGE:     next = SCREEN_BLUETOOTH; break;
-    case SCREEN_BLUETOOTH: next = SCREEN_USAGE;     break;
-    default:               next = SCREEN_USAGE;     break;
+    last_account_rotate_ms = lv_tick_get();  // manual nav resets auto-rotate
+    // On the usage screen, step through accounts first; only after the last
+    // account does the cycle advance to the Bluetooth screen. With a single
+    // account this collapses to the original USAGE <-> BLUETOOTH toggle.
+    if (current_screen == SCREEN_USAGE && ui_account_idx + 1 < ui_account_count) {
+        ui_account_idx++;
+        render_current_account();
+        return;
     }
-    ui_show_screen(next);
+
+    if (current_screen == SCREEN_USAGE) {
+        ui_account_idx = 0;  // wrap so the next return to USAGE starts at #0
+        ui_show_screen(SCREEN_BLUETOOTH);
+    } else {
+        ui_account_idx = 0;
+        render_current_account();
+        ui_show_screen(SCREEN_USAGE);
+    }
 }
 
 void ui_toggle_splash(void) {

--- a/firmware/src/ui.h
+++ b/firmware/src/ui.h
@@ -10,7 +10,8 @@ enum screen_t {
 };
 
 void ui_init(void);
-void ui_update(const UsageData* data);
+void ui_update(const UsageData* data);                       // single-account (legacy)
+void ui_update_accounts(const UsageData* accounts, int n);   // multi-account
 void ui_tick_anim(void);
 void ui_show_screen(screen_t screen);
 void ui_cycle_screen(void);


### PR DESCRIPTION
## What

Show usage for **multiple Claude subscription accounts** on the device, not just one. The Usage screen auto-rotates through each account (every 5s) with a row of page dots, and the middle (PWR) button steps through them manually before moving on to the Bluetooth screen.

> **Note:** this is stacked on #51 (the macOS BLE fix). Until that merges, the diff here also includes its commit; it'll collapse to just the multi-account commits once #51 is merged.

## How it works

**Daemon** — accounts are declared in `~/.config/claude-usage-monitor/accounts.json` as a list of `{label, config_dir}`. No file = a single default account (fully backward compatible). Each account's token is resolved from its Claude Code profile:

- **macOS:** the per-profile Keychain item — `Claude Code-credentials` for the default profile, or `Claude Code-credentials-<hash>` where `<hash>` is the first 8 hex of `sha256(<absolute config_dir>)`. (This is how Claude Code itself namespaces `CLAUDE_CONFIG_DIR` profiles.)
- **Linux:** `<config_dir>/.credentials.json`.

All accounts are polled concurrently each cycle and sent as a single JSON array on the RX characteristic:

```json
{ "a": [ { "n": "main", "s": 45, "sr": 120, "w": 28, "wr": 7200, "st": "allowed", "ok": true } ] }
```

A failed account is still included as `{ "n": "...", "ok": false }` so the device shows it **offline** rather than dropping it. Writes use write-with-response so CoreBluetooth performs a long write for multi-account arrays up to the 512-byte device buffer.

**Firmware** — `parse_json()` reads the `{"a":[...]}` array into a fixed `accounts[]` (up to `MAX_ACCOUNTS = 8`, bounded by the BLE buffer), still accepting a legacy bare object. The usage screen renders one account at a time (label as the title), auto-rotates in `ui_tick_anim()`, and draws a page-dot indicator. Offline accounts show `--%` / `offline`.

## Backward compatibility

With a single account, behavior is **identical** to before: no page dots, title stays "Usage", no auto-rotation, the same Usage↔Bluetooth toggle, and the legacy single-object payload still parses (a missing `ok` defaults to `true`).

## Testing

Verified end-to-end on a Waveshare AMOLED-2.16 with two real accounts: the daemon polls both concurrently and the device auto-rotates between them with correct per-account numbers and page dots; manual button cycling works; a transient poll failure correctly rendered the account offline. Both the daemon and firmware diffs were reviewed by a second model (Codex) and its findings applied (first-payload rotate-timer reset; legacy `ok`-missing compatibility). Docs + `daemon/accounts.example.json` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
