### PR TITLE
feat(c6): enable auto-rotation + imu debug command

### DIFF
--- a/firmware/src/boards/waveshare_amoled_18/imu.cpp
+++ b/firmware/src/boards/waveshare_amoled_18/imu.cpp
@@ -23,3 +23,7 @@ void imu_hal_tick(void) {
 }
 
 uint8_t imu_hal_rotation_quadrant(void) { return 0; }
+
+void imu_hal_print_debug(void) {
+    Serial.println("IMU: rotation disabled on this board");
+}

--- a/firmware/src/boards/waveshare_amoled_216/imu.cpp
+++ b/firmware/src/boards/waveshare_amoled_216/imu.cpp
@@ -64,3 +64,20 @@ void imu_hal_tick(void) {
 }
 
 uint8_t imu_hal_rotation_quadrant(void) { return current_rotation; }
+
+void imu_hal_print_debug(void) {
+    if (!imu_ok) {
+        Serial.println("IMU: init failed — imu_ok=false");
+        return;
+    }
+    float ax, ay, az;
+    if (!imu.getAccelerometer(ax, ay, az)) {
+        Serial.println("IMU: getAccelerometer failed");
+        return;
+    }
+    uint8_t raw = accel_to_rotation(ax, ay);
+    Serial.printf("IMU: ax=%.3f ay=%.3f az=%.3f  raw=%s  rotation=%d  candidate=%d\n",
+        ax, ay, az,
+        raw == 255 ? "ambiguous" : String(raw).c_str(),
+        current_rotation, candidate_rotation);
+}

--- a/firmware/src/boards/waveshare_amoled_216_c6/board.h
+++ b/firmware/src/boards/waveshare_amoled_216_c6/board.h
@@ -52,7 +52,9 @@
 #define BTN_FWD_GPIO         10
 
 // ---- Rotation offset ----
-// Physical mounting has the panel rotated 270° CW from the IMU's 0° reference.
+// Y axis inverted in accel_to_rotation() to match PCB mounting.
+// With inverted Y: raw=1 (ay>0) = usuario, raw=3 (ay<0) = abajo.
+// Offset 3 aligns: (1+3)%4=0 usuario, (3+3)%4=2 abajo, (0/2+3)%4=3/1 costados.
 // Applied as (imu_quadrant + BOARD_ROTATION_OFFSET) % 4 in imu_hal_rotation_quadrant().
 #define BOARD_ROTATION_OFFSET 3
 

--- a/firmware/src/boards/waveshare_amoled_216_c6/board.h
+++ b/firmware/src/boards/waveshare_amoled_216_c6/board.h
@@ -51,9 +51,14 @@
 #define BTN_BACK_GPIO        9
 #define BTN_FWD_GPIO         10
 
+// ---- Rotation offset ----
+// Physical mounting has the panel rotated 270° CW from the IMU's 0° reference.
+// Applied as (imu_quadrant + BOARD_ROTATION_OFFSET) % 4 in imu_hal_rotation_quadrant().
+#define BOARD_ROTATION_OFFSET 3
+
 // ---- Capability flags ----
 #define BOARD_HAS_SECONDARY_BUTTON 1
-#define BOARD_HAS_ROTATION         0    // C6 has no PSRAM headroom for the rotation strip
+#define BOARD_HAS_ROTATION         1    // rotation strip fits in internal SRAM (37 KB)
 #define BOARD_HAS_IMU              1    // present + initialized for I2C bus health
 #define BOARD_HAS_BATTERY          1
 #define BOARD_HAS_IO_EXPANDER      0    // TCA9554 exists on board but only services audio

--- a/firmware/src/boards/waveshare_amoled_216_c6/display.cpp
+++ b/firmware/src/boards/waveshare_amoled_216_c6/display.cpp
@@ -1,12 +1,17 @@
 #include "../../hal/display_hal.h"
+#include "../../hal/imu_hal.h"
+#include "../../brightness.h"
 #include "board.h"
 #include <Arduino.h>
 #include <Arduino_GFX_Library.h>
+#include <esp_heap_caps.h>
+#include <lvgl.h>
 
