### PR TITLE
Add Waveshare ESP32-S3-Touch-AMOLED-1.43 (466×466 round) board port

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -177,3 +177,58 @@ lib_deps =
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+; Waveshare ESP32-S3-Touch-AMOLED-1.43 — 466x466 round, 16MB flash / 8MB OPI PSRAM
+[env:waveshare_amoled_143]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+; 16 MB flash — same layout as the 1.8 env so the ~1.4 MB app + assets fit.
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_build.partitions = default_16MB.csv
+upload_speed = 921600
+monitor_speed = 115200
+
+; Shared code + this board's folder only.
+build_src_filter =
+    +<*>
+    -<boards/>
+    +<boards/waveshare_amoled_143/>
+
+build_flags =
+    -DBOARD_AMOLED_143
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    ; NimBLE — peripheral, 2 connections (HID link + daemon data link).
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    ; LVGL
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    ; 1.6.4+ ships both Arduino_CO5300 and Arduino_SH8601 in mainline.
+    moononournation/GFX Library for Arduino@^1.6.4
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1
+    ; NOTE: SensorLib (QMI8658) and XPowersLib (AXP2101) are intentionally
+    ; omitted — this board's imu.cpp/power.cpp don't use them. If the link
+    ; step complains about a stray XPowers*/QMI* symbol pulled in from shared
+    ; code, add lewisxhe/SensorLib and lewisxhe/XPowersLib back here.

--- a/firmware/src/boards/waveshare_amoled_143/board.h
+++ b/firmware/src/boards/waveshare_amoled_143/board.h
@@ -1,0 +1,57 @@
+#pragma once
+
+// Waveshare ESP32-S3-Touch-AMOLED-1.43 — 466x466 round AMOLED.
+// CO5300 (or SH8601 on early units) + CST820/FT3168 touch + QMI8658 IMU + RTC.
+// 16 MB flash, 8 MB octal PSRAM. No IO expander, no AXP2101 PMU, no PWR button.
+//
+// Pins below verified against a working PlatformIO port of this exact board
+// (lcd_config.h: CS=9 PCLK=10 D0..D3=11..14 RST=21, touch I2C SDA=47 SCL=48).
+// The display RST is a direct GPIO here (the 1.8 routed it through an expander),
+// so the GFX driver owns reset and board_init() needs no expander step.
+//
+// Two panel revisions exist, same as the 1.8 line — check the label on the back:
+//   - early:   SH8601 + FT3168 (touch @ 0x38)
+//   - current: CO5300 + CST820 (touch @ 0x15)   <-- what Waveshare ships now
+// board_init.cpp auto-detects by which touch address answers; display.cpp
+// picks the matching GFX driver. If yours is unambiguous you can hard-wire it.
+
+#define BOARD_NAME           "Waveshare AMOLED 1.43"
+
+// ---- Display geometry (square framebuffer; panel is a 466 round cut) ----
+#define LCD_WIDTH            466
+#define LCD_HEIGHT           466
+
+// ---- QSPI display pins (CO5300 / SH8601) ----
+#define LCD_CS               9
+#define LCD_SCLK             10
+#define LCD_SDIO0            11
+#define LCD_SDIO1            12
+#define LCD_SDIO2            13
+#define LCD_SDIO3            14
+#define LCD_RESET            21       // direct GPIO — driver drives reset itself
+
+// ---- I2C bus (touch only — IMU/RTC live on a separate bus we don't use) ----
+#define IIC_SDA              47
+#define IIC_SCL              48
+
+// ---- Touch ----
+// FocalTech-style data layout at regs 0x02..0x06 on both controllers; only the
+// address differs. CST820 (0x15) is Hynitron CST8xx — same reader as CST816.
+#define FT3168_ADDR          0x38     // early (SH8601) revision
+#define CST816_ADDR          0x15     // current (CO5300) revision — CST820 shares this
+// No touch INT pin wired in this port — we poll in touch_hal_read() (a 5-byte
+// I2C burst is ~150us @ 400kHz, well inside LVGL's per-refresh touch budget).
+// If you bring the INT line out to a GPIO, define TP_INT and switch to the
+// interrupt path (see commented block in touch.cpp).
+
+// ---- Buttons ----
+#define BTN_BACK_GPIO        0        // BOOT — primary, Space (PTT)
+// No dedicated PWR button on this board (only RST, which hard-resets the MCU).
+// power.cpp synthesizes the hold-3s-to-pair gesture from a long-press of BOOT.
+
+// ---- Capability flags ----
+#define BOARD_HAS_SECONDARY_BUTTON 0  // no second HID button (no Shift+Tab)
+#define BOARD_HAS_ROTATION         0  // round, fixed orientation
+#define BOARD_HAS_IMU              0  // QMI8658 present but unused (no rotation)
+#define BOARD_HAS_BATTERY          0  // no PMU/fuel gauge — hides battery indicator
+#define BOARD_HAS_IO_EXPANDER      0  // reset lines are direct GPIO

