### PR TITLE
fix(windows-daemon): auto-refresh expired Claude OAuth token

### DIFF
--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -15,6 +15,7 @@ import os
 import re
 import signal
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -51,6 +52,15 @@ API_BODY = {
     "max_tokens": 1,
     "messages": [{"role": "user", "content": "hi"}],
 }
+
+# OAuth token refresh — VERIFIED values from RESEARCH.md
+# Primary: platform.claude.com (current preferred host); fallback: console.anthropic.com (proven working)
+OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+OAUTH_FALLBACK_URL = "https://console.anthropic.com/v1/oauth/token"
+OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+# Proactive refresh window: refresh if token expires within this many seconds
+OAUTH_PROACTIVE_REFRESH_SECS = 5 * 60  # 5 minutes
 
 
 def _build_file_logger() -> logging.Logger | None:
@@ -273,6 +283,24 @@ def read_token() -> str | None:
     return None
 
 
+def _parse_expiry_ms(full_obj: dict) -> int | None:
+    """Return claudeAiOauth.expiresAt as int epoch milliseconds, or None.
+
+    Accepts the full credential object ({"claudeAiOauth": {...}}).
+    Returns None if absent, non-numeric, or the claudeAiOauth key is missing.
+    Factored out of _read_expiry so callers needing the raw ms value (proactive
+    refresh check, write-back) share a single parser.
+    """
+    try:
+        oauth = full_obj.get("claudeAiOauth", {})
+        val = oauth.get("expiresAt")
+        if val is None:
+            return None
+        return int(val)
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
 def _read_expiry() -> str:
     """Return human-readable expiry from the first-hit credentials file.
 
@@ -287,8 +315,7 @@ def _read_expiry() -> str:
             continue
         try:
             data = json.loads(raw)
-            oauth = data.get("claudeAiOauth", {})
-            expires_ms = oauth.get("expiresAt")
+            expires_ms = _parse_expiry_ms(data)
             if expires_ms is None:
                 return "expiry unknown"
             # CRITICAL: expiresAt is JS-convention epoch milliseconds; divide by 1000
@@ -300,6 +327,279 @@ def _read_expiry() -> str:
         except (TypeError, ValueError, OSError, AttributeError, json.JSONDecodeError):
             return "expiry unknown"
     return "expiry unknown"
+
+
+def _read_full_credentials_with_path() -> tuple[dict | None, Path | None]:
+    """Like _read_full_credentials but also returns the path actually read.
+
+    Threading the resolved path out lets a refresh write back to the SAME file
+    it read, closing the TOCTOU window where a second candidate scan could pick
+    a different path if files shift between read and write (WR-03).
+
+    Returns (full_obj, path) on success, (None, None) if no file is found, and
+    (None, path) if the found file is not parseable JSON (so callers can still
+    report which file was bad).
+    """
+    for path in _windows_credential_candidates():
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            return json.loads(raw), path
+        except (json.JSONDecodeError, ValueError):
+            return None, path
+    return None, None
+
+
+def _read_full_credentials() -> dict | None:
+    """Return the full parsed credential object from the first-hit candidate path.
+
+    Reuses _windows_credential_candidates() for path resolution. Returns the
+    WHOLE top-level dict so callers can mutate claudeAiOauth and re-dump all
+    keys (subscriptionType, rateLimitTier, etc.) untouched.
+    Returns None if no file is found or the file is not parseable JSON.
+    """
+    obj, _ = _read_full_credentials_with_path()
+    return obj
+
+
+def _atomic_write_credentials(path: Path, full_obj: dict) -> None:
+    """Write full_obj to path atomically using same-directory tempfile + os.replace.
+
+    Recipe:
+    - mkstemp in the SAME directory (required for os.replace to be a same-volume rename)
+    - json.dump with indent=2 (matches Claude Code formatting)
+    - f.flush() + os.fsync() before close (durability)
+    - os.replace(tmp, path) — atomic on both POSIX and Windows; overwrites existing target
+    - On any exception: unlink the temp file and re-raise (no half-written creds)
+
+    Never logs token values — only logs a success message with the path.
+    """
+    d = path.parent
+    fd, tmp = tempfile.mkstemp(dir=d, prefix=".cred-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(full_obj, f, indent=2, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+        log(f"Credentials written to {path.name} (atomic replace)")
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+async def _refresh_oauth_token(refresh_token: str) -> dict | None:
+    """POST the refreshToken to the OAuth endpoint and return the parsed response dict.
+
+    Tries OAUTH_TOKEN_URL (platform.claude.com) first. On a connection error or a
+    non-OAuth 404, falls back to OAUTH_FALLBACK_URL (console.anthropic.com).
+
+    Returns:
+      dict  — parsed 200 response body (access_token, refresh_token?, expires_in, scope?)
+      None  — transient/network failure (5xx, timeout, unexpected status) — caller treats as None (no toast)
+
+    Raises:
+      AuthError — genuine auth failure (400/401/403 from the token endpoint)
+
+    Never logs raw token values — logs only lengths or human-readable expiry.
+    """
+    body = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": OAUTH_CLIENT_ID,
+    }
+    urls_to_try = [OAUTH_TOKEN_URL, OAUTH_FALLBACK_URL]
+    for i, url in enumerate(urls_to_try):
+        try:
+            async with httpx.AsyncClient(timeout=20.0) as http:
+                resp = await http.post(url, json=body)
+        except httpx.HTTPError as e:
+            if i < len(urls_to_try) - 1:
+                log(f"OAuth refresh: connection error on {url}, trying fallback: {e}")
+                continue
+            log(f"OAuth refresh: transient network error: {type(e).__name__}")
+            return None
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code in (400, 401, 403):
+            # Genuine auth failure — refresh token is revoked/expired/invalid.
+            # Gate purely on status code; parse body only for redacted logging.
+            try:
+                err_body = resp.json()
+                err_code = err_body.get("error", "unknown")
+            except Exception:
+                err_code = "unknown"
+            log(f"OAuth refresh: genuine auth failure {resp.status_code} ({err_code})")
+            raise AuthError(f"OAuth refresh failed: {resp.status_code} {err_code}")
+
+        # 404 on primary might mean wrong host — try fallback once
+        if resp.status_code == 404 and i < len(urls_to_try) - 1:
+            log(f"OAuth refresh: 404 on {url}, trying fallback")
+            continue
+
+        # 5xx or other — transient
+        log(f"OAuth refresh: transient HTTP {resp.status_code}")
+        return None
+
+    # Exhausted all URLs without success (should not normally reach here)
+    return None
+
+
+async def get_valid_token(tray_state=None) -> str | None:
+    """Return a valid access token, refreshing proactively if near expiry.
+
+    Flow:
+    1. Read full credentials from disk.
+    2. If accessToken present AND expiresAt > now + ~5 min: return immediately (no network).
+    3. RE-READ disk (race rule: Claude Code may have refreshed concurrently). Re-check expiry.
+       Still stale -> call _refresh_oauth_token with the on-disk refreshToken.
+    4. On 200: build new claudeAiOauth, _atomic_write_credentials the FULL object, return new token.
+    5. On AuthError from refresh: propagate (genuine — caller toasts "run claude login").
+    6. On transient (None from refresh): return None (no toast, next tick retries).
+
+    Never logs raw token values.
+    """
+    now_ms = int(time.time() * 1000)
+    threshold_ms = now_ms + OAUTH_PROACTIVE_REFRESH_SECS * 1000
+
+    # Step 1: read full credentials
+    full_obj = _read_full_credentials()
+    if full_obj is None:
+        log("get_valid_token: no credentials found")
+        return None
+
+    oauth = full_obj.get("claudeAiOauth", {})
+    access_token = oauth.get("accessToken", "")
+    expires_ms = _parse_expiry_ms(full_obj)
+
+    # Step 2: token is present and not near expiry — return immediately
+    if access_token and expires_ms is not None and expires_ms > threshold_ms:
+        return access_token
+
+    # Step 3: RE-READ disk before spending the refresh token (race-condition mitigation:
+    # Claude Code may have just written a fresh token; single-use refresh tokens mean we
+    # must not use a cached possibly-already-rotated refresh token). Capture the resolved
+    # path so the write-back below targets the exact file we read (WR-03 — no second scan).
+    full_obj, creds_path = _read_full_credentials_with_path()
+    if full_obj is None:
+        log("get_valid_token: credentials vanished on re-read")
+        return None
+
+    oauth = full_obj.get("claudeAiOauth", {})
+    access_token = oauth.get("accessToken", "")
+    expires_ms = _parse_expiry_ms(full_obj)
+
+    if access_token and expires_ms is not None and expires_ms > threshold_ms:
+        # Fresh token appeared on disk (Claude Code refreshed concurrently) — use it
+        log("get_valid_token: on-disk token already fresh after re-read, skipping network refresh")
+        return access_token
+
+    stored_refresh_token = oauth.get("refreshToken", "")
+    if not stored_refresh_token:
+        log("get_valid_token: no refreshToken on disk, cannot refresh")
+        return None
+
+    log(f"get_valid_token: token near expiry or expired, refreshing (len={len(stored_refresh_token)})")
+
+    # Step 4/5/6: call the OAuth endpoint
+    refresh_result = await _refresh_oauth_token(stored_refresh_token)
+    if refresh_result is None:
+        # Transient failure — no toast
+        log("get_valid_token: transient refresh failure, will retry next tick")
+        return None
+
+    # Successful 200 response — build updated credential object
+    new_access_token = refresh_result.get("access_token", "")
+    if not new_access_token:
+        # 200 but no usable access_token. Treat as TRANSIENT (no toast) and do NOT
+        # write back — writing an empty token would burn the single-use refresh
+        # token and trip the proactive check every tick, spinning a refresh loop
+        # against a misbehaving server (WR-01).
+        log("get_valid_token: refresh 200 but empty access_token; treating as transient, not writing back")
+        return None
+    new_refresh_token = refresh_result.get("refresh_token", stored_refresh_token)  # reuse old if absent
+    expires_in_secs = refresh_result.get("expires_in", 0)
+    new_expires_ms = int(time.time() * 1000) + expires_in_secs * 1000
+
+    # Mutate only the token-related keys; all other keys (subscriptionType, rateLimitTier, etc.) preserved
+    oauth["accessToken"] = new_access_token
+    oauth["refreshToken"] = new_refresh_token
+    oauth["expiresAt"] = new_expires_ms
+
+    # Update scopes array only if the response included the scope field
+    scope_str = refresh_result.get("scope")
+    if scope_str:
+        oauth["scopes"] = scope_str.split()
+
+    full_obj["claudeAiOauth"] = oauth
+
+    # Write back to the EXACT path resolved during the race re-read above (WR-03) —
+    # no second candidate scan, so a file shift between read and write can't make us
+    # update the wrong file.
+    if creds_path is not None:
+        _atomic_write_credentials(creds_path, full_obj)
+        expiry_dt = datetime.datetime.fromtimestamp(
+            new_expires_ms / 1000, tz=datetime.timezone.utc
+        )
+        log(f"get_valid_token: refreshed, new expiry {expiry_dt.strftime('%Y-%m-%d %H:%M UTC')}")
+    else:
+        log("get_valid_token: refreshed but could not find creds path to write back")
+
+    return new_access_token
+
+
+async def _poll_with_refresh(token: str, tray_state=None) -> dict | None:
+    """Call poll_api(token); on AuthError, attempt ONE forced refresh + ONE retry.
+
+    Extracted from connect_and_run to keep the reactive-retry logic unit-testable
+    without driving the full BLE session loop.
+
+    Returns:
+      dict  — payload from poll_api (first try or after successful forced refresh)
+      None  — any failure path that should NOT toast (transient poll, transient refresh)
+
+    Side effects (toast "token expired — run claude login"):
+      ONLY when the forced refresh itself raises AuthError (genuine invalid token).
+
+    AuthError from poll_api is NOT re-raised — it is caught here and triggers the
+    forced refresh + retry.  The caller receives None or payload, never AuthError.
+    """
+    try:
+        return await poll_api(token)
+    except AuthError:
+        # Unexpected poll 401/403 — one forced refresh + one retry before toasting.
+        log("poll_api returned 401/403; attempting forced token refresh before toasting")
+
+    try:
+        new_token = await get_valid_token(tray_state)
+    except AuthError:
+        # Forced refresh also failed genuinely — NOW toast.
+        log("Forced refresh also failed (genuine); firing 'run claude login' toast")
+        if tray_state:
+            tray_state.set_error("token expired — run claude login")
+        return None
+
+    if new_token is None:
+        # Transient refresh failure — no toast, next tick retries.
+        log("Forced refresh returned None (transient); leaving tray unchanged")
+        return None
+
+    # Retry poll once with the fresh token
+    try:
+        return await poll_api(new_token)
+    except AuthError:
+        # Retry also rejected — now toast.
+        log("Retry poll also returned 401/403; firing 'run claude login' toast")
+        if tray_state:
+            tray_state.set_error("token expired — run claude login")
+        return None
 
 
 async def _wait_first(*events: asyncio.Event, timeout: float) -> None:
@@ -379,19 +679,29 @@ async def connect_and_run(device, stop_event: asyncio.Event, tray_state=None) ->
             elapsed = now - last_poll
             if session.refresh_requested.is_set() or elapsed >= POLL_INTERVAL:
                 session.refresh_requested.clear()
-                token = read_token()  # D-09: fresh each cycle
-                if not token:
-                    log("No token; skipping poll")
+                # Proactive refresh: get_valid_token() returns a fresh token (possibly
+                # refreshing before the poll if near expiry), or None on transient
+                # failure (which must NOT toast — same as a transient poll failure).
+                # A genuine refresh rejection raises AuthError — catch it here, toast,
+                # and keep the loop alive. Letting it propagate would kill the daemon
+                # thread (no handler exists above), the silent-freeze failure mode (CR-01).
+                try:
+                    token = await get_valid_token(tray_state)  # D-09: fresh each cycle, with refresh
+                except AuthError:
+                    log("Proactive refresh failed genuinely; firing 'run claude login' toast")
                     if tray_state:
                         tray_state.set_error("token expired — run claude login")
+                    token = None
+                if not token:
+                    log("No token; skipping poll")
+                    # Do NOT toast for a transient get_valid_token None — a missing
+                    # file or transient refresh failure should not show "run claude login".
+                    # (A genuine AuthError was already handled + toasted just above.)
                 else:
-                    try:
-                        payload = await poll_api(token)
-                    except AuthError:
-                        # Real 401/403 — token genuinely needs a refresh.
-                        if tray_state:
-                            tray_state.set_error("token expired — run claude login")
-                        payload = None
+                    # _poll_with_refresh handles: first poll OK -> payload; poll 401 ->
+                    # forced refresh + retry; retry OK -> payload; forced refresh genuine
+                    # AuthError -> toast + None; transient -> None (no toast).
+                    payload = await _poll_with_refresh(token, tray_state)
                     if payload is not None:
                         if await session.write_payload(payload):
                             last_poll = time.time()

--- a/daemon/tests/test_windows_token.py
+++ b/daemon/tests/test_windows_token.py
@@ -3,17 +3,31 @@
 
 Run: python -m pytest daemon/tests/test_windows_token.py -x -q
 """
