### PR TITLE
Fix macOS daemon crash: remove non-existent wait_until_ready call

### DIFF
--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -181,8 +181,7 @@ async def _get_cb_manager():
             CentralManagerDelegate,
         )
 
-        mgr = CentralManagerDelegate()
-        await mgr.wait_until_ready()  # raises if Bluetooth is unauthorized/off
+        mgr = CentralManagerDelegate()  # raises BleakError if BT off/unauthorized
         _cb_manager = mgr
     return _cb_manager
 


### PR DESCRIPTION
## Problem

On macOS, the launchd-managed daemon crashed immediately on every start with `SIGABRT`, producing repeated \"Python quit unexpectedly\" dialogs. The daemon would print its startup banner and exit before attempting any BLE connection.

## Root cause

`_get_cb_manager()` called `await mgr.wait_until_ready()` on a `CentralManagerDelegate` instance, but this method does not exist in bleak's API. State readiness and error signalling (Bluetooth off, unauthorized) are handled inside `CentralManagerDelegate.__init__` itself — calling a non-existent method raised `AttributeError` before any BLE work could begin.

## Fix

Remove the `await mgr.wait_until_ready()` line. `CentralManagerDelegate()` already raises `BleakError` on failure, so no additional readiness check is needed.

## Notes

- The daemon requires **Python 3.10+** (`str | None` union syntax is used throughout). Venvs built with Python 3.9 (macOS system default) also crash at import time with `TypeError: unsupported operand type(s) for |`.
- Tested on macOS with bleak 1.1.1 and Python 3.14.

## Test plan

- [ ] Rebuild venv with Python 3.10+: `python3 -m venv daemon/.venv && daemon/.venv/bin/pip install bleak httpx`
- [ ] Reload launchd agent: `launchctl kickstart -k gui/$(id -u)/com.user.claude-usage-daemon`
- [ ] Confirm daemon connects and sends data (check `~/Library/Logs/claude-usage-daemon.out.log`)
- [ ] Confirm no crash dialogs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)