--- a/firmware/src/boards/waveshare_amoled_143/board_init.cpp
+++ b/firmware/src/boards/waveshare_amoled_143/board_init.cpp
@@ -1,0 +1,34 @@
+#include "board.h"
+#include "board_rev.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// No IO expander on this board — the display/touch reset lines are direct
+// GPIO, so all we do at boot is start the I2C bus and sniff the panel
+// revision from the touch controller address.
+
+static BoardRev g_rev = REV_CO5300_CST816;   // default to current production rev
+
+BoardRev board_rev(void) { return g_rev; }
+
+static bool i2c_present(uint8_t addr) {
+    Wire.beginTransmission(addr);
+    return Wire.endTransmission() == 0;
+}
+
+extern "C" void board_init(void) {
+    Wire.begin(IIC_SDA, IIC_SCL);
+    delay(10);
+
+    // CST820 (current) answers at 0x15; FT3168 (early) at 0x38.
+    if (i2c_present(CST816_ADDR)) {
+        g_rev = REV_CO5300_CST816;
+        Serial.println("Board revision: CO5300 + CST820 (0x15)");
+    } else if (i2c_present(FT3168_ADDR)) {
+        g_rev = REV_SH8601_FT3168;
+        Serial.println("Board revision: SH8601 + FT3168 (0x38)");
+    } else {
+        Serial.println("WARNING: no touch controller found on I2C "
+                       "(47/48) — defaulting to CO5300 + CST820");
+    }
+}

--- a/firmware/src/boards/waveshare_amoled_143/board_rev.h
+++ b/firmware/src/boards/waveshare_amoled_143/board_rev.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// Two shipping panel revisions, distinguished by which touch controller
+// answers on I2C. board_init() sets this; display.cpp and touch.cpp read it.
+enum BoardRev {
+    REV_SH8601_FT3168 = 0,   // early units
+    REV_CO5300_CST816 = 1,   // current units (CO5300 + CST820 @ 0x15)
+};
+
+BoardRev board_rev(void);

