### PR TITLE
feat: optional clock on the Usage screen (off by default)

### DIFF
--- a/daemon/claude-usage-daemon.sh
+++ b/daemon/claude-usage-daemon.sh
@@ -12,6 +12,7 @@ REQ_CHAR_UUID="4c41555a-4465-7669-6365-000000000004"
 POLL_INTERVAL=60
 TICK=5
 SAVED_MAC_FILE="$HOME/.config/claude-usage-monitor/ble-address"
+CONFIG_FILE="$HOME/.config/claude-usage-monitor/config"
 REFRESH_FLAG="/tmp/claude-usage-refresh-$$"
 DBUS_DEST="org.bluez"
 NOTIFY_PID=""
@@ -22,6 +23,32 @@ log() {
 
 read_token() {
     grep -o '"accessToken":"[^"]*"' "$HOME/.claude/.credentials.json" | cut -d'"' -f4
+}
+
+# Read the `clock` option from the config file. Echoes one of: off|auto|12|24.
+# Defaults to "off" so existing setups keep showing "Usage" until opted in.
+read_clock_setting() {
+    local val=""
+    if [ -f "$CONFIG_FILE" ]; then
+        val=$(grep -E '^[[:space:]]*clock[[:space:]]*=' "$CONFIG_FILE" | tail -1 \
+            | tr -d '\r' \
+            | sed -E 's/^[[:space:]]*clock[[:space:]]*=[[:space:]]*//; s/[[:space:]]*(#.*)?$//' \
+            | tr '[:upper:]' '[:lower:]')
+    fi
+    case "$val" in
+        off|auto|12|24) echo "$val" ;;
+        *)              echo "off" ;;
+    esac
+}
+
+# Best-effort 12h/24h detection from the locale. Echoes 12 or 24 (default 24).
+detect_hour_format() {
+    local tfmt
+    tfmt=$(locale -k LC_TIME 2>/dev/null | grep -E '^t_fmt=')
+    case "$tfmt" in
+        *%p*|*%r*|*%I*) echo 12 ;;
+        *)              echo 24 ;;
+    esac
 }
 
 # Convert MAC to D-Bus path: AA:BB:CC:DD:EE:FF -> dev_AA_BB_CC_DD_EE_FF