+import asyncio
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from daemon.claude_usage_daemon_windows import _extract_access_token, read_token, _windows_credential_candidates, _read_expiry
+from daemon.claude_usage_daemon_windows import (
+    AuthError,
+    _extract_access_token,
+    _read_expiry,
+    _windows_credential_candidates,
+    read_token,
+)
 
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _run(coro):
+    """Run a coroutine synchronously for synchronous test functions."""
+    return asyncio.run(coro)
 
 
 def test_extract_nested_shape():
@@ -118,7 +132,6 @@ def test_extract_empty_token_is_none():
     assert _extract_access_token('{}') is None
 
 
-
 def test_read_token_empty_credential_file_returns_none(tmp_path, monkeypatch):
     """read_token() returns None (not empty string) when credential file has empty accessToken."""
     creds = tmp_path / ".credentials.json"
@@ -174,7 +187,6 @@ def test_main_emits_linux_warning(monkeypatch):
 
 def test_main_emits_linux_warning_before_loop(monkeypatch):
     """__main__ stderr warning appears before the async scan loop starts on Linux/WSL."""
-    import signal as _signal
     env = {**__import__("os").environ}
     env.pop("CLAUDE_CONFIG_DIR", None)
     env.pop("CLAUDE_CREDENTIALS_PATH", None)