--- a/firmware/src/boards/waveshare_amoled_143/caps.cpp
+++ b/firmware/src/boards/waveshare_amoled_143/caps.cpp
@@ -1,0 +1,14 @@
+#include "../../hal/board_caps.h"
+#include "board.h"
+
+static const BoardCaps caps = {
+    .name = BOARD_NAME,
+    .width = LCD_WIDTH,
+    .height = LCD_HEIGHT,
+    .button_count = (uint8_t)(1 + BOARD_HAS_SECONDARY_BUTTON),
+    .has_rotation = (bool)BOARD_HAS_ROTATION,
+    .has_battery  = (bool)BOARD_HAS_BATTERY,
+    .has_imu      = (bool)BOARD_HAS_IMU,
+};
+
+const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_amoled_143/display.cpp
+++ b/firmware/src/boards/waveshare_amoled_143/display.cpp
@@ -1,0 +1,85 @@
+#include "../../hal/display_hal.h"
+#include "board.h"
+#include "board_rev.h"
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+// 466x466 round panel. Reset is a direct GPIO (LCD_RESET), so the GFX driver
+// drives it; unlike the 1.8 port we do NOT pass GFX_NOT_DEFINED.
+//
+// Display driver is INDEPENDENT of the touch controller on the 1.43: the panel
+// is a CO5300 (verified on hardware + Waveshare spec) even on units fitted with
+// an FT3168 (0x38) touch. The seeded code inferred the display from the touch
+// address, which is wrong here — sending SH8601 init to a CO5300 leaves the
+// panel black. The QSPI bus is write-only so we can't read display ID 0xDA to
+// auto-detect; we drive CO5300 unconditionally. Flip DISPLAY_IS_SH8601 to 1
+// only if you have a genuine early SH8601 panel.
+#define DISPLAY_IS_SH8601  0
+//
+// ORIENTATION: the panel mounts 180° rotated, so the image comes up
+// upside-down. We deliberately do NOT correct this in software — the device is
+// physically rotated 180° in use, which fixes both the image and the touch
+// mapping at once (touch.cpp returns raw coords to match). If you mount it the
+// other way and want a software fix, the CO5300 driver's setRotation can't do
+// it (its MADCTL flip constants 0x02/0x05 are wrong — CLAUDE.md gotcha #1); copy
+// the 2.16 port's CPU strip-flip (rotate_strip case 2) AND mirror both touch
+// axes in touch.cpp to keep them consistent.
+//
+// The CO5300 controller's visible window may need a column offset to center
+// the 466-wide image in GRAM. 0 is correct on this module (no L/R shift seen);
+// if the image looks shifted left/right, nudge this (the 1.8 368-wide panel
+// used 16).
+#define CO5300_COL_OFFSET  0
+
+static Arduino_DataBus* bus = nullptr;
+static Arduino_OLED*    gfx = nullptr;
+
+void display_hal_init(void) {
+    bus = new Arduino_ESP32QSPI(
+        LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
+
+#if DISPLAY_IS_SH8601
+    Serial.println("Display: SH8601 driver");
+    // SH8601: (bus, rst, rotation, w, h) — no `ips` arg in this driver.
+    // Passing one shifts width into `false`(=0) and blanks the panel.
+    gfx = new Arduino_SH8601(
+        bus, LCD_RESET, 0, LCD_WIDTH, LCD_HEIGHT);
+#else
+    Serial.println("Display: CO5300 driver");
+    // CO5300: (bus, rst, rotation, w, h, col_off1, row_off1, col_off2, row_off2)
+    gfx = new Arduino_CO5300(
+        bus, LCD_RESET, 0,
+        LCD_WIDTH, LCD_HEIGHT, CO5300_COL_OFFSET, 0, 0, 0);
+#endif
+}
+
+void display_hal_begin(void) {
+    gfx->begin();
+    gfx->fillScreen(0x0000);
+    gfx->setBrightness(200);
+}
+
+void display_hal_set_brightness(uint8_t level) {
+    if (gfx) gfx->setBrightness(level);
+}
+
+void display_hal_fill_screen(uint16_t color) {
+    if (gfx) gfx->fillScreen(color);
+}
+
+void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
+                             const uint16_t* pixels) {
+    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+}
+
+void display_hal_tick(void) {
+    // No rotation handling needed on this board.
+}
+
+void display_hal_round_area(int32_t* x1, int32_t* y1, int32_t* x2, int32_t* y2) {
+    // CO5300 wants even-aligned flush regions.
+    *x1 = *x1 & ~1;
+    *y1 = *y1 & ~1;
+    *x2 = *x2 | 1;
+    *y2 = *y2 | 1;
+}

--- a/firmware/src/boards/waveshare_amoled_143/imu.cpp
+++ b/firmware/src/boards/waveshare_amoled_143/imu.cpp
@@ -1,0 +1,9 @@
+#include "../../hal/imu_hal.h"
+
+// No IMU on this template. If your board ships an accelerometer (e.g.
+// QMI8658 + want auto-rotation), copy boards/waveshare_amoled_216/imu.cpp
+// here and set BOARD_HAS_ROTATION=1 in board.h.
+
+void    imu_hal_init(void) {}
+void    imu_hal_tick(void) {}
+uint8_t imu_hal_rotation_quadrant(void) { return 0; }