-// C6 AMOLED-2.16 uses an SH8601 panel — same driver family as the
-// AMOLED-1.8 port. LCD reset is not wired to any MCU GPIO; the SH8601
-// boots from its internal POR. Rotation is disabled (no PSRAM headroom
-// for the strip buffer).
+// C6 AMOLED-2.16 uses an SH8601 panel. Rotation buffer lives in internal
+// SRAM (37 KB fits comfortably alongside everything else at ~93 KB used).
+
+#define ROT_BUF_LINES 20   // matches BUF_LINES for non-PSRAM boards in main.cpp
+static uint16_t* rot_buf = nullptr;
 
 static Arduino_DataBus* bus = nullptr;
 static Arduino_SH8601*  gfx = nullptr;
@@ -48,6 +53,8 @@ void display_hal_begin(void) {
     send_vendor_init(bus);       // patch up panel-specific regs the stock init misses
     gfx->fillScreen(0x0000);
     gfx->setBrightness(200);
+
+    rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * ROT_BUF_LINES * 2, MALLOC_CAP_INTERNAL);
 }
 
 void display_hal_set_brightness(uint8_t level) {
@@ -58,13 +65,74 @@ void display_hal_fill_screen(uint16_t color) {
     if (gfx) gfx->fillScreen(color);
 }
 
+static void rotate_strip(const uint16_t* src, int32_t w, int32_t h,
+                         int32_t sx, int32_t sy, uint8_t r,
+                         int32_t* dx, int32_t* dy, int32_t* dw, int32_t* dh) {
+    const int S = LCD_WIDTH;
+    switch (r) {
+    case 1: // 90° CW
+        *dw = h; *dh = w;
+        *dx = S - sy - h; *dy = sx;
+        for (int32_t y = 0; y < h; y++)
+            for (int32_t x = 0; x < w; x++)
+                rot_buf[x * h + (h - 1 - y)] = src[y * w + x];
+        break;
+    case 2: // 180°
+        *dw = w; *dh = h;
+        *dx = S - sx - w; *dy = S - sy - h;
+        for (int32_t y = 0; y < h; y++)
+            for (int32_t x = 0; x < w; x++)
+                rot_buf[(h - 1 - y) * w + (w - 1 - x)] = src[y * w + x];
+        break;
+    case 3: // 270° CW
+        *dw = h; *dh = w;
+        *dx = sy; *dy = S - sx - w;
+        for (int32_t y = 0; y < h; y++)
+            for (int32_t x = 0; x < w; x++)
+                rot_buf[(w - 1 - x) * h + y] = src[y * w + x];
+        break;
+    default:
+        *dx = sx; *dy = sy; *dw = w; *dh = h;
+        break;
+    }
+}
+
 void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
                              const uint16_t* pixels) {
-    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+    if (!gfx) return;
+    uint8_t r = imu_hal_rotation_quadrant();
+    if (r == 0 || !rot_buf) {
+        gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+        return;
+    }
+    int32_t dx, dy, dw, dh;
+    rotate_strip(pixels, w, h, x, y, r, &dx, &dy, &dw, &dh);
+    gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
 }
 
 void display_hal_tick(void) {
-    // No rotation cycle on this board.
+    static uint8_t  last_rotation = 0;
+    static uint8_t  ramp_step = 0;
+    static uint32_t ramp_last = 0;
+
+    uint8_t rot = imu_hal_rotation_quadrant();
+    if (rot != last_rotation) {
+        display_hal_set_brightness(0);
+        last_rotation = rot;
+        lv_obj_invalidate(lv_screen_active());
+        ramp_step = 1;
+        return;
+    }
+    if (ramp_step == 0) return;
+    uint32_t now = millis();
+    if (now - ramp_last < 25) return;
+    ramp_last = now;
+
+    static const uint8_t pct[] = {30, 60, 85, 100};
+    uint8_t target = brightness_get();
+    display_hal_set_brightness((uint8_t)(((uint16_t)target * pct[ramp_step - 1]) / 100));
+    if (ramp_step >= 4) ramp_step = 0;
+    else                ramp_step++;
 }
 
 // Mirrors the CO5300/SH8601 even-alignment pattern from the other ports.

--- a/firmware/src/boards/waveshare_amoled_216_c6/imu.cpp
+++ b/firmware/src/boards/waveshare_amoled_216_c6/imu.cpp
@@ -4,23 +4,77 @@
 #include <Wire.h>
 #include <SensorQMI8658.hpp>
 
-// QMI8658 is populated on the 2.16 carrier PCB but rotation is disabled
-// on the C6 build (BOARD_HAS_ROTATION=0). We still initialize the device
-// so the shared I2C bus stays healthy and so a future build can flip
-// rotation on without changing this file. Always reports quadrant 0.
+#define IMU_POLL_MS       100
+#define STABLE_TIME_MS    300
+#define TILT_THRESHOLD    0.5f
 
 static SensorQMI8658 imu;
