### PR TITLE
fix(daemon): bound client.connect() so a half-open BLE link can't wedge the daemon (#90)

### DIFF
--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -30,6 +30,7 @@ REQ_CHAR_UUID = "4c41555a-4465-7669-6365-000000000004"
 POLL_INTERVAL = 60
 TICK = 5
 SCAN_TIMEOUT = 8.0
+CONNECT_TIMEOUT = 20.0
 
 # macOS: token lives in Keychain (service "Claude Code-credentials").
 # Linux: token lives in ~/.claude/.credentials.json.
@@ -450,7 +451,16 @@ async def connect_and_run(target, stop_event: asyncio.Event) -> bool:
     log(f"Connecting to {display}...")
     client = BleakClient(target)
     try:
-        await client.connect()
+        # Bound the connect the same way #84 bounded the refresh subscribe.
+        # On macOS the OS auto-connects the firmware's HID link, so
+        # CoreBluetooth can hand us a half-open peripheral whose GATT connect
+        # handshake never completes. BleakClient's own timeout governs
+        # discovery, not connectPeripheral, so an unbounded await here wedges
+        # the single-threaded daemon forever at "Connecting..." (observed ~13h,
+        # device stuck on stale data). wait_for raises TimeoutError, which the
+        # handler below already treats as a connection failure -> drop the
+        # cached address and rescan.
+        await asyncio.wait_for(client.connect(), timeout=CONNECT_TIMEOUT)
     except (BleakError, asyncio.TimeoutError) as e:
         log(f"Connection failed: {e}")
         if sys.platform == "darwin" and _is_encryption_error(e):


### PR DESCRIPTION
Closes #90.

## What

`#84` (merged via #59) bounded `start_notify` so a half-open BLE link can't wedge the macOS/Linux daemon between **"Connected"** and the first poll. The **preceding** await — `client.connect()` itself — was still unbounded, so the daemon can hang one call site earlier, **before** it ever logs "Connected".

This wraps the connect in `asyncio.wait_for(client.connect(), timeout=CONNECT_TIMEOUT)`, mirroring #84.

```diff
-        await client.connect()
+        await asyncio.wait_for(client.connect(), timeout=CONNECT_TIMEOUT)
```

The existing `except (BleakError, asyncio.TimeoutError)` already treats a timeout as a connection failure and `return False`s, so a stalled connect now routes straight into the current invalidate-cache → back off → rescan cycle instead of blocking forever. New constant `CONNECT_TIMEOUT = 20.0` sits beside `SCAN_TIMEOUT`.

## Why

On macOS the firmware advertises as a BLE HID keyboard, so the OS auto-connects the physical link and the daemon rides it. If CoreBluetooth hands back a half-open peripheral whose GATT connect handshake never completes, the await hangs — and `BleakClient`'s own `timeout` governs *discovery*, not `connectPeripheral`, so it doesn't fire.

Observed in the wild: the daemon hung **~13h** with the last log line a `Connecting...` that never reached `Connected` — process alive but asleep, ~0% CPU, device stuck showing an expired 5h window with no error and no recovery until a manual `launchctl kickstart -k`. This is the connect-step analogue of the `start_notify` hang #84 reproduced.

## Testing

- `python -m py_compile daemon/claude_usage_daemon.py` — clean.
- A `wait_for` timeout raises `asyncio.TimeoutError`, which the unchanged handler already catches → `return False` → caller rescans (same recovery path #84 relies on).
- 20s is comfortably above a healthy connect (~1–6s in the logs) while capping the worst case.

Scoped intentionally to the connect hang; happy to adjust the timeout value or wording.
