### PR TITLE
feat(amoled-18-c6): add ESP32-C6 Waveshare AMOLED-1.8 board port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,19 @@
 # Project context
 
-ESP32-S3 firmware for a desk-side Claude Code usage monitor. Each supported
-board lives in its own `firmware/src/boards/<name>/` folder and is selected
-via PlatformIO's `build_src_filter`. Adding a board means dropping in a new
-folder + a new `[env:...]` block — `main.cpp`, `ui.cpp`, and `splash.cpp`
+ESP32-S3 / ESP32-C6 firmware for a desk-side Claude Code usage monitor. Each
+supported board lives in its own `firmware/src/boards/<name>/` folder and is
+selected via PlatformIO's `build_src_filter`. Adding a board means dropping in
+a new folder + a new `[env:...]` block — `main.cpp`, `ui.cpp`, and `splash.cpp`
 never see board-specific code. See [`docs/porting/adding-a-board.md`](docs/porting/adding-a-board.md).
 
-Two reference ports today:
+Four ports today (two SoC families, two panel sizes):
 
 - `boards/waveshare_amoled_216/` — original Waveshare ESP32-S3-Touch-AMOLED-2.16 (CO5300, 480×480 square, CST9220 touch, IMU rotation). Build env: `waveshare_amoled_216`.
 - `boards/waveshare_amoled_18/` — Waveshare ESP32-S3-Touch-AMOLED-1.8 (368×448 portrait, XCA9554 IO expander). Build env: `waveshare_amoled_18`. **Two panel revisions are auto-detected at boot** (`board_rev()` in `board_init.cpp`, enum in `board_rev.h`): original = SH8601 display + FT3168 touch (0x38); later = CO5300 display + CST816 touch (0x15). One binary drives both.
+- `boards/waveshare_amoled_216_c6/` — Waveshare ESP32-C6-Touch-AMOLED-2.16 (SH8601, 480×480, CST9217 touch). Build env: `waveshare_amoled_216_c6`. ESP32-C6 SoC: single-core RISC-V, **no PSRAM**, BLE 5 only.
+- `boards/waveshare_amoled_18_c6/` — Waveshare ESP32-C6-Touch-AMOLED-1.8 (368×448 portrait, SH8601, FT3168 touch, TCA9554 expander). Build env: `waveshare_amoled_18_c6`. Same panel as the S3 1.8 but on the C6 SoC. All subsystems (display, touch, BOOT + PWR buttons, battery, BLE) verified on hardware.
+
+**C6 ports have no PSRAM** — shared code gates on `BOARD_HAS_PSRAM` (absent on C6) to use `MALLOC_CAP_INTERNAL` for LVGL/splash buffers, and the `screenshot` serial command is disabled (`LV_USE_SNAPSHOT=0`), so UI changes on a C6 board must be eyeballed on hardware, not auto-captured.
 
 The shared code calls a small HAL (`firmware/src/hal/`) that each board implements: display, touch, input, power, IMU. Optional features are guarded by `BoardCaps` (runtime) and `BOARD_HAS_*` (compile-time) rather than `#ifdef BOARD_*`.
 
