### PR TITLE
Add Waveshare ESP32-S3-Touch-LCD-1.83 board support

### DIFF
--- a/docs/porting/adding-a-board.md
+++ b/docs/porting/adding-a-board.md
@@ -13,9 +13,12 @@ At minimum:
 - An **ESP32-S3** (other ESP32 family members may work; this is what the
   upstream firmware is tested on). OPI PSRAM is **required** — partial
   flush buffers and the splash canvas are allocated from PSRAM.
-- A QSPI **AMOLED panel** with a driver supported by
-  [GFX Library for Arduino](https://github.com/moononournation/Arduino_GFX)
-  (CO5300, SH8601, NV3041A, etc.). Other interfaces aren't supported yet.
+- A display panel with a driver supported by
+  [GFX Library for Arduino](https://github.com/moononournation/Arduino_GFX):
+  a **QSPI AMOLED** (CO5300, SH8601, NV3041A, …) or a **4-wire SPI TFT**
+  (e.g. ST7789, as on the LCD-1.83 port). The board's `display.cpp` builds
+  whatever `Arduino_DataBus` + driver it needs; shared code only calls the
+  `display_hal_*` functions.
 - A **touch controller** over I2C. The HAL just needs init + read; you
   can use any driver you can compile.
 - A **primary button** (typically the BOOT/GPIO 0 push button).
@@ -47,7 +50,7 @@ Optional:
 
    | File              | Reference port (start here)                                    |
    |-------------------|----------------------------------------------------------------|
-   | `display.cpp`     | `boards/waveshare_amoled_216/display.cpp` (with CPU rotation) or `_18/display.cpp` (no rotation) |
+   | `display.cpp`     | `boards/waveshare_amoled_216/display.cpp` (QSPI + CPU rotation), `_18/display.cpp` (QSPI, no rotation), or `waveshare_lcd_183/display.cpp` (4-wire SPI ST7789 + PWM backlight) |
    | `touch.cpp`       | `_216/touch.cpp` (library-based) or `_18/touch.cpp` (vendored I2C reader) |
    | `input.cpp`       | `_216/input.cpp` (two buttons) or `_18/input.cpp` (one button) |
    | `power.cpp`       | `_216/power.cpp` (PMU IRQ) or `_18/power.cpp` (PMU + IO expander button) |

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -397,3 +397,55 @@ lib_deps =
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+[env:waveshare_lcd_183]
+; Waveshare ESP32-S3-Touch-LCD-1.83 — 240x284 IPS LCD, ST7789P over 4-wire SPI
+; (NOT a QSPI AMOLED). CST816 touch + AXP2101 + QMI8658 on the same I2C bus as
+; the AMOLED-1.8; no XCA9554 IO expander. 16 MB flash.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_build.partitions = default_16MB.csv
+upload_speed = 921600
+monitor_speed = 115200
+
+build_src_filter =
+    +<*>
+    -<boards/>
+    +<boards/waveshare_lcd_183/>
+
+build_flags =
+    -DBOARD_LCD_183
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    -DXPOWERS_CHIP_AXP2101
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    moononournation/GFX Library for Arduino@^1.6.4
+    lewisxhe/SensorLib@^0.2.6
+    lewisxhe/XPowersLib@^0.2.7
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1

--- a/firmware/src/boards/waveshare_lcd_183/board.h
+++ b/firmware/src/boards/waveshare_lcd_183/board.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// Waveshare ESP32-S3-Touch-LCD-1.83 — 240x284 IPS LCD (ST7789P over 4-wire SPI).
+// Shares the AMOLED-1.8's I2C peripheral set (AXP2101 PMU, QMI8658 IMU, CST816
+// touch) on the same SDA/SCL pins, but the display is an SPI TFT — not a QSPI
+// AMOLED — and there is no XCA9554 IO expander: the LCD/touch reset lines are
+// plain GPIOs and the backlight is a GPIO-driven LED string. Pins taken from
+// Waveshare's official demo (waveshareteam/ESP32-S3-Touch-LCD-1.83, pin_config.h).
+
+#define BOARD_NAME           "Waveshare LCD 1.83"
+
+// ---- Display geometry (portrait, fixed 0°) ----
+#define LCD_WIDTH            240
+#define LCD_HEIGHT           284
+// ST7789 GRAM is 240x320. Waveshare's demo uses row offset 20, but on this
+// panel the visible glass maps to GRAM rows [0..283] — a row offset of 20
+// leaves the top ~20 rows unwritten (power-on garbage) and clips the bottom.
+// 0 aligns the 284-row window to the top of GRAM. (col offset stays 0.)
+#define LCD_ROW_OFFSET       0
+
+// ---- Display pins (ST7789P, 4-wire SPI) ----
+#define LCD_DC               4
+#define LCD_CS               5
+#define LCD_SCK              6
+#define LCD_MOSI             7
+#define LCD_RST              38    // real GPIO (no IO expander on this board)
+#define LCD_BL               40    // backlight enable, active HIGH (PWM-dimmed)
+
+// ---- I2C bus (touch + PMU + IMU share one bus) ----
+#define IIC_SDA              15
+#define IIC_SCL              14
+
+// ---- Touch (CST816D, FocalTech-style data layout @ regs 0x02..0x06) ----
+#define TP_INT               13
+#define TP_RST               39    // real GPIO; released in board_init()
+#define CST816_ADDR          0x15
+
+// ---- PMU ----
+#define AXP2101_ADDR         0x34
+
+// ---- Buttons ----
+#define BTN_BACK_GPIO        0     // BOOT — primary, Space (PTT)
+// PWR comes via the AXP2101 PKEY IRQ (see power.cpp); no secondary GPIO button.
+
+// ---- Capability flags ----
+#define BOARD_HAS_SECONDARY_BUTTON 0
+#define BOARD_HAS_ROTATION         0
+#define BOARD_HAS_IMU              1
+#define BOARD_HAS_BATTERY          1
+#define BOARD_HAS_IO_EXPANDER      0

--- a/firmware/src/boards/waveshare_lcd_183/board_init.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/board_init.cpp
@@ -1,0 +1,18 @@
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// No IO expander on this board: the LCD reset is driven by the GFX driver
+// (LCD_RST is handed to Arduino_ST7789, which pulses it in begin()), and the
+// touch reset is a plain GPIO we release here before anything probes I2C.
+
+extern "C" void board_init(void) {
+    Wire.begin(IIC_SDA, IIC_SCL);
+
+    // Bring the CST816 touch controller out of reset (active LOW).
+    pinMode(TP_RST, OUTPUT);
+    digitalWrite(TP_RST, LOW);
+    delay(10);
+    digitalWrite(TP_RST, HIGH);
+    delay(50);
+}

--- a/firmware/src/boards/waveshare_lcd_183/caps.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/caps.cpp
@@ -1,0 +1,14 @@
+#include "../../hal/board_caps.h"
+#include "board.h"
+
+static const BoardCaps caps = {
+    .name = BOARD_NAME,
+    .width = LCD_WIDTH,
+    .height = LCD_HEIGHT,
+    .button_count = 1,
+    .has_rotation = false,
+    .has_battery = true,
+    .has_imu = true,
+};
+
+const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_lcd_183/display.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/display.cpp
@@ -1,0 +1,55 @@
+#include "../../hal/display_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+// Waveshare LCD-1.83: ST7789P IPS panel over 4-wire SPI, fixed 0° (no rotation,
+// no CPU pixel remap). Unlike the QSPI AMOLED ports, the panel is backlit by a
+// GPIO LED string, so display_hal_set_brightness() drives an LEDC PWM channel
+// on LCD_BL instead of issuing an AMOLED brightness command. Geometry/offsets
+// match Waveshare's demo: Arduino_ST7789(bus, RST, 0, IPS, 240, 284, 0, 20).
+
+#define BL_PWM_FREQ   5000
+#define BL_PWM_BITS   8
+
+static Arduino_DataBus* bus = nullptr;
+static Arduino_GFX*     gfx = nullptr;
+
+void display_hal_init(void) {
+    bus = new Arduino_ESP32SPI(LCD_DC, LCD_CS, LCD_SCK, LCD_MOSI);
+    // (bus, rst, rotation, IPS, w, h, col_off1, row_off1, col_off2, row_off2)
+    gfx = new Arduino_ST7789(
+        bus, LCD_RST, 0 /*rotation*/, true /*IPS*/,
+        LCD_WIDTH, LCD_HEIGHT, 0, LCD_ROW_OFFSET, 0, 0);
+}
+
+void display_hal_begin(void) {
+    gfx->begin();
+    gfx->fillScreen(0x0000);
+    // Enable the backlight only after the panel is initialized + cleared, so
+    // there's no white flash on boot. LEDC gives us real brightness control.
+    ledcAttach(LCD_BL, BL_PWM_FREQ, BL_PWM_BITS);
+    ledcWrite(LCD_BL, 200);
+}
+
+void display_hal_set_brightness(uint8_t level) {
+    ledcWrite(LCD_BL, level);
+}
+
+void display_hal_fill_screen(uint16_t color) {
+    if (gfx) gfx->fillScreen(color);
+}
+
+void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
+                             const uint16_t* pixels) {
+    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+}
+
+void display_hal_tick(void) {
+    // No rotation handling on this board.
+}
+
+void display_hal_round_area(int32_t* x1, int32_t* y1, int32_t* x2, int32_t* y2) {
+    // ST7789 has no even-alignment constraint on flush regions.
+    (void)x1; (void)y1; (void)x2; (void)y2;
+}

--- a/firmware/src/boards/waveshare_lcd_183/imu.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/imu.cpp
@@ -1,0 +1,25 @@
+#include "../../hal/imu_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <SensorQMI8658.hpp>
+
+// QMI8658 is populated on this board, but the panel mounts in a fixed
+// orientation in the enclosure. We initialize the device so the shared I2C bus
+// stays healthy, but always report rotation 0 (rotation disabled).
+
+static SensorQMI8658 imu;
+
+void imu_hal_init(void) {
+    if (!imu.begin(Wire, QMI8658_L_SLAVE_ADDRESS, IIC_SDA, IIC_SCL)) {
+        Serial.println("QMI8658 init failed");
+        return;
+    }
+    Serial.println("QMI8658 init OK (rotation disabled on this board)");
+}
+
+void imu_hal_tick(void) {
+    // No-op — rotation is disabled.
+}
+
+uint8_t imu_hal_rotation_quadrant(void) { return 0; }

--- a/firmware/src/boards/waveshare_lcd_183/input.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/input.cpp
@@ -1,0 +1,20 @@
+#include "../../hal/input_hal.h"
+#include "board.h"
+#include <Arduino.h>
+
+// Only the BOOT button (GPIO0) is a screen-independent input. PWR comes through
+// power_hal (AXP2101 PKEY). No secondary button on this board.
+
+void input_hal_init(void) {
+    pinMode(BTN_BACK_GPIO, INPUT_PULLUP);
+}
+
+bool input_hal_is_held(InputButton btn) {
+    switch (btn) {
+    case INPUT_BTN_PRIMARY:
+        return digitalRead(BTN_BACK_GPIO) == LOW;
+    case INPUT_BTN_SECONDARY:
+        return false;   // not present on this board
+    }
+    return false;
+}

--- a/firmware/src/boards/waveshare_lcd_183/power.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/power.cpp
@@ -1,0 +1,91 @@
+#include "../../hal/power_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <XPowersLib.h>
+
+// No IO expander on this board, so PWR comes from the AXP2101 PKEY IRQs (same
+// scheme as the AMOLED-2.16):
+//   SHORT    — quick tap (cycle screens / splash animations)
+//   LONG     — ~1.5s mark, starts the hold-to-pair countdown
+//   POSITIVE — release edge, completes/cancels the gesture
+
+#define BATTERY_POLL_MS  2000
+#define CHARGING_POLL_MS 500
+#define PWR_POLL_MS      50
+
+static XPowersPMU pmu;
+
+static int      cached_pct        = -1;
+static bool     cached_charging   = false;
+static bool     cached_vbus       = false;
+static bool     pwr_pressed_flag  = false;
+static bool     pwr_long_flag     = false;
+static bool     pwr_released_flag = false;
+static uint32_t last_battery_ms   = 0;
+static uint32_t last_charging_ms  = 0;
+static uint32_t last_pwr_ms       = 0;
+
+void power_hal_init(void) {
+    if (!pmu.begin(Wire, AXP2101_ADDR, IIC_SDA, IIC_SCL)) {
+        Serial.println("AXP2101 init failed");
+        return;
+    }
+    Serial.println("AXP2101 init OK");
+
+    pmu.enableBattDetection();
+    pmu.enableBattVoltageMeasure();
+
+    pmu.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
+    pmu.clearIrqStatus();
+    pmu.enableIRQ(XPOWERS_AXP2101_PKEY_SHORT_IRQ
+                | XPOWERS_AXP2101_PKEY_LONG_IRQ
+                | XPOWERS_AXP2101_PKEY_POSITIVE_IRQ);
+
+    pmu.setPowerKeyPressOffTime(XPOWERS_POWEROFF_8S);
+
+    cached_charging = pmu.isCharging();
+    cached_vbus     = pmu.isVbusIn();
+    cached_pct = pmu.getBatteryPercent();
+}
+
+void power_hal_tick(void) {
+    uint32_t now = millis();
+
+    if (now - last_charging_ms >= CHARGING_POLL_MS) {
+        last_charging_ms = now;
+        cached_charging = pmu.isCharging();
+        cached_vbus     = pmu.isVbusIn();
+    }
+    if (now - last_battery_ms >= BATTERY_POLL_MS) {
+        last_battery_ms = now;
+        cached_pct = pmu.getBatteryPercent();
+    }
+    if (now - last_pwr_ms >= PWR_POLL_MS) {
+        last_pwr_ms = now;
+        pmu.getIrqStatus();
+        if (pmu.isPekeyShortPressIrq())    pwr_pressed_flag  = true;
+        if (pmu.isPekeyLongPressIrq())     pwr_long_flag     = true;
+        if (pmu.isPekeyPositiveIrq())      pwr_released_flag = true;
+        pmu.clearIrqStatus();
+    }
+}
+
+int  power_hal_battery_pct(void) { return cached_pct; }
+bool power_hal_is_charging(void) { return cached_charging; }
+bool power_hal_is_vbus_in(void)  { return cached_vbus; }
+
+bool power_hal_pwr_pressed(void) {
+    if (pwr_pressed_flag) { pwr_pressed_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_long_pressed(void) {
+    if (pwr_long_flag) { pwr_long_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_released(void) {
+    if (pwr_released_flag) { pwr_released_flag = false; return true; }
+    return false;
+}

--- a/firmware/src/boards/waveshare_lcd_183/sound.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/sound.cpp
@@ -1,0 +1,9 @@
+#include "../../hal/sound_hal.h"
+
+// LCD-1.83: no sound path wired up in this port, so output is a no-op. See
+// boards/waveshare_lcd_154/sound.cpp for an ES8311 speaker reference if the
+// onboard audio ever gets hooked up.
+
+void sound_hal_init(void) {}
+void sound_hal_tick(void) {}
+void sound_hal_play_reset(void) {}

--- a/firmware/src/boards/waveshare_lcd_183/touch.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/touch.cpp
@@ -1,0 +1,61 @@
+#include "../../hal/touch_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// CST816D capacitive touch over I2C. Same FocalTech-style data layout the
+// AMOLED ports' controllers use, so the inline reader is identical — only one
+// fixed address (0x15) here, since this board has a single panel revision.
+//   reg 0x02:        low nibble = active finger count
+//   reg 0x03 / 0x04: X high (low nibble) + X low
+//   reg 0x05 / 0x06: Y high (low nibble) + Y low
+
+static volatile bool     touch_data_ready = false;
+static volatile bool     touch_pressed = false;
+static volatile uint16_t touch_x = 0;
+static volatile uint16_t touch_y = 0;
+
+static void IRAM_ATTR touch_isr(void) {
+    touch_data_ready = true;
+}
+
+static void touch_read_into_shared_state(void) {
+    Wire.beginTransmission(CST816_ADDR);
+    Wire.write(0x02);
+    if (Wire.endTransmission(false) != 0) { touch_pressed = false; return; }
+    if (Wire.requestFrom(CST816_ADDR, (uint8_t)5) != 5) { touch_pressed = false; return; }
+    uint8_t fingers = Wire.read() & 0x0F;
+    uint8_t xH = Wire.read();
+    uint8_t xL = Wire.read();
+    uint8_t yH = Wire.read();
+    uint8_t yL = Wire.read();
+    if (fingers == 0 || fingers > 5) { touch_pressed = false; return; }
+    touch_x = ((uint16_t)(xH & 0x0F) << 8) | xL;
+    touch_y = ((uint16_t)(yH & 0x0F) << 8) | yL;
+    touch_pressed = true;
+}
+
+void touch_hal_init(void) {
+    // Verify the controller answers (CST816 chip-id is reg 0xA7).
+    Wire.beginTransmission(CST816_ADDR);
+    Wire.write(0xA7);
+    if (Wire.endTransmission(false) == 0 && Wire.requestFrom(CST816_ADDR, (uint8_t)1) == 1) {
+        Serial.printf("Touch CST816 ID=0x%02X (addr 0x%02X)\n", Wire.read(), CST816_ADDR);
+    } else {
+        Serial.printf("Touch ID read failed (addr 0x%02X)\n", CST816_ADDR);
+    }
+
+    pinMode(TP_INT, INPUT_PULLUP);
+    attachInterrupt(TP_INT, touch_isr, FALLING);
+    Serial.println("Touch attached on INT pin");
+}
+
+void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
+    if (touch_data_ready) {
+        touch_data_ready = false;
+        touch_read_into_shared_state();
+    }
+    *x = touch_x;
+    *y = touch_y;
+    *pressed = touch_pressed;
+}

--- a/tools/shot_png.py
+++ b/tools/shot_png.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Capture the LVGL framebuffer via the firmware's `screenshot` serial command
+# and write a PNG using only the Python standard library (no ffmpeg / PIL).
+# Usage: shot_png.py <port> <out.png>
+import sys, struct, zlib, serial
+
+port_path, out_path = sys.argv[1], sys.argv[2]
+# Open without asserting DTR/RTS so we don't reset the board (RTS is wired to
+# EN on this board) — keeps live BLE data on screen for the capture.
+port = serial.Serial()
+port.port = port_path
+port.baudrate = 115200
+port.timeout = 12
+port.dtr = False
+port.rts = False
+port.open()
+port.reset_input_buffer()
+port.write(b"screenshot\n")
+port.flush()
+
+w = h = raw_size = 0
+while True:
+    line = port.readline().decode("utf-8", "replace").strip()
+    if line.startswith("SCREENSHOT_START"):
+        _, w, h, raw_size = line.split()
+        w, h, raw_size = int(w), int(h), int(raw_size)
+        break
+    if line == "SCREENSHOT_ERR":
+        print("device reported SCREENSHOT_ERR", file=sys.stderr); sys.exit(1)
+
+data = b""
+while len(data) < raw_size:
+    chunk = port.read(min(4096, raw_size - len(data)))
+    if not chunk:
+        print(f"timeout: {len(data)}/{raw_size} bytes", file=sys.stderr); sys.exit(1)
+    data += chunk
+port.close()
+
+# RGB565 little-endian -> RGB888 scanlines (each row prefixed with filter byte 0)
+rows = bytearray()
+for y in range(h):
+    rows.append(0)
+    base = y * w * 2
+    for x in range(w):
+        px = data[base + x*2] | (data[base + x*2 + 1] << 8)
+        r = (px >> 11) & 0x1F; g = (px >> 5) & 0x3F; b = px & 0x1F
+        rows += bytes(((r << 3) | (r >> 2), (g << 2) | (g >> 4), (b << 3) | (b >> 2)))
+
+def chunk(tag, body):
+    c = tag + body
+    return struct.pack(">I", len(body)) + c + struct.pack(">I", zlib.crc32(c) & 0xffffffff)
+
+png = b"\x89PNG\r\n\x1a\n"
+png += chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+png += chunk(b"IDAT", zlib.compress(bytes(rows), 9))
+png += chunk(b"IEND", b"")
+with open(out_path, "wb") as f:
+    f.write(png)
+print(f"wrote {out_path} ({w}x{h})")


### PR DESCRIPTION
## What

Adds a board port for the **Waveshare ESP32-S3-Touch-LCD-1.83** (240×284).

This is the first **SPI TFT** port — the panel is an **ST7789P** driven over 4-wire SPI rather than a QSPI AMOLED, and the board has **no XCA9554 IO expander** (LCD/touch resets are plain GPIOs, backlight is a PWM-dimmed LED string). Touch (CST816D @ 0x15), PMU (AXP2101) and IMU (QMI8658) match the AMOLED-1.8, all on the same I2C bus.

## Changes

- `firmware/src/boards/waveshare_lcd_183/` — new per-board folder (display, touch, power, imu, caps, board_init). Display uses `Arduino_ESP32SPI` + `Arduino_ST7789`; brightness maps onto an LEDC PWM backlight. Pins taken from Waveshare's official demo ([`waveshareteam/ESP32-S3-Touch-LCD-1.83`](https://github.com/waveshareteam/ESP32-S3-Touch-LCD-1.83)).
- `firmware/platformio.ini` — `[env:waveshare_lcd_183]`.
- `firmware/src/ui.cpp` — adds a third `compute_layout()` breakpoint for small 240×284 screens (smaller fonts + shrunk logo) and makes the usage-screen fonts responsive (the Bluetooth screen already worked this way). **The two existing boards (480×480, 368×448) render identically** — they keep their current font choices.
- `tools/shot_png.py` — small ffmpeg-free framebuffer→PNG capture helper (complements `screenshot.sh`).
- `docs/porting/adding-a-board.md` — note that 4-wire SPI TFT panels are supported, with this board as the reference.

## Testing

Built and flashed on real hardware (`pio run -e waveshare_lcd_183`). Boot is clean (display, CST816 touch, AXP2101, QMI8658 all init), the splash and usage screens render correctly at 240×284, the daemon pairs over BLE and live usage shows. Note: row offset is 0 on this panel (Waveshare's demo uses 20, which left the top ~20 rows unwritten here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
