### PR TITLE
daemon: fix Windows daemon scanning for outdated BLE name

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Run `pio run -d firmware` with no env to see the available board envs.
 
 ### Pair the device
 
-The device is a bonded BLE HID keyboard, so pair it once: **Settings → Bluetooth & devices → Add device → Bluetooth**, then select "Claude Controller". Pairing is **required** — it enables the physical buttons and keeps a persistent connection (the device keeps showing your last-synced usage even after the daemon quits). To undo, use **Remove device** (this disables the buttons).
+The device is a bonded BLE HID keyboard, so pair it once: **Settings → Bluetooth & devices → Add device → Bluetooth**, then select "Clawdmeter". Pairing is **required** — it enables the physical buttons and keeps a persistent connection (the device keeps showing your last-synced usage even after the daemon quits). To undo, use **Remove device** (this disables the buttons).
 
 ### Install the daemon (recommended)
 

--- a/daemon/README-windows.md
+++ b/daemon/README-windows.md
@@ -42,7 +42,7 @@ before running the daemon:
 
 1. Put the device on its Bluetooth waiting screen (powered on, not yet connected).
 2. Open **Settings → Bluetooth & devices → Add device → Bluetooth**.
-3. Select **Claude Controller** and complete pairing.
+3. Select **Clawdmeter** and complete pairing.
 
 **Why this is required:**
 
@@ -104,7 +104,7 @@ python daemon\claude_usage_daemon_windows.py
 ```
 [HH:MM:SS] === Claude Usage Tracker Daemon (BLE, Windows) ===
 [HH:MM:SS] Poll interval: 60s
-[HH:MM:SS] Scanning for 'Claude Controller' (8.0s)...
+[HH:MM:SS] Scanning for 'Clawdmeter' (8.0s)...
 [HH:MM:SS] Found: XX:XX:XX:XX:XX:XX
 [HH:MM:SS] Connecting to XX:XX:XX:XX:XX:XX...
 [HH:MM:SS] Connected
@@ -135,7 +135,7 @@ Press **Ctrl+C** in the terminal. The daemon logs `Daemon stopping` and exits cl
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
 | `Warning: running under Linux/WSL` | Running in WSL, not native Windows | Run from a native PowerShell or Command Prompt on Windows |
-| `Scanning for 'Claude Controller'… Device not found` | Clawdmeter is off, out of range, or showing a non-Bluetooth screen | Power on the device and ensure it is on the Bluetooth waiting screen |
+| `Scanning for 'Clawdmeter'… Device not found` | Clawdmeter is off, out of range, or showing a non-Bluetooth screen | Power on the device and ensure it is on the Bluetooth waiting screen |
 | `No token; skipping poll` | No credentials file found at any candidate path | Confirm `claude login` ran on this machine; check `%USERPROFILE%\.claude\.credentials.json` exists |
 | `API HTTP 401` | Token expired | Re-run `claude login` in a terminal to refresh the token, then restart the daemon |
 | `Connection failed` | WinRT BLE initialisation issue | Ensure Windows Bluetooth is on; try toggling Bluetooth off/on in Windows Settings |

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -188,7 +188,7 @@ async def _get_cb_manager():
 
 
 async def retrieve_connected_macos(skip_addr: str | None = None):
-    """Return a BLEDevice for a system-connected 'Claude Controller', or None.
+    """Return a BLEDevice for a system-connected 'Clawdmeter', or None.
 
     Two-step lookup, strongest signal first:
 

--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -23,7 +23,7 @@ import httpx
 from bleak import BleakClient, BleakScanner
 from bleak.exc import BleakError
 
-DEVICE_NAME = "Claude Controller"
+DEVICE_NAME = "Clawdmeter"
 SERVICE_UUID = "4c41555a-4465-7669-6365-000000000001"
 RX_CHAR_UUID = "4c41555a-4465-7669-6365-000000000002"
 REQ_CHAR_UUID = "4c41555a-4465-7669-6365-000000000004"

--- a/daemon/test_macos_connect.py
+++ b/daemon/test_macos_connect.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Quick end-to-end test of the macOS connected-peripheral path.
 
-Discovers the HID-held 'Claude Controller', connects without scanning,
+Discovers the HID-held 'Clawdmeter', connects without scanning,
 finds the custom GATT characteristics, and writes one test payload.
 Run from Terminal.app (which has Bluetooth permission):
 


### PR DESCRIPTION
## Summary

The Windows daemon scanned for the BLE name `Claude Controller`, which no longer matches the firmware's advertised name `Clawdmeter` (renamed in #49). On Windows the daemon looped forever on "Device not found" and usage was never delivered to the device.

This was introduced because PR #57's fork predated the #49 rename.

## Changes

- `daemon/claude_usage_daemon_windows.py` — `DEVICE_NAME` now `"Clawdmeter"` (the actual functional fix)
- `README.md`, `daemon/README-windows.md` — updated user-facing pairing/troubleshooting instructions
- `daemon/claude_usage_daemon.py`, `daemon/test_macos_connect.py` — updated stale docstring references

`Clawdmeter` is the source of truth from `firmware/src/ble.cpp`.

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)