@@ -34,6 +38,17 @@ Connects to a host daemon over BLE; daemon polls Anthropic API for usage data. T
 - Orientation: **fixed at 0°**. IMU auto-rotation is disabled; `rotate_strip()` / `handle_rotation_change()` are excluded via `#ifndef BOARD_AMOLED_18`.
 - Buttons: GPIO 0 (BOOT → Space/voice-mode), XCA9554 EXIO4 (PWR → cycle screens; on splash → cycle animations). **No third button** (GPIO 18 button doesn't exist on this board).
 
+### AMOLED-1.8 (C6) — `waveshare_amoled_18_c6`
+ESP32-C6 sibling of the S3 1.8: same 368×448 SH8601 panel + FocalTech touch, different SoC and GPIO map. **All pins/edges below verified on hardware via temporary GPIO/IRQ scans, since Waveshare's wiki publishes no pin table and the third-party BSP's numbers were partly wrong.**
+- Display: **SH8601** AMOLED via QSPI (CS=5, SCLK=0, SDIO0..3=1..4, no MCU reset pin — internal POR; effective reset is the TCA9554 power-cycle). Stock `Arduino_SH8601` init (no vendor-register patch — that's only needed on the C6 2.16).
+- Touch: **FT3168** (some units FT6146) @ I2C 0x38, INT=15. Same inline FocalTech reader as the S3 1.8 (regs 0x02..0x06); no reset pin (gated by TCA9554 touch power).
+- I2C bus: SDA=8, SCL=7 (shared by TCA9554, AXP2101, FT3168, QMI8658, PCF85063 RTC, ES8311 codec).
+- IO expander: **TCA9554 / PCA9554** @ 0x20 — here it gates **power**, not reset: **P4 = display power, P5 = touch power, P7 = audio amp**. `io_expander_init()` runs the documented power-on sequence (P4/P5 LOW → 200 ms → HIGH) and **MUST run before `display_hal_init()`** or the panel stays unpowered. Amp (P7) left off (no audio path).
+- PMU: AXP2101 @ 0x34 (owned by `power.cpp`, not `board_init` — LCD isn't on an ALDO rail here).
+- IMU: QMI8658 @ 0x6B (init'd for bus health, rotation disabled).
+- Orientation: **fixed at 0°**, no rotation (no PSRAM headroom).
+- Buttons: **GPIO 9** (BOOT → Space/voice-mode, active LOW — *not* the docs' GPIO 0/9 guess; confirmed by scan), **AXP2101 PKEY** (PWR → cycle screens; on splash → cycle animations). The PKEY **SHORT-press IRQ fires on release** — that's the edge `power.cpp` acts on. No secondary button.
+
 ## Architecture
 
 ```text
@@ -48,6 +63,8 @@ firmware/src/
   boards/
     waveshare_amoled_216/   — CO5300 + CST9220 + AXP PKEY + QMI8658 rotation
     waveshare_amoled_18/    — SH8601 + FT3168 + AXP + XCA9554 (PWR via EXIO4), no rotation
+    waveshare_amoled_216_c6/— C6: SH8601 + CST9217 + AXP PKEY, no PSRAM
+    waveshare_amoled_18_c6/ — C6: SH8601 + FT3168 + AXP PKEY + TCA9554 (gates power), no PSRAM
     template/               — copy this to bootstrap a new port
   main.cpp                  — setup() + loop(): HAL calls only, zero #ifdef BOARD_*
   ui.{h,cpp}                — 3-screen UI (splash, usage, bluetooth). compute_layout() picks fonts/positions from board_caps() (responsive — current breakpoint: H >= 460 → large, else compact)
@@ -70,10 +87,14 @@ PlatformIO's `build_src_filter` includes shared code + one board's folder per en
 ## Build / flash
 
 ```bash
-pio run -d firmware -e waveshare_amoled_216                                     # build 2.16 (default original)
-pio run -d firmware -e waveshare_amoled_18                                      # build 1.8 (new port)
+pio run -d firmware -e waveshare_amoled_216                                     # build 2.16 (S3, default original)
+pio run -d firmware -e waveshare_amoled_18                                      # build 1.8 (S3)
+pio run -d firmware -e waveshare_amoled_216_c6                                  # build 2.16 (C6)
+pio run -d firmware -e waveshare_amoled_18_c6                                   # build 1.8 (C6)
 pio run -d firmware -e waveshare_amoled_18 -t upload --upload-port /dev/cu.usbmodem101   # flash 1.8 on macOS
 pio run -d firmware -e waveshare_amoled_216 -t upload --upload-port /dev/ttyACM0         # flash 2.16 on Linux
+# C6 boards: same native USB-JTAG flashing; flag a chip mismatch ("This chip is ESP32-C6,
+# not ESP32-S3") means you picked an S3 env — use a *_c6 env for C6 hardware.
 ```
 
 If `pio` isn't on PATH: try `~/.platformio/penv/bin/pio` (Linux/macOS pio install) or `brew install platformio` on macOS.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Boards supported out of the box:
 - [Waveshare ESP32-S3-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm?&aff_id=149786)
 - [Waveshare ESP32-C6-Touch-AMOLED-2.16](https://www.waveshare.com/esp32-c6-touch-amoled-2.16.htm?&aff_id=149786) 
 - [Waveshare ESP32-S3-Touch-AMOLED-1.8](https://www.waveshare.com/esp32-s3-touch-amoled-1.8.htm?&aff_id=149786)
+- [Waveshare ESP32-C6-Touch-AMOLED-1.8](https://www.waveshare.com/esp32-c6-touch-amoled-1.8.htm?&aff_id=149786)
 
 > Please check if a pull request exists for your alternative hardware port before opening a new one, providing QA feedback and testing on the same hardware is more valuable than duplicate pull requests.
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -177,3 +177,70 @@ lib_deps =
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+
+[env:waveshare_amoled_18_c6]
+; C6 sibling of the AMOLED-1.8. Same 368x448 SH8601 panel + FT3168 touch as
+; the S3 1.8, but on the C6 SoC: no PSRAM, single-core RISC-V, BLE 5 only.
+; Display/touch power is gated by a TCA9554 IO expander (P4/P5); PWR button
+; is the AXP2101 PKEY. If the build fails resolving the C6 board, bump
+; pioarduino to a newer 55.x release that ships esp32-c6-devkitc-1.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-c6-devkitc-1
+framework = arduino
+upload_speed = 921600
+monitor_speed = 115200
+; Waveshare's C6-AMOLED-1.8 ships with 16 MB flash. The default 1.25 MB app
+; partition can't hold this firmware — switch to the 16 MB layout that gives
+; the app ~6.5 MB, matching the other 16 MB envs.
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_build.partitions = default_16MB.csv
+
+build_src_filter =
+    +<*>
+    -<boards/>
+    +<boards/waveshare_amoled_18_c6/>
+
+build_flags =
+    -DBOARD_AMOLED_18_C6
+    ; C6 has only USB-Serial-JTAG (HWCDC), no native USB-OTG. The Arduino
+    ; core maps Serial → HWCDCSerial only when BOTH flags below are set;
+    ; CDC_ON_BOOT alone selects USBSerial (TinyUSB) which doesn't exist on
+    ; C6 and breaks the build.
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DARDUINO_USB_MODE=1
+    ; No -DBOARD_HAS_PSRAM — C6 has no external PSRAM. Shared code
+    ; (main.cpp, splash.cpp) gates on this to pick MALLOC_CAP_INTERNAL
+    ; and shrink LVGL buffers + splash canvas accordingly.
+    -DXPOWERS_CHIP_AXP2101
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    ; Screenshot capture needs a full-frame RGB565 buffer that doesn't fit in
+    ; C6 internal SRAM. send_screenshot prints SCREENSHOT_UNSUPPORTED instead.
+    -DLV_USE_SNAPSHOT=0
+
+lib_deps =
+    ; 1.6.4+ required for Arduino_SH8601
+    moononournation/GFX Library for Arduino@^1.6.4
+    lewisxhe/SensorLib@^0.2.6
+    lewisxhe/XPowersLib@^0.2.7
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/src/boards/waveshare_amoled_18_c6/board.h
+++ b/firmware/src/boards/waveshare_amoled_18_c6/board.h
@@ -1,0 +1,65 @@
+#pragma once
+
+// Waveshare ESP32-C6-Touch-AMOLED-1.8 — the C6 sibling of the S3 AMOLED-1.8.
+//
+// Same 368x448 SH8601 panel and FocalTech FT3168 (some units FT6146) touch
+// as the S3 1.8 kit, but on the ESP32-C6 SoC: single-core RISC-V, no PSRAM,
+// BLE 5 only, and its own GPIO map. AXP2101 PMU + QMI8658 IMU + a TCA9554 IO
+// expander all share one I2C bus with the touch controller and RTC/codec.
+//
+// Unlike the S3 1.8 (where the TCA9554 gates display/touch *reset*), this
+// board's expander gates display/touch *power*: P4 = display power, P5 =
+// touch power, P7 = audio amp. The documented power-up sequence pulls P4/P5
+// LOW, waits 200 ms, then drives them HIGH before the panel sees any QSPI.
+//
+// Pin map from the official product docs plus the third-party ESP-IDF BSP at
+// github.com/chayuto/ESP32-C6-Touch-AMOLED-1.8 (CLAUDE.md GPIO map). The PWR
+// button routes through the AXP2101 PKEY (like the C6 2.16), not the expander.
+
+#define BOARD_NAME           "Waveshare AMOLED 1.8 (C6)"
+
+// ---- Display geometry (portrait) ----
+#define LCD_WIDTH            368
+#define LCD_HEIGHT           448
+
+// ---- QSPI display pins (SH8601) ----
+#define LCD_CS               5
+#define LCD_SCLK             0
+#define LCD_SDIO0            1
+#define LCD_SDIO1            2
+#define LCD_SDIO2            3
+#define LCD_SDIO3            4
+// LCD reset is not wired to a MCU GPIO. The panel boots from its internal
+// POR; the TCA9554 power-cycle (P4) below acts as the effective reset. The
+// Arduino_GFX driver gets GFX_NOT_DEFINED for reset.
+
+// ---- I2C bus (touch + PMU + IMU + IO expander + RTC + codec share one bus) ----
+#define IIC_SDA              8
+#define IIC_SCL              7
+
+// ---- Touch (minimal inline I2C reader; FT3168/FT6146, FocalTech layout) ----
+// Data layout at regs 0x02..0x06, same family as the S3 1.8 FT3168. INT only;
+// reset is handled by the TCA9554 touch-power line, not a dedicated pin.
+#define TP_INT               15
+#define FT3168_ADDR          0x38
+
+// ---- PMU ----
+#define AXP2101_ADDR         0x34
+
+// ---- IO expander (TCA9554/PCA9554 compatible) ----
+// Gates display power, touch power, and the audio amp enable.
+#define XCA9554_ADDR         0x20
+#define IOX_PIN_LCD_PWR      4     // P4 → display power (active HIGH)
+#define IOX_PIN_TP_PWR       5     // P5 → touch power   (active HIGH)
+#define IOX_PIN_PA_EN        7     // P7 → audio amp enable (active HIGH)
+
+// ---- Buttons ----
+#define BTN_BACK_GPIO        9     // BOOT — primary, Space (PTT)
+// PWR comes via the AXP2101 PKEY (see power.cpp); there is no secondary button.
+
+// ---- Capability flags ----
+#define BOARD_HAS_SECONDARY_BUTTON 0
+#define BOARD_HAS_ROTATION         0    // C6 has no PSRAM headroom for the rotation strip
+#define BOARD_HAS_IMU              1    // present + initialized for I2C bus health
+#define BOARD_HAS_BATTERY          1
+#define BOARD_HAS_IO_EXPANDER      1

--- a/firmware/src/boards/waveshare_amoled_18_c6/board_init.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/board_init.cpp
@@ -1,0 +1,20 @@
+#include "board.h"
+#include "io_expander.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// Bring up the shared I2C bus, then run the TCA9554 power-on sequence that
+// applies power to the display (P4) and touch (P5). This MUST happen before
+// display_hal_init() / touch_hal_init() — both controllers are unpowered
+// until the expander drives their rails HIGH.
+//
+// Unlike the C6 2.16, the LCD here is not fed from an AXP2101 ALDO rail, so
+// no PMU rail config is needed at this stage; power.cpp brings the PMU up
+// later for battery monitoring + PKEY handling. (If the panel ever comes up
+// black despite the expander sequence, enabling the AXP ALDO rails here is
+// the first thing to try.)
+
+extern "C" void board_init(void) {
+    Wire.begin(IIC_SDA, IIC_SCL);
+    io_expander_init();
+}

--- a/firmware/src/boards/waveshare_amoled_18_c6/caps.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/caps.cpp
@@ -1,0 +1,14 @@
+#include "../../hal/board_caps.h"
+#include "board.h"
+
+static const BoardCaps caps = {
+    .name = BOARD_NAME,
+    .width = LCD_WIDTH,
+    .height = LCD_HEIGHT,
+    .button_count = 1,
+    .has_rotation = false,
+    .has_battery = true,
+    .has_imu = true,
+};
+
+const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_amoled_18_c6/display.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/display.cpp
@@ -1,0 +1,52 @@
+#include "../../hal/display_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+// Same SH8601 368x448 panel as the S3 AMOLED-1.8, so the stock Arduino_GFX
+// SH8601 init is sufficient — no vendor-register patch like the C6 2.16
+// needs. Display power is gated by the TCA9554 (P4), brought up in
+// board_init() before this runs; reset is the panel's internal POR, so the
+// GFX driver gets GFX_NOT_DEFINED. Rotation is disabled (no PSRAM headroom).
+
+static Arduino_DataBus* bus = nullptr;
+static Arduino_SH8601*  gfx = nullptr;
+
+void display_hal_init(void) {
+    bus = new Arduino_ESP32QSPI(
+        LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
+    gfx = new Arduino_SH8601(
+        bus, GFX_NOT_DEFINED, 0, LCD_WIDTH, LCD_HEIGHT);
+}
+
+void display_hal_begin(void) {
+    gfx->begin();
+    gfx->fillScreen(0x0000);
+    gfx->setBrightness(200);
+}
+
+void display_hal_set_brightness(uint8_t level) {
+    if (gfx) gfx->setBrightness(level);
+}
+
+void display_hal_fill_screen(uint16_t color) {
+    if (gfx) gfx->fillScreen(color);
+}
+
+void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
+                             const uint16_t* pixels) {
+    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+}
+
+void display_hal_tick(void) {
+    // No rotation cycle on this board.
+}
+
+// Even-alignment rounder — harmless on SH8601, kept for consistency with the
+// other AMOLED ports.
+void display_hal_round_area(int32_t* x1, int32_t* y1, int32_t* x2, int32_t* y2) {
+    *x1 = *x1 & ~1;
+    *y1 = *y1 & ~1;
+    *x2 = *x2 | 1;
+    *y2 = *y2 | 1;
+}

--- a/firmware/src/boards/waveshare_amoled_18_c6/imu.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/imu.cpp
@@ -1,0 +1,25 @@
+#include "../../hal/imu_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <SensorQMI8658.hpp>
+
+// QMI8658 is populated but rotation is disabled (BOARD_HAS_ROTATION=0, and
+// the C6 has no PSRAM headroom for the rotation strip). We still initialize
+// it to keep the shared I2C bus healthy. Always reports quadrant 0.
+
+static SensorQMI8658 imu;
+
+void imu_hal_init(void) {
+    if (!imu.begin(Wire, QMI8658_L_SLAVE_ADDRESS, IIC_SDA, IIC_SCL)) {
+        Serial.println("QMI8658 init failed");
+        return;
+    }
+    Serial.println("QMI8658 init OK (rotation disabled on this board)");
+}
+
+void imu_hal_tick(void) {
+    // No-op — rotation is disabled.
+}
+
+uint8_t imu_hal_rotation_quadrant(void) { return 0; }

--- a/firmware/src/boards/waveshare_amoled_18_c6/input.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/input.cpp
@@ -1,0 +1,21 @@
+#include "../../hal/input_hal.h"
+#include "board.h"
+#include <Arduino.h>
+
+// Only the BOOT button (primary, GPIO 9, active LOW — verified on hardware)
+// is a GPIO input here. The PWR button comes through power_hal (AXP2101
+// PKEY). No secondary button on this board.
+
+void input_hal_init(void) {
+    pinMode(BTN_BACK_GPIO, INPUT_PULLUP);
+}
+
+bool input_hal_is_held(InputButton btn) {
+    switch (btn) {
+    case INPUT_BTN_PRIMARY:
+        return digitalRead(BTN_BACK_GPIO) == LOW;
+    case INPUT_BTN_SECONDARY:
+        return false;   // not present on this board
+    }
+    return false;
+}

--- a/firmware/src/boards/waveshare_amoled_18_c6/io_expander.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/io_expander.cpp
@@ -1,0 +1,68 @@
+#include "io_expander.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// TCA9554/PCA9554 register map
+#define IOX_REG_INPUT    0x00
+#define IOX_REG_OUTPUT   0x01
+#define IOX_REG_POLARITY 0x02
+#define IOX_REG_CONFIG   0x03   // 1 = input, 0 = output
+
+// P4 (display power), P5 (touch power), P7 (amp enable) are outputs; the rest
+// stay inputs. Config bit = 1 means input, so the output mask is the inverse
+// of bits 4, 5, 7: ~0b10110000 = 0x4F.
+#define IOX_CONFIG_MASK    0x4F
+// Display + touch powered on, amp left off (this firmware has no audio path,
+// and enabling an idle class-D amp just adds hiss). Bits 4 | 5 = 0x30.
+#define IOX_OUTPUT_DEFAULT 0x30
+
+static uint8_t output_state = 0x00;
+
+static bool write_reg(uint8_t reg, uint8_t val) {
+    Wire.beginTransmission(XCA9554_ADDR);
+    Wire.write(reg);
+    Wire.write(val);
+    return Wire.endTransmission() == 0;
+}
+
+static bool read_reg(uint8_t reg, uint8_t& val) {
+    Wire.beginTransmission(XCA9554_ADDR);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return false;
+    if (Wire.requestFrom(XCA9554_ADDR, (uint8_t)1) != 1) return false;
+    val = Wire.read();
+    return true;
+}
+
+bool io_expander_init(void) {
+    if (!write_reg(IOX_REG_CONFIG, IOX_CONFIG_MASK)) {
+        Serial.println("TCA9554 init failed (config)");
+        return false;
+    }
+    // Documented power-on sequence: display + touch power LOW, hold 200 ms,
+    // then HIGH. The hold lets the panel rails fully discharge so the SH8601
+    // sees a clean cold start (its only "reset" on this board).
+    output_state = 0x00;
+    write_reg(IOX_REG_OUTPUT, output_state);
+    delay(200);
+    output_state = IOX_OUTPUT_DEFAULT;
+    write_reg(IOX_REG_OUTPUT, output_state);
+    delay(120);   // let display + touch rails stabilize before probing
+    Serial.println("TCA9554 init OK (display + touch powered)");
+    return true;
+}
+
+void io_expander_set(uint8_t pin, bool high) {
+    if (pin > 7) return;
+    if (high) output_state |= (1u << pin);
+    else      output_state &= ~(1u << pin);
+    write_reg(IOX_REG_OUTPUT, output_state);
+}
+
+bool io_expander_get(uint8_t pin) {
+    if (pin > 7) return false;
+    uint8_t v = 0;
+    if (!read_reg(IOX_REG_INPUT, v)) return false;
+    return (v & (1u << pin)) != 0;
+}

--- a/firmware/src/boards/waveshare_amoled_18_c6/io_expander.h
+++ b/firmware/src/boards/waveshare_amoled_18_c6/io_expander.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <stdint.h>
+
+// TCA9554 / PCA9554-compatible 8-bit I2C IO expander.
+// Board-private to the C6 AMOLED-1.8 port; not exposed in hal/.
+//
+// On this board the expander gates display power (P4) and touch power (P5),
+// so it MUST be brought up (and the power-on sequence run) BEFORE the display
+// or touch are initialized — otherwise both panels stay unpowered and fail to
+// probe. board_init() calls io_expander_init() before display_hal_init().
+
+bool io_expander_init(void);
+void io_expander_set(uint8_t pin, bool high);
+bool io_expander_get(uint8_t pin);

--- a/firmware/src/boards/waveshare_amoled_18_c6/power.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/power.cpp
@@ -1,0 +1,94 @@
+#include "../../hal/power_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <XPowersLib.h>
+
+// AXP2101 PMU — same chip and protocol as the other ports. On this board the
+// LCD/touch rails are gated by the TCA9554 (see board_init.cpp), not by the
+// PMU, so the PMU is owned here and brought up in power_hal_init(). The PWR
+// button is the AXP2101 PKEY (like the C6 2.16): a short press fires the
+// SHORT-press IRQ on release (verified on hardware — raw status 0x49 reports
+// neg edge on press, then short+positive on release).
+
+#define BATTERY_POLL_MS  2000
+#define CHARGING_POLL_MS 500
+#define PWR_POLL_MS      50
+
+static XPowersPMU pmu;
+
+static int      cached_pct        = -1;
+static bool     cached_charging   = false;
+static bool     cached_vbus       = false;
+static bool     pwr_pressed_flag  = false;
+static bool     pwr_long_flag     = false;
+static bool     pwr_released_flag = false;
+static uint32_t last_battery_ms   = 0;
+static uint32_t last_charging_ms  = 0;
+static uint32_t last_pwr_ms       = 0;
+
+void power_hal_init(void) {
+    if (!pmu.begin(Wire, AXP2101_ADDR, IIC_SDA, IIC_SCL)) {
+        Serial.println("AXP2101 init failed");
+        return;
+    }
+    Serial.println("AXP2101 init OK");
+
+    pmu.enableBattDetection();
+    pmu.enableBattVoltageMeasure();
+
+    pmu.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
+    pmu.clearIrqStatus();
+    pmu.enableIRQ(XPOWERS_AXP2101_PKEY_SHORT_IRQ
+                | XPOWERS_AXP2101_PKEY_LONG_IRQ
+                | XPOWERS_AXP2101_PKEY_POSITIVE_IRQ);
+
+    // Bump press-off to 8s so a slightly-too-long hold doesn't shut the
+    // device down mid hold-to-pair gesture.
+    pmu.setPowerKeyPressOffTime(XPOWERS_POWEROFF_8S);
+
+    cached_charging = pmu.isCharging();
+    cached_vbus     = pmu.isVbusIn();
+    cached_pct = pmu.getBatteryPercent();
+}
+
+void power_hal_tick(void) {
+    uint32_t now = millis();
+
+    if (now - last_charging_ms >= CHARGING_POLL_MS) {
+        last_charging_ms = now;
+        cached_charging = pmu.isCharging();
+        cached_vbus     = pmu.isVbusIn();
+    }
+    if (now - last_battery_ms >= BATTERY_POLL_MS) {
+        last_battery_ms = now;
+        cached_pct = pmu.getBatteryPercent();
+    }
+    if (now - last_pwr_ms >= PWR_POLL_MS) {
+        last_pwr_ms = now;
+        pmu.getIrqStatus();
+        if (pmu.isPekeyShortPressIrq())    pwr_pressed_flag  = true;
+        if (pmu.isPekeyLongPressIrq())     pwr_long_flag     = true;
+        if (pmu.isPekeyPositiveIrq())      pwr_released_flag = true;
+        pmu.clearIrqStatus();
+    }
+}
+
+int  power_hal_battery_pct(void) { return cached_pct; }
+bool power_hal_is_charging(void) { return cached_charging; }
+bool power_hal_is_vbus_in(void)  { return cached_vbus; }
+
+bool power_hal_pwr_pressed(void) {
+    if (pwr_pressed_flag) { pwr_pressed_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_long_pressed(void) {
+    if (pwr_long_flag) { pwr_long_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_released(void) {
+    if (pwr_released_flag) { pwr_released_flag = false; return true; }
+    return false;
+}

--- a/firmware/src/boards/waveshare_amoled_18_c6/sound.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/sound.cpp
@@ -1,0 +1,12 @@
+#include "../../hal/sound_hal.h"
+
+// C6 AMOLED-1.8: an ES8311 codec sits on the shared I2C bus and the audio amp
+// is gated by TCA9554 P7, but this port never brings that path up (P7 is left
+// off in io_expander_init) and it's unverified on hardware — so sound output
+// is a no-op. The real ES8311 chime engine lives in ../../chime.cpp and is
+// wired up by the S3 sibling (boards/waveshare_amoled_18/sound.cpp) behind
+// BOARD_HAS_SOUND; enable it here once the amp path is verified on this board.
+
+void sound_hal_init(void) {}
+void sound_hal_tick(void) {}
+void sound_hal_play_reset(void) {}

--- a/firmware/src/boards/waveshare_amoled_18_c6/touch.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/touch.cpp
@@ -1,0 +1,71 @@
+#include "../../hal/touch_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// Minimal capacitive-touch reader for the FT3168 (some units ship an FT6146;
+// both are FocalTech parts at 0x38 with the same data layout, so one path
+// serves both). Mirrors the S3 1.8 inline reader — touch reset is handled by
+// the TCA9554 touch-power line, so there's no reset pin to drive here.
+//   reg 0x02:        low nibble = active finger count
+//   reg 0x03 / 0x04: X1 high (low nibble) + X1 low
+//   reg 0x05 / 0x06: Y1 high (low nibble) + Y1 low
+
+static volatile bool     touch_data_ready = false;
+static volatile bool     touch_pressed = false;
+static volatile uint16_t touch_x = 0;
+static volatile uint16_t touch_y = 0;
+
+static void IRAM_ATTR touch_isr(void) {
+    touch_data_ready = true;
+}
+
+static void touch_read_into_shared_state(void) {
+    Wire.beginTransmission(FT3168_ADDR);
+    Wire.write(0x02);
+    if (Wire.endTransmission(false) != 0) { touch_pressed = false; return; }
+    if (Wire.requestFrom(FT3168_ADDR, (uint8_t)5) != 5) { touch_pressed = false; return; }
+    uint8_t fingers = Wire.read() & 0x0F;
+    uint8_t xH = Wire.read();
+    uint8_t xL = Wire.read();
+    uint8_t yH = Wire.read();
+    uint8_t yL = Wire.read();
+    if (fingers == 0 || fingers > 5) {
+        touch_pressed = false;
+        return;
+    }
+    touch_x = ((uint16_t)(xH & 0x0F) << 8) | xL;
+    touch_y = ((uint16_t)(yH & 0x0F) << 8) | yL;
+    touch_pressed = true;
+}
+
+void touch_hal_init(void) {
+    // FT3168 power-mode register 0xA5 = 0x00: active scanning.
+    Wire.beginTransmission(FT3168_ADDR);
+    Wire.write(0xA5);
+    Wire.write(0x00);
+    Wire.endTransmission();
+
+    // Verify the controller answers (FT3168 chip-id is reg 0xA0).
+    Wire.beginTransmission(FT3168_ADDR);
+    Wire.write(0xA0);
+    if (Wire.endTransmission(false) == 0 && Wire.requestFrom(FT3168_ADDR, (uint8_t)1) == 1) {
+        Serial.printf("Touch FT3168 ID=0x%02X (addr 0x%02X)\n", Wire.read(), FT3168_ADDR);
+    } else {
+        Serial.printf("Touch ID read failed (addr 0x%02X)\n", FT3168_ADDR);
+    }
+
+    pinMode(TP_INT, INPUT_PULLUP);
+    attachInterrupt(TP_INT, touch_isr, FALLING);
+    Serial.println("Touch attached on INT pin");
+}
+
+void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
+    if (touch_data_ready) {
+        touch_data_ready = false;
+        touch_read_into_shared_state();
+    }
+    *x = touch_x;
+    *y = touch_y;
+    *pressed = touch_pressed;
+}


### PR DESCRIPTION
Adds boards/waveshare_amoled_18_c6/ and [env:waveshare_amoled_18_c6]. Same 368x448 SH8601 panel + FT3168 touch as the S3 AMOLED-1.8, on the ESP32-C6 SoC (single-core RISC-V, no PSRAM, BLE 5). A TCA9554 IO expander gates display/touch power (P4/P5); BOOT button is on GPIO 9 and PWR on the AXP2101 PKEY. No-PSRAM gating reuses the existing BOARD_HAS_PSRAM paths; screenshot capture is disabled (LV_USE_SNAPSHOT=0).

Pin map and button edges verified on hardware via temporary GPIO/IRQ scans (Waveshare publishes no pin table; the third-party BSP's numbers were partly wrong). Display, touch, both buttons, battery/PMU, IMU and BLE all confirmed.