@@ -196,3 +208,635 @@ def test_main_emits_linux_warning_before_loop(monkeypatch):
         assert "WinRT BLE will not be available" in partial_stderr, (
             f"Expected Linux/WSL warning in stderr before scan loop, got: {partial_stderr!r}"
         )
+
+
+# ===========================================================================
+# TASK 1: _atomic_write_credentials, _read_full_credentials, _parse_expiry_ms
+# ===========================================================================
+
+class TestAtomicWriteCredentials:
+    """Tests for _atomic_write_credentials (T-mah-02: atomic write-back)."""
+
+    def test_atomic_write_creates_file_with_exact_content(self, tmp_path):
+        """_atomic_write_credentials writes the given object to path atomically."""
+        from daemon.claude_usage_daemon_windows import _atomic_write_credentials
+        creds = tmp_path / ".credentials.json"
+        obj = {
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-new-token",
+                "refreshToken": "sk-ant-ort-new",
+                "expiresAt": 9999999999000,
+                "scopes": ["user:inference"],
+                "subscriptionType": "claude_pro",
+            }
+        }
+        _atomic_write_credentials(creds, obj)
+        result = json.loads(creds.read_text(encoding="utf-8"))
+        assert result == obj
+
+    def test_atomic_write_preserves_unrelated_keys(self, tmp_path):
+        """_atomic_write_credentials preserves subscriptionType and other unrelated keys through a write."""
+        from daemon.claude_usage_daemon_windows import _atomic_write_credentials
+        creds = tmp_path / ".credentials.json"
+        # Write initial state with extra keys
+        initial = {
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-old",
+                "refreshToken": "sk-ant-ort-old",
+                "expiresAt": 1000,
+                "scopes": ["user:inference", "user:profile"],
+                "subscriptionType": "claude_pro",
+                "rateLimitTier": "tier_1",
+            }
+        }
+        creds.write_text(json.dumps(initial), encoding="utf-8")
+        # Simulate mutating only the token-related keys
+        updated = json.loads(creds.read_text(encoding="utf-8"))
+        updated["claudeAiOauth"]["accessToken"] = "sk-ant-new"
+        updated["claudeAiOauth"]["refreshToken"] = "sk-ant-ort-new"
+        updated["claudeAiOauth"]["expiresAt"] = 9999999999000
+        _atomic_write_credentials(creds, updated)
+        result = json.loads(creds.read_text(encoding="utf-8"))
+        # Unrelated keys must be preserved
+        assert result["claudeAiOauth"]["subscriptionType"] == "claude_pro"
+        assert result["claudeAiOauth"]["rateLimitTier"] == "tier_1"
+        # Updated keys must be updated
+        assert result["claudeAiOauth"]["accessToken"] == "sk-ant-new"
+        assert result["claudeAiOauth"]["expiresAt"] == 9999999999000
+
+    def test_atomic_write_no_tmp_file_leak_on_success(self, tmp_path):
+        """No .cred-*.tmp sibling remains after a successful atomic write."""
+        from daemon.claude_usage_daemon_windows import _atomic_write_credentials
+        creds = tmp_path / ".credentials.json"
+        obj = {"claudeAiOauth": {"accessToken": "sk-ant-tok"}}
+        _atomic_write_credentials(creds, obj)
+        tmp_files = list(tmp_path.glob(".cred-*.tmp"))
+        assert tmp_files == [], f"Temp file leaked: {tmp_files}"
+
+    def test_atomic_write_utf8_encoding(self, tmp_path):
+        """_atomic_write_credentials uses UTF-8 encoding."""
+        from daemon.claude_usage_daemon_windows import _atomic_write_credentials
+        creds = tmp_path / ".credentials.json"
+        obj = {"claudeAiOauth": {"accessToken": "sk-ant-tok", "note": "café"}}
+        _atomic_write_credentials(creds, obj)
+        raw = creds.read_bytes()
+        # UTF-8 encoding of 'café' should be present
+        assert "café".encode("utf-8") in raw
+
+
+class TestReadFullCredentials:
+    """Tests for _read_full_credentials (returns the whole object)."""
+
+    def test_read_full_credentials_returns_nested_object(self, tmp_path, monkeypatch):
+        """_read_full_credentials returns the full parsed dict including refreshToken."""
+        from daemon.claude_usage_daemon_windows import _read_full_credentials
+        creds = tmp_path / ".credentials.json"
+        obj = {
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-test-1234",
+                "refreshToken": "sk-ant-ort-test-5678",
+                "expiresAt": 9999999999000,
+                "scopes": ["user:inference", "user:profile"],
+                "subscriptionType": "claude_pro",
+            }
+        }
+        creds.write_text(json.dumps(obj), encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        result = _read_full_credentials()
+        assert result is not None
+        assert result["claudeAiOauth"]["refreshToken"] == "sk-ant-ort-test-5678"
+        assert result["claudeAiOauth"]["subscriptionType"] == "claude_pro"
+
+    def test_read_full_credentials_returns_none_when_no_file(self, tmp_path, monkeypatch):
+        """_read_full_credentials returns None when no credential file exists."""
+        from daemon.claude_usage_daemon_windows import _read_full_credentials
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        assert _read_full_credentials() is None
+
+    def test_read_full_credentials_returns_none_on_invalid_json(self, tmp_path, monkeypatch):
+        """_read_full_credentials returns None if file contains invalid JSON."""
+        from daemon.claude_usage_daemon_windows import _read_full_credentials
+        creds = tmp_path / ".credentials.json"
+        creds.write_text("not json at all", encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        assert _read_full_credentials() is None
+
+
+class TestParseExpiryMs:
+    """Tests for _parse_expiry_ms (factored expiry parser)."""
+
+    def test_parse_expiry_ms_returns_int(self, tmp_path, monkeypatch):
+        """_parse_expiry_ms returns the expiresAt int from a credentials object."""
+        from daemon.claude_usage_daemon_windows import _parse_expiry_ms
+        obj = {"claudeAiOauth": {"expiresAt": 9999999999000}}
+        result = _parse_expiry_ms(obj)
+        assert result == 9999999999000
+
+    def test_parse_expiry_ms_returns_none_when_absent(self):
+        """_parse_expiry_ms returns None when expiresAt is absent."""
+        from daemon.claude_usage_daemon_windows import _parse_expiry_ms
+        obj = {"claudeAiOauth": {}}
+        assert _parse_expiry_ms(obj) is None
+
+    def test_parse_expiry_ms_returns_none_for_non_numeric(self):
+        """_parse_expiry_ms returns None when expiresAt is not numeric."""
+        from daemon.claude_usage_daemon_windows import _parse_expiry_ms
+        obj = {"claudeAiOauth": {"expiresAt": "not-a-number"}}
+        assert _parse_expiry_ms(obj) is None
+
+    def test_parse_expiry_ms_returns_none_for_no_oauth_key(self):
+        """_parse_expiry_ms returns None when claudeAiOauth key is absent."""
+        from daemon.claude_usage_daemon_windows import _parse_expiry_ms
+        assert _parse_expiry_ms({}) is None
+
+    def test_read_expiry_still_works_after_refactor(self, monkeypatch):
+        """_read_expiry() contract is preserved after refactoring to use _parse_expiry_ms."""
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(FIXTURES / "credentials_nested.json"))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        result = _read_expiry()
+        assert result.startswith("2286-"), f"Expected year 2286, got: {result}"
+
+
+# ===========================================================================
+# TASK 2: _refresh_oauth_token + get_valid_token
+# ===========================================================================
+
+def _make_oauth_creds_file(tmp_path, access_token, refresh_token, expires_at_ms,
+                            subscription_type="claude_pro", rate_limit_tier="tier_1"):
+    """Helper: write a credentials file and return its path."""
+    creds = tmp_path / ".credentials.json"
+    obj = {
+        "claudeAiOauth": {
+            "accessToken": access_token,
+            "refreshToken": refresh_token,
+            "expiresAt": expires_at_ms,
+            "scopes": ["user:inference", "user:profile"],
+            "subscriptionType": subscription_type,
+            "rateLimitTier": rate_limit_tier,
+        }
+    }
+    creds.write_text(json.dumps(obj), encoding="utf-8")
+    return creds
+
+
+def _make_mock_http_client(status_code, response_json=None, side_effect=None):
+    """Helper: build a mock httpx.AsyncClient for token endpoint calls."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=response_json or {})
+    resp.text = json.dumps(response_json or {})
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    if side_effect is not None:
+        mock_client.post = AsyncMock(side_effect=side_effect)
+    else:
+        mock_client.post = AsyncMock(return_value=resp)
+    return mock_client
+
+
+class TestRefreshOauthToken:
+    """Tests for _refresh_oauth_token (network call, fully mocked)."""
+
+    def test_successful_refresh_returns_response_dict(self):
+        """_refresh_oauth_token returns parsed dict on 200 response."""
+        from daemon.claude_usage_daemon_windows import _refresh_oauth_token
+        response_data = {
+            "access_token": "sk-ant-oat01-new",
+            "refresh_token": "sk-ant-ort01-new",
+            "expires_in": 28800,
+            "scope": "user:inference user:profile",
+        }
+        mock_client = _make_mock_http_client(200, response_data)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = _run(_refresh_oauth_token("sk-ant-ort01-old"))
+        assert result["access_token"] == "sk-ant-oat01-new"
+        assert result["refresh_token"] == "sk-ant-ort01-new"
+        assert result["expires_in"] == 28800
+
+    def test_400_raises_autherror(self):
+        """_refresh_oauth_token raises AuthError on 400 (invalid_grant)."""
+        from daemon.claude_usage_daemon_windows import _refresh_oauth_token
+        mock_client = _make_mock_http_client(400, {"error": "invalid_grant"})
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(AuthError):
+                _run(_refresh_oauth_token("sk-ant-ort01-old"))
+
+    def test_401_raises_autherror(self):
+        """_refresh_oauth_token raises AuthError on 401."""
+        from daemon.claude_usage_daemon_windows import _refresh_oauth_token
+        mock_client = _make_mock_http_client(401, {"error": "unauthorized"})
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(AuthError):
+                _run(_refresh_oauth_token("sk-ant-ort01-old"))
+
+    def test_403_raises_autherror(self):
+        """_refresh_oauth_token raises AuthError on 403."""
+        from daemon.claude_usage_daemon_windows import _refresh_oauth_token
+        mock_client = _make_mock_http_client(403, {"error": "forbidden"})
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(AuthError):
+                _run(_refresh_oauth_token("sk-ant-ort01-old"))
+
+    def test_network_error_returns_none(self):
+        """_refresh_oauth_token returns None on network/transient error."""
+        import httpx as _httpx
+        from daemon.claude_usage_daemon_windows import _refresh_oauth_token
+        mock_client = _make_mock_http_client(0, side_effect=_httpx.ConnectError("timeout"))
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = _run(_refresh_oauth_token("sk-ant-ort01-old"))
+        assert result is None
+
+    def test_500_returns_none(self):
+        """_refresh_oauth_token returns None on 5xx (transient)."""
+        from daemon.claude_usage_daemon_windows import _refresh_oauth_token
+        mock_client = _make_mock_http_client(503, {"error": "service_unavailable"})
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = _run(_refresh_oauth_token("sk-ant-ort01-old"))
+        assert result is None
+
+    def test_uses_correct_client_id_and_grant_type(self):
+        """_refresh_oauth_token sends the correct client_id and grant_type in request body."""
+        from daemon.claude_usage_daemon_windows import (
+            OAUTH_CLIENT_ID,
+            _refresh_oauth_token,
+        )
+        response_data = {
+            "access_token": "sk-ant-oat01-new",
+            "expires_in": 28800,
+        }
+        mock_client = _make_mock_http_client(200, response_data)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            _run(_refresh_oauth_token("sk-ant-ort01-old"))
+        call_kwargs = mock_client.post.call_args
+        # The body should contain grant_type=refresh_token and the correct client_id
+        body = call_kwargs[1].get("json") or call_kwargs[0][1] if len(call_kwargs[0]) > 1 else None
+        if body is None and call_kwargs[1]:
+            body = call_kwargs[1].get("json")
+        assert body is not None, f"Could not find json body in call: {call_kwargs}"
+        assert body["grant_type"] == "refresh_token"
+        assert body["client_id"] == OAUTH_CLIENT_ID
+        assert body["refresh_token"] == "sk-ant-ort01-old"
+
+
+class TestGetValidToken:
+    """Tests for get_valid_token (proactive + race re-read + write-back)."""
+
+    def test_fresh_token_returned_without_network_call(self, tmp_path, monkeypatch):
+        """get_valid_token returns access token immediately when not near expiry (no network)."""
+        from daemon.claude_usage_daemon_windows import get_valid_token
+        # expiresAt far in the future (year 2286)
+        creds = _make_oauth_creds_file(tmp_path, "sk-ant-fresh", "sk-ant-ort-fresh", 9999999999000)
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock()
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = _run(get_valid_token())
+        assert result == "sk-ant-fresh"
+        mock_client.post.assert_not_called()
+
+    def test_proactive_refresh_on_near_expiry(self, tmp_path, monkeypatch):
+        """get_valid_token refreshes proactively when token is near expiry (<5 min)."""
+        from daemon.claude_usage_daemon_windows import get_valid_token
+        # expiresAt 2 minutes in the future — inside the ~5 min proactive window
+        near_expiry_ms = int(time.time() * 1000) + 2 * 60 * 1000
+        creds = _make_oauth_creds_file(tmp_path, "sk-ant-old", "sk-ant-ort-old", near_expiry_ms)
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        new_expires_in = 28800
+        response_data = {
+            "access_token": "sk-ant-refreshed",
+            "refresh_token": "sk-ant-ort-rotated",
+            "expires_in": new_expires_in,
+            "scope": "user:inference user:profile",
+        }
+        mock_client = _make_mock_http_client(200, response_data)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = _run(get_valid_token())
+        assert result == "sk-ant-refreshed"
+        # Verify write-back: credentials file should now have the new token
+        written = json.loads(creds.read_text(encoding="utf-8"))
+        assert written["claudeAiOauth"]["accessToken"] == "sk-ant-refreshed"
+        assert written["claudeAiOauth"]["refreshToken"] == "sk-ant-ort-rotated"
+        # expiresAt should be approximately now + 28800 * 1000 ms
+        expected_expires = int(time.time() * 1000) + new_expires_in * 1000
+        assert abs(written["claudeAiOauth"]["expiresAt"] - expected_expires) < 5000  # within 5s
+
+    def test_rotated_refresh_token_persisted(self, tmp_path, monkeypatch):
+        """get_valid_token persists the rotated refresh_token returned in 200 response."""
+        from daemon.claude_usage_daemon_windows import get_valid_token
+        near_expiry_ms = int(time.time() * 1000) + 60 * 1000  # 1 min — near expiry
+        creds = _make_oauth_creds_file(tmp_path, "sk-ant-old", "sk-ant-ort-old", near_expiry_ms)
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        response_data = {
+            "access_token": "sk-ant-new",
+            "refresh_token": "sk-ant-ort-NEW-ROTATED",
+            "expires_in": 28800,
+        }
+        mock_client = _make_mock_http_client(200, response_data)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            _run(get_valid_token())
+        written = json.loads(creds.read_text(encoding="utf-8"))
+        assert written["claudeAiOauth"]["refreshToken"] == "sk-ant-ort-NEW-ROTATED"
+
+    def test_absent_refresh_token_in_response_reuses_old(self, tmp_path, monkeypatch):
+        """When the 200 response omits refresh_token, the old refreshToken is preserved."""
+        from daemon.claude_usage_daemon_windows import get_valid_token
+        near_expiry_ms = int(time.time() * 1000) + 60 * 1000
+        creds = _make_oauth_creds_file(tmp_path, "sk-ant-old", "sk-ant-ort-KEEP", near_expiry_ms)
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        # Response does NOT include refresh_token
+        response_data = {"access_token": "sk-ant-new", "expires_in": 28800}
+        mock_client = _make_mock_http_client(200, response_data)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            _run(get_valid_token())
+        written = json.loads(creds.read_text(encoding="utf-8"))
+        assert written["claudeAiOauth"]["refreshToken"] == "sk-ant-ort-KEEP"
+
+    def test_write_back_preserves_subscription_type_and_other_keys(self, tmp_path, monkeypatch):
+        """get_valid_token preserves subscriptionType, rateLimitTier, and other keys through refresh write-back."""
+        from daemon.claude_usage_daemon_windows import get_valid_token
+        near_expiry_ms = int(time.time() * 1000) + 60 * 1000
+        creds = _make_oauth_creds_file(
+            tmp_path, "sk-ant-old", "sk-ant-ort-old", near_expiry_ms,
+            subscription_type="claude_max", rate_limit_tier="tier_2"
+        )
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        response_data = {"access_token": "sk-ant-new", "refresh_token": "sk-ant-ort-new", "expires_in": 28800}
+        mock_client = _make_mock_http_client(200, response_data)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            _run(get_valid_token())
+        written = json.loads(creds.read_text(encoding="utf-8"))
+        assert written["claudeAiOauth"]["subscriptionType"] == "claude_max"
+        assert written["claudeAiOauth"]["rateLimitTier"] == "tier_2"
+
+    def test_invalid_grant_raises_autherror(self, tmp_path, monkeypatch):
+        """get_valid_token propagates AuthError when refresh endpoint returns 400."""
+        from daemon.claude_usage_daemon_windows import get_valid_token
+        near_expiry_ms = int(time.time() * 1000) + 60 * 1000
+        creds = _make_oauth_creds_file(tmp_path, "sk-ant-old", "sk-ant-ort-old", near_expiry_ms)
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        mock_client = _make_mock_http_client(400, {"error": "invalid_grant"})
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(AuthError):
+                _run(get_valid_token())
+
+    def test_transient_refresh_error_returns_none(self, tmp_path, monkeypatch):
+        """get_valid_token returns None (no AuthError) when refresh has a transient network failure."""
+        import httpx as _httpx
+        from daemon.claude_usage_daemon_windows import get_valid_token
+        near_expiry_ms = int(time.time() * 1000) + 60 * 1000
+        creds = _make_oauth_creds_file(tmp_path, "sk-ant-old", "sk-ant-ort-old", near_expiry_ms)
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        mock_client = _make_mock_http_client(0, side_effect=_httpx.ConnectError("timeout"))
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = _run(get_valid_token())
+        assert result is None
+
+    def test_no_raw_token_in_logs(self, tmp_path, monkeypatch, capsys):
+        """get_valid_token never logs raw access or refresh token values (T-mah-01)."""
+        from daemon.claude_usage_daemon_windows import get_valid_token
+        near_expiry_ms = int(time.time() * 1000) + 60 * 1000
+        secret_access = "sk-ant-SECRET-ACCESS-TOKEN-12345"
+        secret_refresh = "sk-ant-ort-SECRET-REFRESH-TOKEN-67890"
+        creds = _make_oauth_creds_file(tmp_path, secret_access, secret_refresh, near_expiry_ms)
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        response_data = {
+            "access_token": "sk-ant-NEW-SECRET-ACCESS-ABCDEF",
+            "refresh_token": "sk-ant-ort-NEW-SECRET-REFRESH-GHIJKL",
+            "expires_in": 28800,
+        }
+        mock_client = _make_mock_http_client(200, response_data)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            _run(get_valid_token())
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        # Neither old nor new token values should appear in any log output
+        assert secret_access not in combined, "Old access token leaked to log (T-mah-01)"
+        assert secret_refresh not in combined, "Old refresh token leaked to log (T-mah-01)"
+        assert "sk-ant-NEW-SECRET-ACCESS-ABCDEF" not in combined, "New access token leaked to log (T-mah-01)"
+        assert "sk-ant-ort-NEW-SECRET-REFRESH-GHIJKL" not in combined, "New refresh token leaked to log (T-mah-01)"
+
+
+# ===========================================================================
+# TASK 3: _poll_with_refresh + wiring in connect_and_run
+# ===========================================================================
+
+class TestPollWithRefresh:
+    """Tests for _poll_with_refresh (reactive retry helper)."""
+
+    def test_reactive_retry_succeeds_no_toast(self):
+        """When poll_api raises AuthError then refresh succeeds, retry returns payload and no toast fires."""
+        from daemon.claude_usage_daemon_windows import _poll_with_refresh
+
+        good_payload = {"s": 42, "w": 10, "ok": True}
+
+        # First poll raises AuthError, second succeeds
+        poll_api_mock = AsyncMock(side_effect=[AuthError("401"), good_payload])
+        # get_valid_token returns a fresh token on forced refresh
+        get_valid_token_mock = AsyncMock(return_value="sk-ant-refreshed-token")
+
+        tray_state = MagicMock()
+        tray_state.set_error = MagicMock()
+
+        with patch("daemon.claude_usage_daemon_windows.poll_api", poll_api_mock), \
+             patch("daemon.claude_usage_daemon_windows.get_valid_token", get_valid_token_mock):
+            result = _run(_poll_with_refresh("sk-ant-old-token", tray_state))
+
+        assert result == good_payload
+        tray_state.set_error.assert_not_called()
+
+    def test_reactive_retry_forced_refresh_raises_autherror_fires_toast(self):
+        """When forced refresh raises AuthError, toast IS fired and payload is None."""
+        from daemon.claude_usage_daemon_windows import _poll_with_refresh
+
+        # First poll raises AuthError; forced refresh also raises AuthError
+        poll_api_mock = AsyncMock(side_effect=AuthError("401"))
+        get_valid_token_mock = AsyncMock(side_effect=AuthError("refresh_failed"))
+
+        tray_state = MagicMock()
+        tray_state.set_error = MagicMock()
+
+        with patch("daemon.claude_usage_daemon_windows.poll_api", poll_api_mock), \
+             patch("daemon.claude_usage_daemon_windows.get_valid_token", get_valid_token_mock):
+            result = _run(_poll_with_refresh("sk-ant-old-token", tray_state))
+
+        assert result is None
+        tray_state.set_error.assert_called_once()
+        error_msg = tray_state.set_error.call_args[0][0]
+        assert "claude login" in error_msg
+
+    def test_reactive_retry_transient_refresh_returns_none_no_toast(self):
+        """When forced refresh returns None (transient), payload is None and no toast fires."""
+        from daemon.claude_usage_daemon_windows import _poll_with_refresh
+
+        # First poll raises AuthError; forced refresh returns None (transient)
+        poll_api_mock = AsyncMock(side_effect=AuthError("401"))
+        get_valid_token_mock = AsyncMock(return_value=None)
+
+        tray_state = MagicMock()
+        tray_state.set_error = MagicMock()
+
+        with patch("daemon.claude_usage_daemon_windows.poll_api", poll_api_mock), \
+             patch("daemon.claude_usage_daemon_windows.get_valid_token", get_valid_token_mock):
+            result = _run(_poll_with_refresh("sk-ant-old-token", tray_state))
+
+        assert result is None
+        tray_state.set_error.assert_not_called()
+
+    def test_successful_first_poll_returns_payload_directly(self):
+        """When poll_api succeeds on first try, payload returned without any refresh."""
+        from daemon.claude_usage_daemon_windows import _poll_with_refresh
+
+        good_payload = {"s": 50, "w": 20, "ok": True}
+        poll_api_mock = AsyncMock(return_value=good_payload)
+        get_valid_token_mock = AsyncMock()
+
+        tray_state = MagicMock()
+
+        with patch("daemon.claude_usage_daemon_windows.poll_api", poll_api_mock), \
+             patch("daemon.claude_usage_daemon_windows.get_valid_token", get_valid_token_mock):
+            result = _run(_poll_with_refresh("sk-ant-valid-token", tray_state))
+
+        assert result == good_payload
+        get_valid_token_mock.assert_not_called()
+
+
+# ===========================================================================
+# CODE-REVIEW FIX REGRESSIONS (260607-mah REVIEW.md: CR-01, WR-01, IN-01, IN-02)
+# ===========================================================================
+
+class TestReviewFixRegressions:
+    """Regression guards for the issues found by code review on the OAuth refresh feature."""
+
+    def test_cr01_proactive_autherror_does_not_crash_and_toasts(self):
+        """CR-01: a genuine AuthError from the PROACTIVE get_valid_token inside
+        connect_and_run must be caught — it toasts and the function returns
+        normally instead of letting AuthError kill the daemon thread."""
+        from daemon.claude_usage_daemon_windows import connect_and_run
+
+        stop_event = asyncio.Event()
+
+        # get_valid_token (proactive) raises AuthError; set stop so the loop exits
+        # immediately after the except block (no TICK wait).
+        def _raise_after_stopping(*_a, **_k):
+            stop_event.set()
+            raise AuthError("genuine refresh rejection")
+
+        get_valid_token_mock = AsyncMock(side_effect=_raise_after_stopping)
+
+        # Mock a successfully-connected BLE client.
+        mock_client = AsyncMock()
+        mock_client.is_connected = True
+        mock_client.connect = AsyncMock()
+        mock_client.disconnect = AsyncMock()
+        mock_client.start_notify = AsyncMock()
+
+        device = MagicMock()
+        device.address = "AA:BB:CC:DD:EE:FF"
+
+        tray_state = MagicMock()
+        tray_state.set_error = MagicMock()
+
+        with patch("daemon.claude_usage_daemon_windows.BleakClient", return_value=mock_client), \
+             patch("daemon.claude_usage_daemon_windows.get_valid_token", get_valid_token_mock):
+            # Must NOT raise AuthError — that would crash the daemon (CR-01).
+            result = _run(connect_and_run(device, stop_event, tray_state))
+
+        assert result is False  # no successful write occurred
+        tray_state.set_error.assert_called_once()
+        assert "claude login" in tray_state.set_error.call_args[0][0]
+
+    def test_wr01_empty_access_token_in_200_is_transient_and_no_writeback(self, tmp_path, monkeypatch):
+        """WR-01: a 200 response with an empty/absent access_token must be treated
+        as transient (return None) and must NOT write back — writing an empty token
+        would burn the single-use refresh token and spin a refresh loop."""
+        from daemon.claude_usage_daemon_windows import get_valid_token
+        near_expiry_ms = int(time.time() * 1000) + 60 * 1000  # near expiry -> would refresh
+        creds = _make_oauth_creds_file(tmp_path, "sk-ant-old", "sk-ant-ort-PRECIOUS", near_expiry_ms)
+        monkeypatch.setenv("CLAUDE_CREDENTIALS_PATH", str(creds))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        # 200 but NO access_token field
+        mock_client = _make_mock_http_client(200, {"refresh_token": "sk-ant-ort-rotated", "expires_in": 28800})
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = _run(get_valid_token())
+        assert result is None, "empty access_token must be treated as transient (None)"
+        # The on-disk credentials must be UNCHANGED — refresh token not burned.
+        written = json.loads(creds.read_text(encoding="utf-8"))
+        assert written["claudeAiOauth"]["accessToken"] == "sk-ant-old"
+        assert written["claudeAiOauth"]["refreshToken"] == "sk-ant-ort-PRECIOUS"
+
+    def test_in01_race_reread_fresh_on_disk_skips_network(self, tmp_path, monkeypatch):
+        """IN-01: if the FIRST read is stale but the race RE-READ finds a fresh
+        token (Claude Code refreshed concurrently), get_valid_token returns the
+        on-disk token and never spends the (possibly already-rotated) refresh token."""
+        import daemon.claude_usage_daemon_windows as mod
+        from daemon.claude_usage_daemon_windows import get_valid_token
+
+        stale_ms = int(time.time() * 1000) + 60 * 1000           # within 5-min window -> "stale"
+        fresh_ms = int(time.time() * 1000) + 9999999 * 1000       # far future -> "fresh"
+        stale_obj = {"claudeAiOauth": {"accessToken": "sk-ant-stale", "refreshToken": "sk-ant-ort", "expiresAt": stale_ms}}
+        fresh_obj = {"claudeAiOauth": {"accessToken": "sk-ant-CONCURRENT-FRESH", "refreshToken": "sk-ant-ort", "expiresAt": fresh_ms}}
+
+        # Step 1 reads stale; the race re-read (with_path) returns the fresh on-disk token.
+        first_read = MagicMock(return_value=stale_obj)
+        race_read = MagicMock(return_value=(fresh_obj, tmp_path / ".credentials.json"))
+
+        post_mock = AsyncMock()
+        net_client = AsyncMock()
+        net_client.__aenter__ = AsyncMock(return_value=net_client)
+        net_client.__aexit__ = AsyncMock(return_value=False)
+        net_client.post = post_mock
+
+        with patch.object(mod, "_read_full_credentials", first_read), \
+             patch.object(mod, "_read_full_credentials_with_path", race_read), \
+             patch("httpx.AsyncClient", return_value=net_client):
+            result = _run(get_valid_token())
+
+        assert result == "sk-ant-CONCURRENT-FRESH"
+        post_mock.assert_not_called()  # no network refresh — refresh token preserved
+
+    def test_in02_404_on_primary_falls_back_to_secondary(self):
+        """IN-02: a 404 on the primary OAuth URL escalates to the fallback URL."""
+        from daemon.claude_usage_daemon_windows import (
+            OAUTH_TOKEN_URL,
+            OAUTH_FALLBACK_URL,
+            _refresh_oauth_token,
+        )
+        resp404 = MagicMock()
+        resp404.status_code = 404
+        resp404.json = MagicMock(return_value={})
+        resp404.text = "not found"
+        resp200 = MagicMock()
+        resp200.status_code = 200
+        resp200.json = MagicMock(return_value={"access_token": "sk-ant-fallback", "expires_in": 28800})
+        resp200.text = "ok"
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=[resp404, resp200])
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = _run(_refresh_oauth_token("sk-ant-ort-old"))
+
+        assert result["access_token"] == "sk-ant-fallback"
+        assert mock_client.post.call_count == 2
+        # First attempt hit the primary URL, second hit the fallback.
+        first_url = mock_client.post.call_args_list[0][0][0]
+        second_url = mock_client.post.call_args_list[1][0][0]
+        assert first_url == OAUTH_TOKEN_URL
+        assert second_url == OAUTH_FALLBACK_URL


### PR DESCRIPTION
## Problem

The Windows daemon reads only the short-lived `accessToken` from `.credentials.json` and never refreshes it. Because nothing renews the token while the PC is asleep or powered off, the first poll after wake gets a 401 and the tray repeatedly tells the user to run `claude login` — often several times a day.

## Fix

Implement the OAuth refresh-token flow Claude Code performs internally:

- **`get_valid_token()`** — proactively refreshes when the access token is expired or within ~5 min of `expiresAt`, before polling. Re-reads the credentials file immediately before refreshing so that if Claude Code refreshed concurrently we use its fresh token instead of spending our (possibly already-rotated, single-use) refresh token.
- **`_refresh_oauth_token()`** — POSTs the refresh token to the OAuth endpoint (`platform.claude.com`, with `console.anthropic.com` fallback) using the public Claude Code `client_id`; gates genuine auth failure vs transient purely on HTTP status.
- **Atomic write-back** to `.credentials.json` (same-dir `mkstemp` + `fsync` + `os.replace`) preserving every other key, so native Claude Code stays logged in and the rotated refresh token survives a daemon restart.
- **Reactive path** — one forced refresh + retry on an unexpected poll 401. The "run claude login" toast now fires only when the refresh token itself is genuinely revoked.

### Hardening
- A genuine refresh `AuthError` is caught in the poll loop (it previously could crash the daemon thread).
- An empty `access_token` in a 200 response is treated as transient and not written back (avoids burning the single-use refresh token in a loop).

## Scope & testing

Scope is the Windows daemon only (`daemon/claude_usage_daemon_windows.py` + tests). 124 daemon tests pass (31 new token tests, fully mocked — no network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)