+static uint8_t  current_rotation   = 0;
+static uint8_t  candidate_rotation = 0;
+static uint32_t candidate_since    = 0;
+static uint32_t last_poll_ms       = 0;
+static bool     imu_ok             = false;
+
+static uint8_t accel_to_rotation(float ax, float ay) {
+    float abs_ax = fabsf(ax);
+    float abs_ay = fabsf(ay);
+    if (abs_ax < TILT_THRESHOLD && abs_ay < TILT_THRESHOLD) return 255;
+    if (abs_ay > abs_ax) return (ay > 0) ? 3 : 1;
+    return (ax > 0) ? 0 : 2;
+}
 
 void imu_hal_init(void) {
     if (!imu.begin(Wire, QMI8658_L_SLAVE_ADDRESS, IIC_SDA, IIC_SCL)) {
         Serial.println("QMI8658 init failed");
         return;
     }
-    Serial.println("QMI8658 init OK (rotation disabled on this board)");
+    Serial.println("QMI8658 init OK");
+    imu.configAccelerometer(
+        SensorQMI8658::ACC_RANGE_4G,
+        SensorQMI8658::ACC_ODR_LOWPOWER_21Hz,
+        SensorQMI8658::LPF_MODE_3);
+    imu.enableAccelerometer();
+    imu_ok = true;
 }
 
 void imu_hal_tick(void) {
-    // No-op — rotation is disabled.
+    if (!imu_ok) return;
+    uint32_t now = millis();
+    if (now - last_poll_ms < IMU_POLL_MS) return;
+    last_poll_ms = now;
+
+    float ax, ay, az;
+    if (!imu.getAccelerometer(ax, ay, az)) return;
+
+    uint8_t target = accel_to_rotation(ax, ay);
+    if (target == 255 || target == current_rotation) {
+        candidate_rotation = current_rotation;
+        return;
+    }
+    if (target != candidate_rotation) {
+        candidate_rotation = target;
+        candidate_since = now;
+    } else if (now - candidate_since >= STABLE_TIME_MS) {
+        current_rotation = target;
+        Serial.printf("Rotation: %d\n", current_rotation);
+    }
 }
 
-uint8_t imu_hal_rotation_quadrant(void) { return 0; }
+uint8_t imu_hal_rotation_quadrant(void) { return (current_rotation + BOARD_ROTATION_OFFSET) % 4; }
+
+void imu_hal_print_debug(void) {
+    if (!imu_ok) {
+        Serial.println("IMU: init failed — imu_ok=false");
+        return;
+    }
+    float ax, ay, az;
+    if (!imu.getAccelerometer(ax, ay, az)) {
+        Serial.println("IMU: getAccelerometer failed");
+        return;
+    }
+    uint8_t raw = accel_to_rotation(ax, ay);
+    Serial.printf("IMU: ax=%.3f ay=%.3f az=%.3f  raw=%s  rotation=%d  candidate=%d\n",
+        ax, ay, az,
+        raw == 255 ? "ambiguous" : String(raw).c_str(),
+        current_rotation, candidate_rotation);
+}

--- a/firmware/src/boards/waveshare_amoled_216_c6/imu.cpp
+++ b/firmware/src/boards/waveshare_amoled_216_c6/imu.cpp
@@ -19,7 +19,7 @@ static uint8_t accel_to_rotation(float ax, float ay) {
     float abs_ax = fabsf(ax);
     float abs_ay = fabsf(ay);
     if (abs_ax < TILT_THRESHOLD && abs_ay < TILT_THRESHOLD) return 255;
-    if (abs_ay > abs_ax) return (ay > 0) ? 3 : 1;
+    if (abs_ay > abs_ax) return (ay > 0) ? 1 : 3;  // Y invertido para corregir montaje
     return (ax > 0) ? 0 : 2;
 }
 

--- a/firmware/src/hal/imu_hal.h
+++ b/firmware/src/hal/imu_hal.h
@@ -9,3 +9,4 @@
 void    imu_hal_init(void);
 void    imu_hal_tick(void);
 uint8_t imu_hal_rotation_quadrant(void);
