### PR TITLE
fix(daemon): bound start_notify so a half-open BLE link can't wedge the macOS daemon

### DIFF
--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -324,10 +324,22 @@ class Session:
         self.refresh_requested.set()
 
     async def setup_refresh_subscription(self) -> None:
+        # start_notify awaits CoreBluetooth's CCCD-write confirmation, which
+        # never arrives if the peripheral doesn't ACK the subscribe (a
+        # half-open link after the OS auto-connects the HID). Unbounded, that
+        # await wedges the whole daemon between "Connected" and the first poll
+        # — the device then shows nothing until a manual restart. Bound it: the
+        # subscription is only an optional device-initiated refresh nudge (we
+        # poll every POLL_INTERVAL regardless), so on timeout we proceed.
         try:
-            await self.client.start_notify(REQ_CHAR_UUID, self._on_refresh)
+            await asyncio.wait_for(
+                self.client.start_notify(REQ_CHAR_UUID, self._on_refresh),
+                timeout=10,
+            )
         except (BleakError, ValueError) as e:
             log(f"Refresh subscription unavailable: {e}")
+        except asyncio.TimeoutError:
+            log("Refresh subscription timed out; polling without it")
 
     async def write_payload(self, payload: dict) -> bool:
         data = json.dumps(payload, separators=(",", ":")).encode()


### PR DESCRIPTION
## Problem

On macOS the firmware advertises as a BLE HID keyboard, so the OS auto-connects the physical link and the daemon rides it via `retrieveConnectedPeripherals`. If the peripheral then fails to ACK the GATT subscribe, `BleakClient.start_notify()` awaits CoreBluetooth's CCCD-write confirmation **forever**.

Because that await sits between logging `Connected` and the first poll, the single-threaded daemon wedges indefinitely:

- process alive, **0% CPU**, stuck in state `S` on the `await`
- no further log output (last line is `Connected`, never reaches `Sending:`)
- the OS still reports the device "connected" (the HID link is fine)

So the monitor silently shows stale data with **no error and no recovery** until a manual restart. Observed in the wild as an ~18 h hang.

## Fix

Bound the call with `asyncio.wait_for(..., timeout=10)`. The refresh subscription is only an *optional* device-initiated nudge — the daemon polls every `POLL_INTERVAL` (60 s) regardless — so on timeout we log and proceed instead of blocking the whole loop.

## Testing

Reproduced the wedge live (29 h hung process, 0% CPU, no log past `Connected`). After the fix, restarted the daemon onto the patched code and confirmed it connects and resumes sending within ~1 s. `python -m py_compile` clean.