--- a/firmware/src/boards/waveshare_amoled_143/input.cpp
+++ b/firmware/src/boards/waveshare_amoled_143/input.cpp
@@ -1,0 +1,21 @@
+#include "../../hal/input_hal.h"
+#include "board.h"
+#include <Arduino.h>
+
+// Only the BOOT button is a usable physical input on this board. There is no
+// secondary button (no HID Shift+Tab) and no PWR button — the pairing gesture
+// is synthesized from a BOOT long-press in power.cpp.
+
+void input_hal_init(void) {
+    pinMode(BTN_BACK_GPIO, INPUT_PULLUP);
+}
+
+bool input_hal_is_held(InputButton btn) {
+    switch (btn) {
+    case INPUT_BTN_PRIMARY:
+        return digitalRead(BTN_BACK_GPIO) == LOW;
+    case INPUT_BTN_SECONDARY:
+        return false;   // not present on this board
+    }
+    return false;
+}

--- a/firmware/src/boards/waveshare_amoled_143/power.cpp
+++ b/firmware/src/boards/waveshare_amoled_143/power.cpp
@@ -1,0 +1,74 @@
+#include "../../hal/power_hal.h"
+#include "board.h"
+#include <Arduino.h>
+
+// No PMU, no battery gauge, no dedicated PWR button on this board.
+// Battery/charging stubs return "unavailable" and the UI hides the indicator
+// (BOARD_HAS_BATTERY=0).
+//
+// The one piece we can't just stub: the documented "hold PWR 3s, release ->
+// pairing mode" gesture. With no PWR button, we synthesize the same three
+// edge signals main.cpp expects from a long-press of the BOOT button, using
+// the identical software hold-timer the 1.8 port runs off its EXIO4 line.
+//
+// Trade-off to be aware of: BOOT is also the primary PTT button (Space) read
+// by input_hal. A short tap = PTT as normal; a deliberate >=3s hold will both
+// hold Space for the duration AND trigger pairing on release. That only fires
+// on an intentional 3s hold, so it's an acceptable wart. If you'd rather keep
+// BOOT purely for PTT, drive the gesture from a touch long-press instead — but
+// that needs a small edit to shared code (main.cpp), which a clean port avoids.
+
+#define PWR_POLL_MS   50
+#define PWR_LONG_MS   3000     // matches the documented 3-second hold
+
+static bool     pwr_pressed_flag  = false;
+static bool     pwr_long_flag     = false;
+static bool     pwr_released_flag = false;
+static bool     last_state        = false;
+static uint32_t press_started_ms  = 0;
+static bool     long_fired        = false;
+static uint32_t last_poll_ms      = 0;
+
+void power_hal_init(void) {
+    // BOOT already set INPUT_PULLUP by input_hal_init(); harmless to repeat.
+    pinMode(BTN_BACK_GPIO, INPUT_PULLUP);
+}
+
+void power_hal_tick(void) {
+    uint32_t now = millis();
+    if (now - last_poll_ms < PWR_POLL_MS) return;
+    last_poll_ms = now;
+
+    bool pressed_now = (digitalRead(BTN_BACK_GPIO) == LOW);   // active-low
+
+    if (pressed_now && !last_state) {                 // rising edge — hold begins
+        press_started_ms = now;
+        long_fired = false;
+    } else if (pressed_now && last_state) {           // held
+        if (!long_fired && (now - press_started_ms >= PWR_LONG_MS)) {
+            pwr_long_flag = true;
+            long_fired = true;
+        }
+    } else if (!pressed_now && last_state) {          // falling edge — release
+        pwr_released_flag = true;
+        if (!long_fired) pwr_pressed_flag = true;     // treat as a short press
+    }
+    last_state = pressed_now;
+}
+
+int  power_hal_battery_pct(void) { return -1; }
+bool power_hal_is_charging(void) { return false; }
+bool power_hal_is_vbus_in(void)  { return false; }
+
+bool power_hal_pwr_pressed(void) {
+    if (pwr_pressed_flag) { pwr_pressed_flag = false; return true; }
+    return false;
+}
+bool power_hal_pwr_long_pressed(void) {
+    if (pwr_long_flag) { pwr_long_flag = false; return true; }
+    return false;
+}
+bool power_hal_pwr_released(void) {
+    if (pwr_released_flag) { pwr_released_flag = false; return true; }
+    return false;
+}