@@ -197,6 +224,24 @@ poll() {
     local now
     now=$(date +%s)
 
+    # Optional clock. When enabled, send a local wall-clock epoch (UTC epoch shifted
+    # by the timezone offset, so gmtime() on-device reads local) plus the hour format.
+    local clock clock_fragment=""
+    clock=$(read_clock_setting)
+    if [ "$clock" != "off" ]; then
+        local tz off_sec local_epoch tf
+        tz=$(date +%z)            # e.g. +0200 or -0500
+        off_sec=$(( (10#${tz:1:2} * 3600) + (10#${tz:3:2} * 60) ))
+        [ "${tz:0:1}" = "-" ] && off_sec=$(( -off_sec ))
+        local_epoch=$(( now + off_sec ))
+        case "$clock" in
+            12) tf=12 ;;
+            24) tf=24 ;;
+            *)  tf=$(detect_hour_format) ;;
+        esac
+        clock_fragment=",\"t\":$local_epoch,\"tf\":$tf"
+    fi
+
     local headers
     headers=$(curl -s -D - -o /dev/null \
         "https://api.anthropic.com/v1/messages" \
@@ -222,13 +267,13 @@ poll() {
     status=${status:-unknown}
 
     local payload
-    payload=$(awk -v u5="$s5h_util" -v r5="$s5h_reset" -v u7="$s7d_util" -v r7="$s7d_reset" -v st="$status" -v now="$now" \
+    payload=$(awk -v u5="$s5h_util" -v r5="$s5h_reset" -v u7="$s7d_util" -v r7="$s7d_reset" -v st="$status" -v now="$now" -v clk="$clock_fragment" \
         'BEGIN {
             sp = sprintf("%.0f", u5 * 100);
             sr = (r5 - now) / 60; sr = sr > 0 ? sprintf("%.0f", sr) : 0;
             wp = sprintf("%.0f", u7 * 100);
             wr = (r7 - now) / 60; wr = wr > 0 ? sprintf("%.0f", wr) : 0;
-            printf "{\"s\":%s,\"sr\":%s,\"w\":%s,\"wr\":%s,\"st\":\"%s\",\"ok\":true}", sp, sr, wp, wr, st;
+            printf "{\"s\":%s,\"sr\":%s,\"w\":%s,\"wr\":%s,\"st\":\"%s\"%s,\"ok\":true}", sp, sr, wp, wr, st, clk;
         }')
 
     log "Sending: $payload"

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -35,6 +35,7 @@ SCAN_TIMEOUT = 8.0
 KEYCHAIN_SERVICE = "Claude Code-credentials"
 CREDENTIALS_PATH = Path.home() / ".claude" / ".credentials.json"
 SAVED_ADDR_FILE = Path.home() / ".config" / "claude-usage-monitor" / "ble-address"
+CONFIG_FILE = Path.home() / ".config" / "claude-usage-monitor" / "config"
 
 API_URL = "https://api.anthropic.com/v1/messages"
 API_HEADERS_TEMPLATE = {
@@ -271,6 +272,66 @@ async def discover_target(skip_addr: str | None = None):
     return address
 
 
+def read_clock_setting() -> str:
+    """Read the `clock` option from the config file. One of: off|auto|12|24.
+
+    Defaults to "off" (no clock; the device keeps showing "Usage") so existing
+    setups are unaffected until the user opts in.
+    """
+    try:
+        if CONFIG_FILE.exists():
+            for line in CONFIG_FILE.read_text().splitlines():
+                line = line.split("#", 1)[0].strip()
+                if "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                if key.strip().lower() == "clock":
+                    val = val.strip().lower()
+                    if val in ("off", "auto", "12", "24"):
+                        return val
+    except OSError:
+        pass
+    return "off"
+
+
+def detect_hour_format() -> int:
+    """Best-effort 12h/24h detection for the host. Returns 12 or 24 (default 24)."""
+    # macOS: the explicit System Settings toggle lives in NSGlobalDomain.
+    for key, result in (("AppleICUForce24HourTime", 24), ("AppleICUForce12HourTime", 12)):
+        try:
+            out = subprocess.run(["defaults", "read", "-g", key],
+                                 capture_output=True, text=True, timeout=3)
+            if out.stdout.strip() == "1":
+                return result
+        except (OSError, subprocess.SubprocessError):
+            pass
+    # Fallback to the C locale's time format (may be C/24h under launchd).
+    try:
+        import locale
+        locale.setlocale(locale.LC_TIME, "")
+        fmt = locale.nl_langinfo(locale.T_FMT)
+        if "%p" in fmt or "%r" in fmt or "%I" in fmt:
+            return 12
+    except (ImportError, locale.Error, AttributeError):
+        pass
+    return 24
+
+
+def add_clock_fields(payload: dict) -> None:
+    """Add wall-clock fields to the payload when the config opts in.
+
+    "t"  = local wall-clock epoch (UTC epoch shifted by the tz offset) so the
+           device can show the time without an RTC.
+    "tf" = 12 or 24, the hour format the device should render.
+    """
+    clock = read_clock_setting()
+    if clock == "off":
+        return
+    tf = 24 if clock == "24" else 12 if clock == "12" else detect_hour_format()
+    payload["t"] = int(time.time()) + time.localtime().tm_gmtoff
+    payload["tf"] = tf
+
+
 async def poll_api(token: str) -> dict | None:
     headers = dict(API_HEADERS_TEMPLATE)
     headers["Authorization"] = f"Bearer {token}"
@@ -311,6 +372,7 @@ async def poll_api(token: str) -> dict | None:
         "st": hdr("anthropic-ratelimit-unified-5h-status", "unknown"),
         "ok": True,
     }
+    add_clock_fields(payload)   # adds "t" + "tf" iff the config opts in
     return payload
 
 

--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -39,6 +39,9 @@ ZOMBIE_BREAK_LIMIT = 1     # D-03: consecutive write failures before abandoning 
 RECONNECT_BACKOFF_CAP = 8  # D-05: fast-reconnect cap (seconds); keeps stacked retries inside 120s SLA
                            # ~5–10s band per CONTEXT.md Claude's Discretion; 8 chosen as middle ground
 
+# Optional clock display. Config lives under the same Clawdmeter dir as daemon.log.
+CONFIG_FILE = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local")) / "Clawdmeter" / "config"
+
 API_URL = "https://api.anthropic.com/v1/messages"
 API_HEADERS_TEMPLATE = {
     "anthropic-version": "2023-06-01",
@@ -106,6 +109,49 @@ class AuthError(Exception):
     failed` DNS blip wrongly fired the 'token expired' toast)."""
 
 
+def read_clock_setting() -> str:
+    """Read the `clock` option from the config file. One of: off|auto|12|24.
+
+    Defaults to "off" so existing setups keep showing "Usage" until opted in.
+    """
+    try:
+        if CONFIG_FILE.exists():
+            for line in CONFIG_FILE.read_text().splitlines():
+                line = line.split("#", 1)[0].strip()
+                if "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                if key.strip().lower() == "clock":
+                    val = val.strip().lower()
+                    if val in ("off", "auto", "12", "24"):
+                        return val
+    except OSError:
+        pass
+    return "off"
+
+
+def detect_hour_format() -> int:
+    """Best-effort 12h/24h detection on Windows via the registry. Returns 12 or 24."""
+    try:
+        import winreg
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Control Panel\International") as k:
+            # iTime: "1" = 24-hour, "0" = 12-hour.
+            val, _ = winreg.QueryValueEx(k, "iTime")
+            return 24 if str(val).strip() == "1" else 12
+    except (ImportError, OSError):
+        return 24
+
+
+def add_clock_fields(payload: dict) -> None:
+    """Add "t" (local wall-clock epoch) + "tf" (12|24) when the config opts in."""
+    clock = read_clock_setting()
+    if clock == "off":
+        return
+    tf = 24 if clock == "24" else 12 if clock == "12" else detect_hour_format()
+    payload["t"] = int(time.time()) + time.localtime().tm_gmtoff
+    payload["tf"] = tf
+
+
 async def poll_api(token: str) -> dict | None:
     headers = dict(API_HEADERS_TEMPLATE)
     headers["Authorization"] = f"Bearer {token}"
@@ -153,6 +199,7 @@ async def poll_api(token: str) -> dict | None:
         "st": hdr("anthropic-ratelimit-unified-5h-status", "unknown"),
         "ok": True,
     }
+    add_clock_fields(payload)   # adds "t" + "tf" iff the config opts in
     return payload
 
 

--- a/daemon/config.example
+++ b/daemon/config.example
@@ -1,0 +1,16 @@
+# Clawdmeter daemon config
+#
+# Copy this file to:
+#   macOS / Linux : ~/.config/claude-usage-monitor/config
+#   Windows       : %LOCALAPPDATA%\Clawdmeter\config
+#
+# The daemon re-reads it on every poll, so edits take effect within ~60s — no restart needed.
+
+# Show a clock on the Usage screen, in place of the "Usage" title.
+#   off  = no clock; the screen keeps showing "Usage" (default)
+#   auto = show the clock, auto-detecting 12h/24h from this machine's settings
+#          (detection can default to 24h when the daemon runs under launchd/systemd
+#           with no locale — set 12 or 24 explicitly below if auto guesses wrong)
+#   12   = show the clock, forced 12-hour  (e.g. 6:28 PM)
+#   24   = show the clock, forced 24-hour  (e.g. 18:28)
+clock = off

--- a/firmware/src/data.h
+++ b/firmware/src/data.h
@@ -7,6 +7,8 @@ struct UsageData {
     float weekly_pct;        // 7-day window utilization (0-100)
     int weekly_reset_mins;   // minutes until weekly resets
     char status[16];         // "allowed" or "limited"
+    long clock_epoch;        // local wall-clock epoch (s) from daemon; 0 = not provided
+    int  clock_fmt;          // 12 or 24 (hour format from daemon); defaults to 24
     bool ok;                 // data parse succeeded
     bool valid;              // false until first successful parse
 };

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -110,6 +110,8 @@ static bool parse_json(const char* json, UsageData* out) {
     out->weekly_pct = doc["w"] | 0.0f;
     out->weekly_reset_mins = doc["wr"] | -1;
     strlcpy(out->status, doc["st"] | "unknown", sizeof(out->status));
+    out->clock_epoch = doc["t"] | 0L;
+    out->clock_fmt = doc["tf"] | 24;
     out->ok = doc["ok"] | false;
     out->valid = true;
     return true;

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -1,6 +1,7 @@
 #include "ui.h"
 #include "splash.h"
 #include <lvgl.h>
+#include <time.h>
 #include "logo.h"
 #include "icons.h"
 #include "hal/board_caps.h"
@@ -102,6 +103,12 @@ static void compute_layout(const BoardCaps& c) {
 // ---- Usage screen widgets (single non-splash view) ----
 static lv_obj_t* usage_container;
 static lv_obj_t* lbl_title;
+// Clock fed by the daemon: base epoch (local wall-clock seconds) + the lv_tick at
+// which it landed, so the title ticks forward locally between 60s payloads.
+static long     clock_base_epoch = 0;
+static uint32_t clock_base_ms = 0;
+static int      clock_fmt = 24;   // 12 or 24, set from the daemon payload
+static int      clock_last_min = -1;   // last rendered minute; avoids redrawing the title every tick
 static lv_obj_t* usage_group;   // the two usage panels — shown when connected
 static lv_obj_t* pair_group;    // pairing hint — shown when disconnected
 static lv_obj_t* bar_session;
@@ -434,6 +441,16 @@ void ui_update(const UsageData* data) {
     last_data_ms = lv_tick_get();   // a valid usage update just landed → dot goes green
     data_received = true;
 
+    if (data->clock_epoch > 0) {    // daemon supplied wall-clock time → drive the title clock
+        clock_base_epoch = data->clock_epoch;
+        clock_base_ms = last_data_ms;
+        clock_fmt = data->clock_fmt;
+    } else if (clock_base_epoch != 0) {   // clock turned off daemon-side → revert title to "Usage"
+        clock_base_epoch = 0;
+        clock_last_min = -1;
+        lv_label_set_text(lbl_title, "Usage");
+    }
+
     int s_pct = (int)(data->session_pct + 0.5f);
 
     lv_label_set_text_fmt(lbl_session_pct, "%d%%", s_pct);
@@ -482,6 +499,27 @@ void ui_tick_anim(void) {
     if (view_state == 1) splash_mini_tick();   // animate the sleeping creature on the idle screen
 
     uint32_t now = lv_tick_get();
+
+    // Title clock: once the daemon has sent wall-clock time, replace "Usage" with
+    // the live time, advanced locally so it ticks every minute between payloads.
+    if (clock_base_epoch > 0) {
+        time_t cur = (time_t)(clock_base_epoch + (now - clock_base_ms) / 1000);
+        struct tm tmv;
+        gmtime_r(&cur, &tmv);   // epoch is already local wall-clock → gmtime keeps it as-is
+        if (tmv.tm_min != clock_last_min) {   // only rewrite the title when the minute changes
+            clock_last_min = tmv.tm_min;
+            char tbuf[12];
+            if (clock_fmt == 12) {
+                int h12 = tmv.tm_hour % 12;
+                if (h12 == 0) h12 = 12;
+                snprintf(tbuf, sizeof(tbuf), "%d:%02d %s", h12, tmv.tm_min,
+                         tmv.tm_hour < 12 ? "AM" : "PM");
+            } else {
+                snprintf(tbuf, sizeof(tbuf), "%02d:%02d", tmv.tm_hour, tmv.tm_min);
+            }
+            lv_label_set_text(lbl_title, tbuf);
+        }
+    }
 
     if (now - anim_msg_start >= ANIM_MSG_MS) {
         anim_msg_idx = (anim_msg_idx + 1) % ANIM_MSG_COUNT;


### PR DESCRIPTION
Addresses #54 — re-opening the clock idea with a working implementation and screenshots, as you suggested.

## What

Optionally show the current time in place of the **Usage** title. It's **off by default**, so existing setups are completely unchanged. One config knob on the daemon turns it on.

| 24-hour | 12-hour | off (default) |
| --- | --- | --- |
| ![24h](https://github.com/devalnor/Clawdmeter/blob/clock-screenshots/screenshots/clock-pr/usage-24h.png?raw=1) | ![12h](https://github.com/devalnor/Clawdmeter/blob/clock-screenshots/screenshots/clock-pr/usage-12h.png?raw=1) | ![off](https://github.com/devalnor/Clawdmeter/blob/clock-screenshots/screenshots/clock-pr/usage-off.png?raw=1) |

## How it works

The firmware has no RTC, so the daemon is the time source. When enabled, the daemon adds two optional fields to the existing BLE JSON payload:

- `t` — local wall-clock epoch (UTC epoch shifted by the host's tz offset, so the firmware's `gmtime()` renders local time)
- `tf` — `12` or `24`, the hour format

The firmware caches `(epoch, lv_tick)` on each payload and **advances the clock locally** in `ui_tick_anim()`, so it ticks every minute between the 60s polls instead of only updating on each payload. The title label is only rewritten when the minute changes.

## Config

A single option, in a small `key = value` file the daemon re-reads every poll (no restart needed):

- macOS / Linux: `~/.config/claude-usage-monitor/config`
- Windows: `%LOCALAPPDATA%\Clawdmeter\config`

```
clock = off | auto | 12 | 24
```

- `off` (default) → no clock, the screen keeps showing "Usage"
- `auto` → show the clock, auto-detect 12h/24h from the host (macOS `defaults`, Linux `locale`, Windows registry)
- `12` / `24` → force the format

See `daemon/config.example`.

## Backward compatibility

Fully additive. Old daemons (no `t`) → firmware shows "Usage". Old firmware → ignores `tf`. No new dependencies, no `#ifdef BOARD_*` in shared code.

## Testing

Verified end-to-end on a real Waveshare ESP32-S3-Touch-AMOLED-2.16 for all three states (`12` → "6:49 PM", `24` → "18:51", `off` → "Usage" reverts live within one poll). Daemon config parsing unit-tested for bash + Python (off/auto/12/24, comments, CRLF, missing file). Both firmware envs (`waveshare_amoled_216` and `waveshare_amoled_18`) build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)