+void    imu_hal_print_debug(void);  // print raw accel + rotation state to Serial

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -164,6 +164,7 @@ static void check_serial_cmd() {
         if (c == '\n' || c == '\r') {
             cmd_buf[cmd_pos] = '\0';
             if (strcmp(cmd_buf, "screenshot") == 0) send_screenshot();
+            else if (strcmp(cmd_buf, "imu") == 0)   imu_hal_print_debug();
             cmd_pos = 0;
         } else if (cmd_pos < CMD_BUF_SIZE - 1) {
             cmd_buf[cmd_pos++] = c;

--- a/hardware/stand/README.md
+++ b/hardware/stand/README.md
@@ -1,0 +1,224 @@
+# Clawdmeter 3D Stand
+
+Soporte impreso en 3D para el Waveshare ESP32-C6-Touch-AMOLED-2.16 (pantalla cuadrada AMOLED 480×480).
+
+## Características
+
+- **Dos piezas**: cuna (cradle) + pata (leg kickstand)
+- **Tilt adjustable**: bisagra con muescas cada 10° + bloqueo con tornillo M3
+- **Plegable**: la pata se pliega para almacenaje plano
+- **Snap-fit**: el dispositivo se inserta sin tornillos (retención elástica)
+- **Cable libre**: USB-C cuelga desde la parte inferior
+
+---
+
+## Hardware Necesario
+
+| Ítem | Cantidad |
+|------|----------|
+| Tornillo M3 × 20mm | 1 |
+| Tuerca M3 hexagonal | 1 |
+| Pad de goma antideslizante 10×10mm | 1 |
+
+---
+
+## Exportar desde OpenSCAD
+
+### Opción A: Interfaz Gráfica (GUI)
+
+1. Abre `clawdmeter_stand.scad` en OpenSCAD
+2. **Exportar cradle:**
+   - En la parte superior, cambia `RENDER = "assembly";` a `RENDER = "cradle";`
+   - Presiona F5 (Preview) para ver la pieza
+   - Menu **File → Export as STL** → `clawdmeter_cradle.stl`
+3. **Exportar leg:**
+   - Cambia `RENDER = "cradle";` a `RENDER = "leg";`
+   - Presiona F5
+   - Menu **File → Export as STL** → `clawdmeter_leg.stl`
+
+### Opción B: Línea de Comandos (CLI)
+
+```bash
+# Exportar cradle
+openscad -D 'RENDER="cradle"' -o clawdmeter_cradle.stl clawdmeter_stand.scad
+
+# Exportar leg
+openscad -D 'RENDER="leg"' -o clawdmeter_leg.stl clawdmeter_stand.scad
+```
+
+---
+
+## Parámetros OpenSCAD
+
+Todos los parámetros están en la cabecera del archivo (líneas 13–45) y pueden ajustarse:
+
+```openscad
+DEVICE_W       = 46.0    // ancho PCB
+DEVICE_H       = 46.0    // alto PCB
+DEVICE_D       = 8.3     // grosor PCB
+CRADLE_CLEAR   = 0.3     // holgura snap-fit
+WALL           = 2.5     // espesor paredes cuna
+HINGE_R        = 14.0    // radio disco dentado
+HINGE_TEETH    = 36      // 10° por paso (360/36)
+LEG_L          = 80.0    // largo pata
+M3_D           = 3.4     // diámetro agujero M3
+```
+
+Cambiar parámetros y reimportar los STL para customizar.
+
+---
+
+## Impresión Recomendada
+
+### Cuna (cradle)
+
+| Parámetro | Valor |
+|-----------|-------|
+| Material | PETG o ABS |
+| Relleno | 25% |
+| Perímetros | 3 |
+| Orientación | Boca abajo (cara frontal en la cama) |
+| Soporte | Sí, solo en las orejetas de bisagra (mínimo) |
+| Tiempo est. | ~2–3h a 0.15mm |
+
+**Nota:** Imprimir boca abajo reduce el soporte y mejora la calidad de la cara frontal. Las orejetas de la bisagra necesitan soporte puntual.
+
+### Pata (leg)
+
+| Parámetro | Valor |
+|-----------|-------|
+| Material | PETG o ABS |
+| Relleno | 30% |
+| Perímetros | 4 |
+| Orientación | Plana (como sale del archivo STL) |
+| Soporte | No necesita |
+| Tiempo est. | ~1–1.5h a 0.15mm |
+
+**Nota:** La pata es simple y no necesita soporte. Imprimir plana maximiza resistencia en la bisagra.
+
+---
+
+## Ensamble
+
+### Paso 1: Preparar las piezas
+
+1. Retira soportes (si los hay) y limpia rebabas
+2. Prueba la cuna: inserta y saca el Clawdmeter varias veces para soltar las pestañas snap-fit (deben ceder sin dañarse)
+
+### Paso 2: Preparar la bisagra
+
+1. **En la pata:**
+   - Verifica que el agujero M3 está limpio y puede pasar el tornillo sin fricción
+   - Coloca la **tuerca M3 en el hueco hexagonal** de la cara interior del disco (asiento cuadrado de 0.5–1mm de profundidad)
+   - La tuerca debe encajar sin sobresalir
+
+2. **En la cuna:**
+   - Verifica que los canales de la bisagra (orejetas) están limpios
+
+### Paso 3: Ensamblar
+
+1. Alinea el disco de la pata con los oídos de la cuna (bisagra)
+2. Inserta el **tornillo M3×20** a través de la cuna → disco de la pata → tuerca
+3. **Aprieta con moderación** (1–2 Nm) hasta que:
+   - La pata puede girar pero con fricción tactil (sienta los clicks de 10°)
+   - No hay juego de lado a lado
+4. Usa una llave hexagonal M3 o destornillador Phillips para ajustar
+
+### Paso 4: Instalar el pad antideslizante
+
+1. Limpia la cara inferior del pie de la pata (polvo + residuos de impresión)
+2. Retira la capa adhesiva del pad 10×10mm
+3. **Presiona centrado en el pie** (equidistante del borde)
+4. Presiona 30s para activar adhesivo
+
+### Paso 5: Colocar el dispositivo
+
+1. Con el Clawdmeter en la mano, **inserta primero la esquina inferior en la cuna** (el borde donde está USB-C)
+2. Desliza hacia adentro hasta que encaje con un *click* (las pestañas snap-fit sellan lateralmente)
+3. Confirma que la pantalla no sobresale del marco frontal
+
+---
+
+## Ajuste de Ángulos
+
+### Usar la bisagra con muescas
+
+- La bisagra tiene **36 muescas**, cada una espaciada **10°**
+- Gira la pata lentamente; sentirás *detents* cada 10°
+- **Posiciones recomendadas:**
+  - **0°** (plegado) — almacenaje plano
+  - **30°** (bajo) — referencia rápida en el escritorio
+  - **45°** (medio) — posición estándar de uso
+  - **60°** (alto) — mayor inclinación hacia el usuario
+  - **90°** (vertical) — casi perpendicular al escritorio
+
+### Bloqueo con tornillo
+
+1. Una vez en el ángulo deseado, aprieta el tornillo M3 **con firmeza** (2–3 Nm)
+2. La pata queda bloqueada en esa posición
+3. Para cambiar ángulo: afloja el tornillo, reposiciona, aprieta de nuevo
+
+---
+
+## Ajustes y Troubleshooting
+
+### La pata es muy floja / muy rígida
+
+- **Muy floja**: Aprieta más el tornillo M3 (aumento +0.5 Nm)
+- **Muy rígida**: Afloja ligeramente; la fricción debe permitir giro suave con resistance tactil
+
+### El dispositivo no entra / está muy apretado
+
+- Aumenta `CRADLE_CLEAR` en el SCAD (línea 20) de 0.3 a 0.4–0.5 mm
+- Reexporta y reimpr
+
+ime la cuna
+
+### La tuerca se suelta en la bisagra
+
+- Aprieta el tornillo M3 **con llave** (no solo con los dedos)
+- Verifica que el agujero hexagonal tiene profundidad suficiente (~1.5 mm)
+- Si sigue soltándose, añade un pequeño punto de **Loctite azul** (removible) en la tuerca
+
+---
+
+## Parámetros Técnicos del Diseño
+
+| Parámetro | Valor | Notas |
+|-----------|-------|-------|
+| Diámetro agujero M3 | 3.4 mm | Clearance ajustado para tolerancia |
+| Hueco tuerca M3 | Hexagonal 6.1mm | Capacidad + 0.1mm clearance |
+| Radio cuna interior | 6.1 mm | Sigue R5.8 del PCB + 0.3 clearance |
+| Tamaño snap-tab | 1.5 mm × 14 mm | Flexiona suavemente sin fatiga |
+| Espesor pared cuna | 2.5 mm | Resistencia + paredes finas (impresión rápida) |
+| Espesor pata | 4 mm | Rigidez sin exceso de peso |
+| Pad goma recess | 1.5 mm | Apenas visible en el pie |
+| Holgura entre orejas | 0.4 mm | Movimiento suave sin juego |
+
+---
+
+## Archivos
+
+- `clawdmeter_stand.scad` — Modelo paramétrico (edita parámetros aquí)
+- `clawdmeter_cradle.stl` — Pieza 1, lista para laminar
+- `clawdmeter_leg.stl` — Pieza 2, lista para laminar
+- `README.md` — Este archivo
+
+---
+
+## Licencia
+
+Este diseño es parte del proyecto **Clawdmeter** ([github.com/HermannBjorgvin/Clawdmeter](https://github.com/HermannBjorgvin/Clawdmeter)), de código abierto bajo la licencia que use el proyecto principal.
+
+---
+
+## Notas de Diseño
+
+- **Detentes radiales + M3 bloqueo**: Cualquier ángulo es posible, pero cada 10° hay una posición con feedback tactil natural. El tornillo asegura que no se desliza bajo vibraciones.
+- **Snap-fit vs tornillos**: Snap-fit permite cambios rápidos del dispositivo sin herramientas. Las pestañas son pasivas (solo retención, sin compresión exagerada), así que la vida de fatiga es excelente.
+- **Pata plegable**: La bisagra integral permite plegar 180° plano, ideal para viajeros o almacenaje en mochilas.
+- **Cable libre**: USB-C cuelga desde abajo, no interrumpe la vista frontal de la pantalla.
+
+---
+
+¿Necesitas ajustes? Edita los parámetros en `clawdmeter_stand.scad` (líneas 13–45) y reimporta los STL.

--- a/hardware/stand/clawdmeter_stand.scad
+++ b/hardware/stand/clawdmeter_stand.scad
@@ -1,0 +1,209 @@
+// Clawdmeter Desk Stand
+// Parametric kickstand for Waveshare ESP32-C6-Touch-AMOLED-2.16
+// Two pieces: cradle (snap-fit) + leg (kickstand with detent hinge)
+// Hardware: 1x M3x20mm bolt + 1x M3 hex nut + 1x 10x10mm rubber pad
+
+// ── RENDER CONTROL ──────────────────────────────────────────────────────────
+// Change RENDER to export each piece:
+//   "cradle"   → export clawdmeter_cradle.stl
+//   "leg"      → export clawdmeter_leg.stl
+//   "assembly" → preview both assembled (not for export)
+RENDER = "assembly";
+
+// ── DEVICE DIMENSIONS (Waveshare C6-Touch-AMOLED-2.16 datasheet) ────────────
+DEVICE_W     = 46.0;   // PCB width  [mm]
+DEVICE_H     = 46.0;   // PCB height [mm]
+DEVICE_D     = 8.3;    // PCB depth  [mm]
+DEVICE_R     = 5.8;    // PCB corner radius [mm]
+
+// ── CRADLE PARAMETERS ────────────────────────────────────────────────────────
+CRADLE_CLEAR = 0.3;    // clearance per side for snap-fit [mm]
+WALL         = 2.5;    // cradle wall thickness [mm]
+SNAP_TAB_H   = 1.5;    // snap tab retention depth [mm]
+SNAP_TAB_L   = 14.0;   // snap tab length [mm]
+USBC_W       = 14.0;   // USB-C cutout width [mm]
+USBC_H       = 5.0;    // USB-C cutout height [mm]
+
+// ── HINGE PARAMETERS ─────────────────────────────────────────────────────────
+HINGE_R      = 14.0;   // detent disc radius [mm]
+HINGE_TEETH  = 36;     // teeth count → 10° per step
+TOOTH_H      = 1.2;    // tooth height above disc face [mm]
+EAR_T        = 4.0;    // ear thickness (each side) [mm]
+EAR_GAP      = 0.4;    // clearance between ear and leg disc [mm]
+
+// ── LEG PARAMETERS ───────────────────────────────────────────────────────────
+LEG_L        = 80.0;   // leg length [mm]
+LEG_W        = 12.0;   // leg width [mm]
+LEG_T        = 4.0;    // leg thickness [mm]
+PAD_W        = 10.0;   // rubber pad width [mm]
+PAD_L        = 10.0;   // rubber pad length [mm]
+PAD_D        = 1.5;    // rubber pad recess depth [mm]
+
+// ── HARDWARE ─────────────────────────────────────────────────────────────────
+M3_D         = 3.4;    // M3 bolt hole diameter (with clearance) [mm]
+M3_NUT_W     = 6.1;    // M3 hex nut flat-to-flat + 0.1mm clearance [mm]
+M3_NUT_H     = 2.5;    // M3 hex nut height + 0.1mm [mm]
+
+// ── DERIVED ──────────────────────────────────────────────────────────────────
+CW = DEVICE_W + 2*CRADLE_CLEAR + 2*WALL;  // cradle outer width
+CH = DEVICE_H + 2*CRADLE_CLEAR + 2*WALL;  // cradle outer height
+CD = DEVICE_D + WALL;                      // cradle outer depth (open back)
+
+// ── SANITY CHECKS ─────────────────────────────────────────────────────────────
+echo("Cradle outer WxH:", CW, CH);
+echo("Hinge bolt span:", 2*(EAR_T+EAR_GAP)+LEG_T);
+assert(2*(EAR_T+EAR_GAP)+LEG_T < 20,
+       "Hinge stack exceeds M3x20 bolt — reduce EAR_T or LEG_T");
+assert(HINGE_R > DEVICE_D/2 + 2,
+       "Hinge disc too small — cradle may collide with desk");
+
+$fn = 64;
+
+// ── DISPATCH ─────────────────────────────────────────────────────────────────
+if      (RENDER == "cradle")   cradle();
+else if (RENDER == "leg")      leg();
+else                           assembly();
+
+// ── HELPERS ──────────────────────────────────────────────────────────────────
+
+module rounded_box(w, h, d, r) {
+    hull() {
+        for (xi = [r, w-r], yi = [r, h-r])
+            translate([xi, yi, 0]) cylinder(r=r, h=d);
+    }
+}
+
+module rounded_pocket(w, h, d, r) {
+    hull() {
+        for (xi = [r, w-r], yi = [r, h-r])
+            translate([xi, yi, -0.5]) cylinder(r=r, h=d+1);
+    }
+}
+
+// ── CRADLE ───────────────────────────────────────────────────────────────────
+// Orientation: device face at Z=0 (facing user), bottom (USB-C side) at Y=0
+// Hinge ears extend from Y=0 face downward (negative Y)
+
+module cradle() {
+    difference() {
+        // Outer shell
+        rounded_box(CW, CH, CD, WALL);
+
+        // Device pocket (open on front face, Z=0)
+        translate([WALL - CRADLE_CLEAR, WALL - CRADLE_CLEAR, WALL])
+            rounded_pocket(
+                DEVICE_W + 2*CRADLE_CLEAR,
+                DEVICE_H + 2*CRADLE_CLEAR,
+                CD,
+                DEVICE_R + CRADLE_CLEAR);
+
+        // Top opening — remove top wall for button access
+        translate([-1, CH - WALL, -1])
+            cube([CW + 2, WALL + 1, CD + 2]);
+
+        // USB-C cutout at bottom center (Y=0 wall)
+        translate([CW/2 - USBC_W/2, -1, WALL + CRADLE_CLEAR])
+            cube([USBC_W, WALL + 2, USBC_H]);
+
+        // M3 bolt channel through both ears (Y axis)
+        translate([CW/2, -(EAR_T + EAR_GAP + 1), CD/2])
+            rotate([-90, 0, 0])
+            cylinder(d=M3_D, h=2*(EAR_T + EAR_GAP) + LEG_T + 2);
+    }
+
+    // Snap tabs — left and right
+    snap_tab(true);
+    snap_tab(false);
+
+    // Hinge ears at bottom
+    hinge_ears();
+}
+
+module snap_tab(left) {
+    x_base  = left ? -WALL : CW;
+    flip    = left ? 0 : 1;
+    y_start = (CH - SNAP_TAB_L) / 2;
+
+    translate([x_base, y_start, 0])
+    mirror([flip, 0, 0])
+    difference() {
+        cube([WALL, SNAP_TAB_L, CD]);
+        // 45° lead-in chamfer at the tip (Z=CD end)
+        translate([-0.1, -0.1, CD - SNAP_TAB_H * 2])
+            rotate([0, 45, 0])
+            cube([WALL * 2, SNAP_TAB_L + 0.2, WALL * 2]);
+    }
+}
+
+module hinge_ears() {
+    for (side = [-1, 1]) {
+        x_pos = CW/2 + side * (LEG_T/2 + EAR_GAP + EAR_T/2);
+        translate([x_pos, 0, CD/2])
+        rotate([90, 0, 0])   // disc normal → Y axis
+        difference() {
+            cylinder(r=HINGE_R, h=EAR_T, center=true);
+            // M3 bolt hole
+            cylinder(d=M3_D, h=EAR_T + 1, center=true);
+            // Tooth slots (negative teeth, offset by half pitch to mesh)
+            for (i = [0:HINGE_TEETH-1])
+                rotate([0, 0, i * 360/HINGE_TEETH + 180/HINGE_TEETH])
+                translate([HINGE_R - TOOTH_H - 0.3, 0, 0])
+                cylinder(r=1.1, h=EAR_T + 1, center=true, $fn=3);
+        }
+    }
+}
+
+// ── LEG ──────────────────────────────────────────────────────────────────────
+// Printed flat. Disc at Y=0 end, foot at Y=LEG_L end.
+// Bolt axis = Z when printed; becomes Y in assembly.
+
+module leg() {
+    union() {
+        // Main arm
+        translate([0, HINGE_R, 0])
+            cube([LEG_W, LEG_L - HINGE_R - 18, LEG_T]);
+
+        // Detent disc at top (Y=0)
+        translate([LEG_W/2, 0, LEG_T/2])
+        rotate([90, 0, 0])
+        difference() {
+            union() {
+                cylinder(r=HINGE_R, h=LEG_T, center=true);
+                // Raised teeth
+                for (i = [0:HINGE_TEETH-1])
+                    rotate([0, 0, i * 360/HINGE_TEETH])
+                    translate([HINGE_R - TOOTH_H/2, 0, 0])
+                    cylinder(r=1.0, h=LEG_T + 0.2, center=true, $fn=3);
+            }
+            // M3 bolt through-hole
+            cylinder(d=M3_D, h=LEG_T + 1, center=true);
+            // M3 nut pocket on outer face
+            translate([0, 0, -(LEG_T/2 - M3_NUT_H)])
+                cylinder(d=M3_NUT_W / cos(30), h=M3_NUT_H + 0.5,
+                         center=false, $fn=6);
+        }
+
+        // Foot with rubber pad recess
+        translate([0, LEG_L - 18, 0])
+        difference() {
+            translate([-3, 0, 0]) cube([LEG_W + 6, 18, LEG_T + 2]);
+            translate([(LEG_W + 6)/2 - PAD_W/2 - 3,
+                       4,
+                       LEG_T + 2 - PAD_D])
+                cube([PAD_W, PAD_L, PAD_D + 1]);
+        }
+    }
+}
+
+// ── ASSEMBLY PREVIEW ─────────────────────────────────────────────────────────
+TILT_ANGLE = 60;  // 0=folded flat, 90=upright
+
+module assembly() {
+    cradle();
+    // Hinge center on cradle: [CW/2, 0, CD/2]
+    // Leg disc center matches when placed at origin, then translated
+    translate([CW/2, 0, CD/2])
+    rotate([TILT_ANGLE - 90, 0, 0])
+    translate([-LEG_W/2, -HINGE_R, -LEG_T/2])
+        leg();
+}


### PR DESCRIPTION
## Summary

- **C6 auto-rotation**: The rotation strip buffer (37 KB) fits in the ESP32-C6's internal SRAM. No PSRAM is needed. This enables full IMU-driven auto-rotation on the `waveshare_amoled_216_c6` board, matching the behaviour of the S3 port. A `BOARD_ROTATION_OFFSET` of 3 (270° CW) is applied to correct for the IMU being mounted at a different angle relative to the display on the C6 carrier PCB (verified on hardware).
- **`imu` serial debug command**: A new `imu_hal_print_debug()` HAL function (and matching `imu` serial command) prints raw accelerometer values, the current rotation quadrant, and the candidate state. Useful for diagnosing auto-rotation issues on any board without reflashing.

## Test plan

- [ ] Flash `waveshare_amoled_216_c6` and verify splash/usage screens render correctly at rest
- [ ] Rotate device 90°/180°/270° and confirm display follows with ~300 ms hysteresis
- [ ] Type `imu` in serial monitor and confirm output shows `ax`/`ay`/`az` + rotation state
- [ ] Confirm `waveshare_amoled_216` and `waveshare_amoled_18` still build and `imu` command compiles on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)