--- a/firmware/src/boards/waveshare_amoled_143/touch.cpp
+++ b/firmware/src/boards/waveshare_amoled_143/touch.cpp
@@ -1,0 +1,79 @@
+#include "../../hal/touch_hal.h"
+#include "board.h"
+#include "board_rev.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// Minimal capacitive-touch reader. Both shipping revisions expose the
+// FocalTech-style data layout, so one read path serves both — only the I2C
+// address differs (FT3168 @ 0x38 vs CST820 @ 0x15). CST820 is Hynitron CST8xx,
+// register-compatible with the CST816 the 1.8 port reads.
+//   reg 0x02:        low nibble = active finger count
+//   reg 0x03 / 0x04: X1 high (low nibble) + X1 low
+//   reg 0x05 / 0x06: Y1 high (low nibble) + Y1 low
+//
+// No INT pin is wired in this port, so we poll on every read. A 5-byte burst
+// at 400 kHz is ~150 us, comfortably inside LVGL's per-refresh touch budget.
+
+static uint8_t  touch_addr = CST816_ADDR;
+
+static bool     last_pressed = false;
+static uint16_t last_x = 0;
+static uint16_t last_y = 0;
+
+static void touch_poll(void) {
+    Wire.beginTransmission(touch_addr);
+    Wire.write(0x02);
+    if (Wire.endTransmission(false) != 0) { last_pressed = false; return; }
+    if (Wire.requestFrom(touch_addr, (uint8_t)5) != 5) { last_pressed = false; return; }
+    uint8_t fingers = Wire.read() & 0x0F;
+    uint8_t xH = Wire.read();
+    uint8_t xL = Wire.read();
+    uint8_t yH = Wire.read();
+    uint8_t yL = Wire.read();
+    if (fingers == 0 || fingers > 5) { last_pressed = false; return; }
+    // Raw controller coordinates. The display is left un-rotated (panel mounts
+    // 180°; the device is physically rotated in use — see display.cpp), so touch
+    // is left raw to match. If you ever software-rotate the display 180°, mirror
+    // both axes here too: last_x = LCD_WIDTH-1-x; last_y = LCD_HEIGHT-1-y.
+    last_x = ((uint16_t)(xH & 0x0F) << 8) | xL;
+    last_y = ((uint16_t)(yH & 0x0F) << 8) | yL;
+    last_pressed = true;
+}
+
+void touch_hal_init(void) {
+    bool is_cst = (board_rev() == REV_CO5300_CST816);
+    touch_addr = is_cst ? CST816_ADDR : FT3168_ADDR;
+
+    if (!is_cst) {
+        // FT3168 power-mode register 0xA5 = 0x00: active scanning.
+        // CST820 reports by default; no equivalent setup needed.
+        Wire.beginTransmission(touch_addr);
+        Wire.write(0xA5);
+        Wire.write(0x00);
+        Wire.endTransmission();
+    }
+
+    uint8_t id_reg = is_cst ? 0xA7 : 0xA0;
+    Wire.beginTransmission(touch_addr);
+    Wire.write(id_reg);
+    if (Wire.endTransmission(false) == 0 && Wire.requestFrom(touch_addr, (uint8_t)1) == 1) {
+        Serial.printf("Touch %s ID=0x%02X (addr 0x%02X)\n",
+                      is_cst ? "CST820" : "FT3168", Wire.read(), touch_addr);
+    } else {
+        Serial.printf("Touch ID read failed (addr 0x%02X)\n", touch_addr);
+    }
+    Serial.println("Touch: polled (no INT pin)");
+}
+
+void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
+    touch_poll();
+    *x = last_x;
+    *y = last_y;
+    *pressed = last_pressed;
+}
+
+// --- Optional INT-driven path -------------------------------------------------
+// If you wire the touch INT line to a GPIO, define TP_INT in board.h and use
+// this instead of polling: attach a FALLING ISR that sets a flag, and only call
+// touch_poll() from touch_hal_read() when the flag is set. Mirrors the 1.8 port.

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -15,6 +15,7 @@ LV_FONT_DECLARE(font_styrene_20);
 LV_FONT_DECLARE(font_styrene_16);
 LV_FONT_DECLARE(font_styrene_14);
 LV_FONT_DECLARE(font_mono_32);
