### PR TITLE
feat(macos): self-heal stale BLE bond after reflash + harden installer for Python 3.10+

### DIFF
--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -11,6 +11,7 @@ import getpass
 import json
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -340,6 +341,91 @@ class Session:
             return False
 
 
+def _is_encryption_error(exc: BaseException) -> bool:
+    """True if a connect error is a macOS bonding/encryption mismatch.
+
+    macOS reports a stale bond as CBErrorDomain Code=15 ("Failed to encrypt
+    the connection..."). Match on the message text so we don't depend on how
+    bleak wraps the underlying CoreBluetooth error.
+    """
+    s = str(exc).lower()
+    return "code=15" in s or "encrypt" in s
+
+
+# blueutil talks to Bluetooth via IOBluetooth, which on recent macOS needs its
+# OWN Bluetooth TCC grant (separate from the daemon's CoreBluetooth grant).
+# Without it, blueutil *hangs* instead of erroring — so every call is bounded
+# by a timeout and a hang is reported as a permission problem, not a crash.
+BLUEUTIL_TIMEOUT = 8
+
+
+def _blueutil(*args: str) -> str | None:
+    """Run `blueutil <args>`, returning stdout, or None on failure/timeout.
+
+    A timeout almost always means blueutil lacks Bluetooth permission (it
+    blocks rather than failing), so we surface that cause explicitly.
+    """
+    try:
+        return subprocess.run(
+            ["blueutil", *args],
+            capture_output=True, text=True,
+            timeout=BLUEUTIL_TIMEOUT, check=True,
+        ).stdout
+    except subprocess.TimeoutExpired:
+        log(f"blueutil {' '.join(args)} timed out — it likely lacks Bluetooth "
+            "permission. Grant it under System Settings > Privacy & Security > "
+            "Bluetooth (run `blueutil --paired` once from Terminal to prompt).")
+        return None
+    except (subprocess.SubprocessError, OSError) as e:
+        log(f"blueutil {' '.join(args)} failed: {e}")
+        return None
+
+
+def unpair_macos() -> bool:
+    """Forget a stale macOS bond for DEVICE_NAME so the device can re-pair.
+
+    A Code=15 "failed to encrypt" connect error means macOS holds bonding
+    keys that no longer match the ESP32's (e.g. after a firmware reflash or
+    the on-device bond-clear gesture). The firmware pairs "just works" (no
+    MITM), so once the stale bond is gone the next connect re-bonds silently
+    with no GUI prompt.
+
+    CoreBluetooth exposes no unpair API, so we shell out to `blueutil`. The
+    daemon only knows the peripheral's CoreBluetooth UUID, not the BD_ADDR
+    that blueutil needs, so we map by name via `blueutil --paired`. Returns
+    True if a bond was removed. Mirrors the Linux daemon's `bluetoothctl
+    remove` self-heal.
+    """
+    if not shutil.which("blueutil"):
+        log("Stale bond detected but `blueutil` is not installed; cannot "
+            "auto-recover. Run `brew install blueutil`, or forget "
+            f"'{DEVICE_NAME}' in System Settings > Bluetooth and reconnect.")
+        return False
+
+    out = _blueutil("--paired")
+    if out is None:
+        return False
+
+    # Each line looks like:
+    #   address: 28-84-85-55-5c-3d, ... name: "Clawdmeter", ...
+    addr = None
+    for line in out.splitlines():
+        if f'name: "{DEVICE_NAME}"' in line:
+            m = re.search(r"address:\s*([0-9a-fA-F:-]+)", line)
+            if m:
+                addr = m.group(1)
+                break
+    if not addr:
+        log(f"No paired '{DEVICE_NAME}' found to unpair (already forgotten?)")
+        return False
+
+    if _blueutil("--unpair", addr) is None:
+        return False
+    log(f"Unpaired stale bond for '{DEVICE_NAME}' [{addr}]; re-pairing on "
+        "next connect")
+    return True
+
+
 async def connect_and_run(target, stop_event: asyncio.Event) -> bool:
     """Connect to a target and poll until disconnected or stopped.
 
@@ -355,6 +441,9 @@ async def connect_and_run(target, stop_event: asyncio.Event) -> bool:
         await client.connect()
     except (BleakError, asyncio.TimeoutError) as e:
         log(f"Connection failed: {e}")
+        if sys.platform == "darwin" and _is_encryption_error(e):
+            log("Encryption failed — likely a stale macOS bond; self-healing")
+            unpair_macos()
         return False
 
     if not client.is_connected:

--- a/install-mac.sh
+++ b/install-mac.sh
@@ -17,9 +17,40 @@ echo "=== Clawdmeter macOS install ==="
 echo ""
 
 echo "[1/5] Checking prerequisites..."
-for cmd in python3 curl; do
-    command -v "$cmd" >/dev/null || { echo "Error: $cmd is required"; exit 1; }
+command -v curl >/dev/null || { echo "Error: curl is required"; exit 1; }
+
+# The daemon uses Python 3.10+ syntax (PEP 604 `X | None`). macOS ships an
+# older system python3 (3.9), so prefer a newer interpreter — Homebrew's if
+# present — and fall back to anything on PATH that is >= 3.10.
+py_ge_310() { "$1" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; }
+PYTHON3=""
+for cand in \
+    "$(command -v python3.13)" "$(command -v python3.12)" \
+    "$(command -v python3.11)" "$(command -v python3.10)" \
+    /opt/homebrew/bin/python3 /usr/local/bin/python3 \
+    "$(command -v python3)"; do
+    [ -n "$cand" ] && [ -x "$cand" ] || continue
+    if py_ge_310 "$cand"; then PYTHON3="$cand"; break; fi
 done
+if [ -z "$PYTHON3" ]; then
+    echo "Error: need Python >= 3.10. Install with: brew install python"
+    exit 1
+fi
+echo "  Using $($PYTHON3 --version) at $PYTHON3"
+# blueutil lets the daemon auto-recover from a stale BLE bond (CoreBluetooth
+# Code=15 "failed to encrypt") after a firmware reflash, without you having to
+# manually "Forget This Device". Best-effort: install via Homebrew if present,
+# otherwise warn — the daemon degrades gracefully (logs a manual-fix hint).
+if ! command -v blueutil >/dev/null 2>&1; then
+    if command -v brew >/dev/null 2>&1; then
+        echo "  Installing blueutil (for BLE bond auto-recovery)..."
+        brew install blueutil >/dev/null 2>&1 || echo "  Warning: 'brew install blueutil' failed; auto-recovery disabled."
+    else
+        echo "  Note: blueutil not found and Homebrew is absent. Install blueutil"
+        echo "        ('brew install blueutil') to enable automatic recovery from"
+        echo "        stale BLE bonds; otherwise you'll forget the device manually."
+    fi
+fi
 if ! security find-generic-password -s "Claude Code-credentials" -a "$USER" -w >/dev/null 2>&1; then
     echo "Warning: Claude Code OAuth token not found in Keychain (service 'Claude Code-credentials')."
     echo "  Sign in via Claude Code first, then re-run this installer."
@@ -29,8 +60,14 @@ echo "  OK"
 echo ""
 
 echo "[2/5] Creating Python virtualenv at daemon/.venv ..."
+# Recreate the venv if it's missing or was built with an interpreter older
+# than 3.10 (e.g. a previous run that picked the system python3).
+if [ -d "$VENV_DIR" ] && ! py_ge_310 "$VENV_DIR/bin/python"; then
+    echo "  Existing venv is too old; recreating with $PYTHON3"
+    rm -rf "$VENV_DIR"
+fi
 if [ ! -d "$VENV_DIR" ]; then
-    python3 -m venv "$VENV_DIR"
+    "$PYTHON3" -m venv "$VENV_DIR"
 fi
 "$VENV_DIR/bin/pip" install --quiet --upgrade pip
 "$VENV_DIR/bin/pip" install --quiet "bleak>=0.22" "httpx>=0.27"
@@ -61,6 +98,28 @@ echo ""
 read -r -p "Run a permission-priming scan now? [Y/n] " ans
 if [[ ! "$ans" =~ ^[Nn]$ ]]; then
     "$PYTHON_BIN" "$DAEMON_PY" || true
+fi
+echo ""
+
+# blueutil needs its OWN Bluetooth permission (separate identity from the
+# Python daemon) to auto-recover from a stale bond. It BLOCKS instead of
+# erroring when unauthorized, so prime it now behind a bounded wait: this
+# returns instantly if already authorized, or triggers the one-time Bluetooth
+# permission prompt (the grant sticks even if we time out before you click).
+if command -v blueutil >/dev/null 2>&1; then
+    echo "  Priming blueutil's Bluetooth permission (grant if prompted)..."
+    blueutil --paired >/dev/null 2>&1 &
+    bu_pid=$!
+    ( sleep 20; kill "$bu_pid" 2>/dev/null ) >/dev/null 2>&1 &
+    bu_killer=$!
+    if wait "$bu_pid" 2>/dev/null; then
+        echo "  blueutil authorized — stale-bond auto-recovery enabled."
+    else
+        echo "  blueutil could not access Bluetooth yet. If auto-recovery"
+        echo "  fails later, grant it under System Settings > Privacy &"
+        echo "  Security > Bluetooth, then re-run: blueutil --paired"
+    fi
+    kill "$bu_killer" 2>/dev/null || true
 fi
 echo ""
 


### PR DESCRIPTION
## Problem

After a firmware reflash (or the on-device bond-clear gesture), macOS keeps bonding keys that no longer match the ESP32. Every connect then fails with `CBErrorDomain Code=15 "Failed to encrypt the connection"`. CoreBluetooth exposes no unpair API, so the daemon could never recover on its own — the user had to **"Forget This Device"** by hand each time.

Separately, the macOS installer assumed a usable system `python3`, but the daemon uses PEP 604 `X | None` syntax which needs **Python ≥ 3.10** — and macOS ships 3.9, so a fresh install would crash at import on stock systems.

## Changes

**Daemon (`claude_usage_daemon.py`)**
- Detect the `Code=15` / `encrypt` connect error and, on macOS, shell out to `blueutil --unpair` for the bond matching `DEVICE_NAME` (mapped from name via `blueutil --paired`, since the daemon only holds the CoreBluetooth UUID, not the BD_ADDR). The firmware pairs "just works" (no MITM), so the next connect re-bonds silently with no GUI prompt. Mirrors the Linux daemon's `bluetoothctl remove` self-heal.
- `blueutil` talks via IOBluetooth, which needs its **own** Bluetooth TCC grant and **blocks** (rather than erroring) when unauthorized — so every call is bounded by a timeout and a hang is surfaced as a permission problem.
- Degrades gracefully when `blueutil` is absent: logs a manual-fix hint instead of failing.

**Installer (`install-mac.sh`)**
- Probe for a Python ≥ 3.10 interpreter (prefer Homebrew's), and recreate the venv if a previous run built it with an older one.
- Install `blueutil` via Homebrew (best-effort) and prime its Bluetooth permission behind a bounded wait, so the one-time prompt fires at install time rather than mid-recovery.

## Notes / testing

- `python -m py_compile` and `bash -n install-mac.sh` both clean.
- The self-heal path triggers only on a real stale-bond `Code=15` and is independent of the unrelated start_notify hang fixed in #84.