### PR TITLE
firmware: flip to idle on the daemon's {"ok": false} no-data beat

### DIFF
--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -126,6 +126,7 @@ static lv_image_dsc_t battery_dscs[5];  // empty, low, medium, full, charging
 static lv_obj_t* idle_group;            // the "Zzz" idle screen
 static uint32_t  last_data_ms = 0;      // lv_tick when the last valid usage update landed
 static bool      data_received = false; // any valid update since boot
+static bool      data_ok = true;        // last payload's ok flag; a {"ok":false} beat = "no fresh data"
 static int       view_state = -1;       // -1 unknown / 0 pair / 1 idle / 2 usage
 static const uint32_t DATA_FRESH_MS = 90000;  // usage counts as "live" within this window (daemon sends ~60s)
 
@@ -431,7 +432,9 @@ void ui_init(void) {
 
 void ui_update(const UsageData* data) {
     if (!data->valid) return;
-    last_data_ms = lv_tick_get();   // a valid usage update just landed → dot goes green
+    data_ok = data->ok;
+    if (!data->ok) return;          // a {"ok":false} "no data" beat → fall through to idle, keep last numbers
+    last_data_ms = lv_tick_get();   // a real usage update just landed
     data_received = true;
 
     int s_pct = (int)(data->session_pct + 0.5f);
@@ -462,7 +465,7 @@ static void update_view_state(void) {
     int v;
     if (!s_ble_connected) {
         v = 0;  // pairing hint
-    } else if (data_received && (lv_tick_get() - last_data_ms) < DATA_FRESH_MS) {
+    } else if (data_received && data_ok && (lv_tick_get() - last_data_ms) < DATA_FRESH_MS) {
         v = 2;  // live usage
     } else {
         v = 1;  // idle / Zzz


### PR DESCRIPTION
Follow-up to #64 (idle screen, merged): make the idle screen appear *immediately* when the daemon explicitly says it has no data, instead of waiting out the ~90s freshness window.

The daemon (see #63) sends `{"ok": false}` when it genuinely can't get usage data — token expired, refresh failed, no token. This handles that beat: `ui_update` treats `ok:false` as "no fresh data" — it keeps the last numbers (so they update cleanly when data resumes) but doesn't refresh the freshness timer, and the view-state gate adds `data_ok` so it resolves to the idle screen right away.

Harmless on its own — `ok:true` is the steady state and behaves exactly as before; useful the moment a daemon that emits the beat (#63) is paired.

**Merge order:** land this before #63, so deployed firmware understands the beat. (Firmware without this change would treat `{"ok":false}` as a usage payload and render 0%.)

Verified end-to-end on an AMOLED-2.16: daemon `{"ok":false}` → idle ("No data…") within a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