+LV_FONT_DECLARE(font_mono_18);
 
 // Layout values computed from the active board's geometry. Populated once
 // in ui_init() and treated as const for the rest of the program. Adding a
@@ -24,6 +25,10 @@ struct Layout {
     int16_t scr_w, scr_h;
     int16_t margin;
     int16_t title_y;
+    int16_t title_x;        // horizontal nudge for the centered title
+    bool    show_title;     // false on round (the logo takes the header slot)
+    int16_t logo_x, logo_y; // logo position (corner on square, centred on round)
+    const lv_font_t* title_font;  // small under the logo on round
     int16_t content_y;
     int16_t content_w;
 
@@ -36,6 +41,7 @@ struct Layout {
     // Bluetooth screen
     int16_t bt_info_panel_h;
     int16_t bt_reset_zone_h;
+    const lv_font_t* anim_font;     // bottom status line (long words must fit the chord)
     const lv_font_t* bt_title_font;
     const lv_font_t* bt_status_font;
     const lv_font_t* bt_device_font;
@@ -53,8 +59,44 @@ static void compute_layout(const BoardCaps& c) {
     L.scr_h = c.height;
     L.margin = 20;
     L.title_y = 30;
+    L.title_x = 16;      // nudged right to balance the top-left corner logo
+    L.show_title = true;
+    L.title_font = &font_tiempos_56;
+    L.logo_x = L.margin;          // top-left corner (square boards)
+    L.logo_y = L.title_y - 10;
+    L.anim_font = &font_mono_32;
 
-    if (c.height >= 460) {
+    // Round screen (AMOLED-1.43, 466x466 cut to a circle). The square 480 layout
+    // pushes card corners, pills, the corner logo and the battery under the
+    // bezel. Inset everything inside the circle: narrower cards, vertically
+    // centred stack, centred title, and no corner logo (the battery is already
+    // hidden on this no-battery board).
+    bool round = (c.width == 466 && c.height == 466);
+
+    if (round) {
+        L.margin = 52;
+        L.content_y = 118;
+        L.usage_panel_h = 126;
+        L.usage_panel_gap = 8;
+        L.usage_bar_y = 50;
+        L.usage_reset_y = 74;
+        // Header: logo centred at the top with a small "Usage" tucked under it,
+        // then the (shorter, narrower) cards centred below.
+        L.logo_x = (c.width - LOGO_WIDTH) / 2;
+        L.logo_y = 6;
+        L.show_title = true;
+        L.title_x = 0;                  // centred under the logo
+        L.title_y = 92;
+        L.title_font = &font_styrene_24;
+        L.anim_font = &font_mono_18;  // long status words must fit the narrow bottom chord
+        L.bt_info_panel_h = 150;
+        L.bt_reset_zone_h = 100;
+        L.bt_title_font    = &font_tiempos_56;
+        L.bt_status_font   = &font_styrene_48;
+        L.bt_device_font   = &font_styrene_28;
+        L.bt_credit_1_font = &font_styrene_24;
+        L.bt_credit_2_font = &font_styrene_20;
+    } else if (c.height >= 460) {
         // Large layout — tuned for 480x480 (AMOLED-2.16).
         L.content_y = 100;
         L.usage_panel_h = 150;
@@ -366,9 +408,10 @@ static void init_usage_screen(lv_obj_t* scr) {
 
     lbl_title = lv_label_create(usage_container);
     lv_label_set_text(lbl_title, "Usage");
-    lv_obj_set_style_text_font(lbl_title, &font_tiempos_56, 0);
+    lv_obj_set_style_text_font(lbl_title, L.title_font, 0);
     lv_obj_set_style_text_color(lbl_title, COL_TEXT, 0);
-    lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 16, L.title_y);
+    lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, L.title_x, L.title_y);
+    if (!L.show_title) lv_obj_add_flag(lbl_title, LV_OBJ_FLAG_HIDDEN);
 
     // Usage panels (shown when connected) live in a transparent full-size group
     // so they can be toggled against the pairing hint as one unit.
@@ -395,7 +438,7 @@ static void init_usage_screen(lv_obj_t* scr) {
     // Status line — always visible on the usage view. Driven by ui_tick_anim().
     lbl_anim = lv_label_create(usage_container);
     lv_label_set_text(lbl_anim, "");
-    lv_obj_set_style_text_font(lbl_anim, &font_mono_32, 0);
+    lv_obj_set_style_text_font(lbl_anim, L.anim_font, 0);
     lv_obj_set_style_text_color(lbl_anim, COL_ACCENT, 0);
     lv_obj_align(lbl_anim, LV_ALIGN_BOTTOM_MID, 0, -15);
 }
@@ -419,9 +462,11 @@ void ui_init(void) {
         lv_obj_add_event_cb(splash_get_root(), global_click_cb, LV_EVENT_CLICKED, NULL);
     }
 
+    // Header logo — top-left corner on square boards, centred at the top on the
+    // round screen (where it stands in for the title text).
     logo_img = lv_image_create(scr);
     lv_image_set_src(logo_img, &logo_dsc);
-    lv_obj_set_pos(logo_img, L.margin, L.title_y - 10);
+    lv_obj_set_pos(logo_img, L.logo_x, L.logo_y);
 
     battery_img = lv_image_create(scr);
     lv_image_set_src(battery_img, &battery_dscs[0]);
@@ -516,8 +561,12 @@ void ui_tick_anim(void) {
 static screen_t prev_non_splash_screen = SCREEN_USAGE;
 static void apply_battery_visibility(void) {
     if (!battery_img) return;
-    if (current_screen == SCREEN_SPLASH) lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
-    else                                  lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+    // No PMU/fuel-gauge on this board → never show the indicator (it would just
+    // sit in the clipped corner). Also hidden on the splash.
+    if (!board_caps().has_battery || current_screen == SCREEN_SPLASH)
+        lv_obj_add_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
+    else
+        lv_obj_clear_flag(battery_img, LV_OBJ_FLAG_HIDDEN);
 }
 
 static void global_click_cb(lv_event_t* e) {


### PR DESCRIPTION
Adds a board target for the **Waveshare ESP32-S3-Touch-AMOLED-1.43** — a 466×466 round AMOLED (ESP32-S3, 16 MB flash / 8 MB OPI PSRAM). A new `boards/` folder plus one PlatformIO env; shared code is untouched apart from the sanctioned round-screen layout pass in `ui.cpp`.

Verified end-to-end on hardware: builds clean, boots to the splash, drives the panel, touch toggles screens, and the macOS daemon connects over BLE and updates the usage screen.

## Board — `firmware/src/boards/waveshare_amoled_143/`
- **CO5300** display over QSPI (CS=9 SCLK=10 D0–3=11–14 RST=21). Display selection is **decoupled from touch**: this panel is a CO5300 even on units fitted with an FT3168 touch, so inferring it from the touch address (as the 1.8 port does) is wrong and leaves the panel black. The QSPI bus is write-only so the display ID can't be read; SH8601 stays as a compile-time escape hatch (`DISPLAY_IS_SH8601`).
- **Touch**: FocalTech-style polled reader (FT3168 @ 0x38 / CST820 @ 0x15), raw coordinates — the panel mounts 180° and the device is rotated physically in use.
- **Input**: BOOT only; the hold-3s-to-pair gesture is synthesized from a BOOT long-press in `power.cpp`, so `main.cpp` stays untouched.
- No PMU / IMU / IO-expander; `imu` and the `power` battery paths are stubs.

## Round-screen UI — `ui.cpp::compute_layout()` (keyed on 466×466)
The square-480 layout pushed content under the round bezel. Added a round branch:
- Inset, vertically-centred cards; the logo centred at the top with a small title under it; `mono_18` status line so long animation words fit the narrow bottom chord.
- **Bug fix**: hide the battery indicator on no-battery boards (it was rendering, clipped, in a corner).

The other boards (2.16 / 1.8 / C6) are unaffected.

## Notes
- Build: `pio run -e waveshare_amoled_143` — ~1.3 MB, ~20% of the 6.25 MiB app partition.
- Still unverified on hardware (minor): the 3 s BOOT-hold pairing gesture clearing bonds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
