### PR TITLE
fix(daemon): read OAuth token from Keychain on macOS

### DIFF
--- a/daemon/claude-usage-daemon.sh
+++ b/daemon/claude-usage-daemon.sh
@@ -21,7 +21,18 @@ log() {
 }
 
 read_token() {
-    grep -o '"accessToken":"[^"]*"' "$HOME/.claude/.credentials.json" | cut -d'"' -f4
+    # macOS: token lives in Keychain (service "Claude Code-credentials").
+    # Linux: token lives in ~/.claude/.credentials.json.
+    if [ "$(uname)" = "Darwin" ]; then
+        local blob
+        blob=$(security find-generic-password -s "Claude Code-credentials" -a "$USER" -w 2>/dev/null)
+        if [ -n "$blob" ]; then
+            # Extract accessToken from nested JSON: {"claudeAiOauth":{"accessToken":"..."}}
+            echo "$blob" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); a=d.get('claudeAiOauth',d); print(a.get('accessToken',''))" 2>/dev/null
+            return
+        fi
+    fi
+    grep -o '"accessToken"[[:space:]]*:[[:space:]]*"[^"]*"' "$HOME/.claude/.credentials.json" | cut -d'"' -f4
 }
 
 # Convert MAC to D-Bus path: AA:BB:CC:DD:EE:FF -> dev_AA_BB_CC_DD_EE_FF


### PR DESCRIPTION
## Summary

- Fix the bash daemon's `read_token()` to read from macOS Keychain (`"Claude Code-credentials"` service) instead of `~/.claude/.credentials.json`, which often contains a stale expired token
- Fall back to the credentials file on Linux (unchanged behavior)
- Fix grep pattern to handle optional whitespace around JSON colons (`"accessToken": "..."` vs `"accessToken":"..."`)

## Problem

On macOS, Claude Code stores OAuth credentials in the system Keychain, not in `~/.claude/.credentials.json`. The bash daemon was reading from the file, which holds an old expired token, causing `API HTTP 401: Invalid authentication credentials`. The Python daemon already handled this correctly by reading from Keychain on Darwin.

## Testing

Verified the fixed `read_token()` extracts a valid token from Keychain on macOS and falls back to the file on Linux.