### PR TITLE
Add Waveshare ESP32-S3-Touch-LCD-1.83 board port + responsive small-t…

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -111,6 +111,59 @@ lib_deps =
     h2zero/NimBLE-Arduino@^2.1.1
 
 
+[env:waveshare_lcd_183]
+; Waveshare ESP32-S3-Touch-LCD-1.83 — 240x284 ST7789P over SPI, CST816 touch,
+; AXP2101 PMU, QMI8658 IMU. ESP32-S3R8 (8MB OPI PSRAM, 16MB flash). No IO expander.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_build.partitions = default_16MB.csv
+upload_speed = 921600
+monitor_speed = 115200
+
+build_src_filter =
+    +<*>
+    -<boards/>
+    +<boards/waveshare_lcd_183/>
+
+build_flags =
+    -DBOARD_LCD_183
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    -DXPOWERS_CHIP_AXP2101
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    ; Arduino_ST7789 + Arduino_ESP32SPI ship in mainline GFX
+    moononournation/GFX Library for Arduino@^1.6.4
+    lewisxhe/SensorLib@^0.2.6
+    lewisxhe/XPowersLib@^0.2.7
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1
+
+
 [env:waveshare_amoled_216_c6]
 ; C6 sibling of the AMOLED-2.16. Same panel/touch/PMU/IMU, no PSRAM,
 ; single-core RISC-V, BLE 5.3 only (no classic BT). If the build fails

--- a/firmware/src/boards/waveshare_lcd_183/board.h
+++ b/firmware/src/boards/waveshare_lcd_183/board.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// Waveshare ESP32-S3-Touch-LCD-1.83 — portrait IPS LCD kit.
+// 240x284 ST7789P (SPI) + CST816 touch + AXP2101 PMU + QMI8658 IMU.
+// No IO expander: LCD_RST / TP_RST are direct GPIOs. Backlight on GPIO 40.
+// IMU is populated (initialized for I2C bus health) but rotation is disabled —
+// the panel mounts in a fixed orientation in the kit's enclosure.
+
+#define BOARD_NAME           "Waveshare LCD 1.83"
+
+// ---- Display geometry (portrait) ----
+#define LCD_WIDTH            240
+#define LCD_HEIGHT           284
+// ST7789 GRAM is 240x320. Waveshare's demo passes row offset 20, but on this
+// panel the visible glass maps to GRAM rows [0..283]: an offset of 20 leaves
+// the top ~20 rows unwritten (power-on garbage — the static band) and clips the
+// bottom. 0 aligns the 284-row window to the top of GRAM. (col offset stays 0.)
+#define LCD_ROW_OFFSET       0
+
+// ---- SPI display pins (ST7789P) ----
+#define LCD_DC               4
+#define LCD_CS               5
+#define LCD_SCK              6
+#define LCD_MOSI             7
+#define LCD_RST              38     // direct GPIO (handled by the GFX driver)
+#define LCD_BL               40     // backlight — PWM for brightness
+
+// ---- I2C bus (touch + PMU + IMU all share one bus) ----
+#define IIC_SDA              15
+#define IIC_SCL              14
+
+// ---- Touch (CST816 — same inline FocalTech-style reader as AMOLED-1.8) ----
+#define TP_INT               13
+#define TP_RST               39     // direct GPIO, active LOW
+#define CST816_ADDR          0x15
+
+// ---- PMU ----
+#define AXP2101_ADDR         0x34
+
+// ---- Buttons ----
+#define BTN_BACK_GPIO        0      // BOOT — primary, Space (PTT)
+// PWR comes via the AXP2101 PKEY IRQ (see power.cpp); no secondary button.
+
+// ---- Capability flags ----
+#define BOARD_HAS_SECONDARY_BUTTON 0
+#define BOARD_HAS_ROTATION         0
+#define BOARD_HAS_IMU              1    // present + initialized, rotation off
+#define BOARD_HAS_BATTERY          1
+#define BOARD_HAS_IO_EXPANDER      0

--- a/firmware/src/boards/waveshare_lcd_183/board_init.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/board_init.cpp
@@ -1,0 +1,17 @@
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// No IO expander on this board — LCD_RST is driven by the GFX driver, and the
+// touch controller just needs its own reset released before it's probed.
+
+extern "C" void board_init(void) {
+    Wire.begin(IIC_SDA, IIC_SCL);
+
+    // Release the CST816 from reset (active LOW) so it ACKs on I2C.
+    pinMode(TP_RST, OUTPUT);
+    digitalWrite(TP_RST, LOW);
+    delay(10);
+    digitalWrite(TP_RST, HIGH);
+    delay(50);
+}

--- a/firmware/src/boards/waveshare_lcd_183/caps.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/caps.cpp
@@ -1,0 +1,14 @@
+#include "../../hal/board_caps.h"
+#include "board.h"
+
+static const BoardCaps caps = {
+    .name = BOARD_NAME,
+    .width = LCD_WIDTH,
+    .height = LCD_HEIGHT,
+    .button_count = 1,
+    .has_rotation = false,
+    .has_battery = true,
+    .has_imu = true,
+};
+
+const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_lcd_183/display.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/display.cpp
@@ -1,0 +1,51 @@
+#include "../../hal/display_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+// ST7789P over 4-wire SPI. Unlike the AMOLED panels (QSPI, controller-side
+// brightness command), this is a standard Arduino_GFX TFT with native rotation
+// and a real LED backlight on GPIO 40 — brightness is backlight PWM.
+
+#define BL_PWM_FREQ  5000
+#define BL_PWM_BITS  8        // 0..255, so HAL level maps straight through
+
+static Arduino_DataBus* bus = nullptr;
+static Arduino_GFX*     gfx = nullptr;
+
+void display_hal_init(void) {
+    bus = new Arduino_ESP32SPI(LCD_DC, LCD_CS, LCD_SCK, LCD_MOSI);
+    // (bus, rst, rotation, IPS, w, h, col_off1, row_off1, col_off2, row_off2)
+    gfx = new Arduino_ST7789(
+        bus, LCD_RST, 0 /* rotation */, true /* IPS */,
+        LCD_WIDTH, LCD_HEIGHT, 0, LCD_ROW_OFFSET, 0, 0);
+}
+
+void display_hal_begin(void) {
+    gfx->begin();
+    gfx->fillScreen(0x0000);
+    ledcAttach(LCD_BL, BL_PWM_FREQ, BL_PWM_BITS);
+    ledcWrite(LCD_BL, 200);
+}
+
+void display_hal_set_brightness(uint8_t level) {
+    ledcWrite(LCD_BL, level);
+}
+
+void display_hal_fill_screen(uint16_t color) {
+    if (gfx) gfx->fillScreen(color);
+}
+
+void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
+                             const uint16_t* pixels) {
+    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+}
+
+void display_hal_tick(void) {
+    // No rotation handling on this board.
+}
+
+void display_hal_round_area(int32_t* x1, int32_t* y1, int32_t* x2, int32_t* y2) {
+    // ST7789 over SPI has no even-alignment requirement — passthrough.
+    (void)x1; (void)y1; (void)x2; (void)y2;
+}

--- a/firmware/src/boards/waveshare_lcd_183/imu.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/imu.cpp
@@ -1,0 +1,24 @@
+#include "../../hal/imu_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <SensorQMI8658.hpp>
+
+// QMI8658 is populated but the kit mounts the panel in a fixed orientation.
+// Initialize it to keep the shared I2C bus healthy, but always report rotation 0.
+
+static SensorQMI8658 imu;
+
+void imu_hal_init(void) {
+    if (!imu.begin(Wire, QMI8658_L_SLAVE_ADDRESS, IIC_SDA, IIC_SCL)) {
+        Serial.println("QMI8658 init failed");
+        return;
+    }
+    Serial.println("QMI8658 init OK (rotation disabled on this board)");
+}
+
+void imu_hal_tick(void) {
+    // No-op — rotation is disabled.
+}
+
+uint8_t imu_hal_rotation_quadrant(void) { return 0; }

--- a/firmware/src/boards/waveshare_lcd_183/input.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/input.cpp
@@ -1,0 +1,20 @@
+#include "../../hal/input_hal.h"
+#include "board.h"
+#include <Arduino.h>
+
+// LCD-1.83 has only the BOOT button as a secondary input — the PWR button
+// comes through power_hal (AXP2101 PKEY). No secondary button.
+
+void input_hal_init(void) {
+    pinMode(BTN_BACK_GPIO, INPUT_PULLUP);
+}
+
+bool input_hal_is_held(InputButton btn) {
+    switch (btn) {
+    case INPUT_BTN_PRIMARY:
+        return digitalRead(BTN_BACK_GPIO) == LOW;
+    case INPUT_BTN_SECONDARY:
+        return false;   // not present on this board
+    }
+    return false;
+}

--- a/firmware/src/boards/waveshare_lcd_183/power.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/power.cpp
@@ -1,0 +1,92 @@
+#include "../../hal/power_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <XPowersLib.h>
+
+// No IO expander on this board — PWR comes straight from the AXP2101 PKEY IRQs:
+//   SHORT    — quick tap (cycle screens / splash animations)
+//   LONG     — ~1.5s mark, starts the hold-to-pair countdown
+//   POSITIVE — release edge, completes/cancels the gesture
+
+#define BATTERY_POLL_MS  2000
+#define CHARGING_POLL_MS 500
+#define PWR_POLL_MS      50
+
+static XPowersPMU pmu;
+
+static int      cached_pct        = -1;
+static bool     cached_charging   = false;
+static bool     cached_vbus       = false;
+static bool     pwr_pressed_flag  = false;
+static bool     pwr_long_flag     = false;
+static bool     pwr_released_flag = false;
+static uint32_t last_battery_ms   = 0;
+static uint32_t last_charging_ms  = 0;
+static uint32_t last_pwr_ms       = 0;
+
+void power_hal_init(void) {
+    if (!pmu.begin(Wire, AXP2101_ADDR, IIC_SDA, IIC_SCL)) {
+        Serial.println("AXP2101 init failed");
+        return;
+    }
+    Serial.println("AXP2101 init OK");
+
+    pmu.enableBattDetection();
+    pmu.enableBattVoltageMeasure();
+
+    pmu.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
+    pmu.clearIrqStatus();
+    pmu.enableIRQ(XPOWERS_AXP2101_PKEY_SHORT_IRQ
+                | XPOWERS_AXP2101_PKEY_LONG_IRQ
+                | XPOWERS_AXP2101_PKEY_POSITIVE_IRQ);
+
+    // Bump force-shutdown hold so a slightly-too-long pair gesture doesn't
+    // power the device off mid-gesture (mirrors the AMOLED-2.16 port).
+    pmu.setPowerKeyPressOffTime(XPOWERS_POWEROFF_8S);
+
+    cached_charging = pmu.isCharging();
+    cached_vbus     = pmu.isVbusIn();
+    cached_pct = pmu.getBatteryPercent();
+}
+
+void power_hal_tick(void) {
+    uint32_t now = millis();
+
+    if (now - last_charging_ms >= CHARGING_POLL_MS) {
+        last_charging_ms = now;
+        cached_charging = pmu.isCharging();
+        cached_vbus     = pmu.isVbusIn();
+    }
+    if (now - last_battery_ms >= BATTERY_POLL_MS) {
+        last_battery_ms = now;
+        cached_pct = pmu.getBatteryPercent();
+    }
+    if (now - last_pwr_ms >= PWR_POLL_MS) {
+        last_pwr_ms = now;
+        pmu.getIrqStatus();
+        if (pmu.isPekeyShortPressIrq())    pwr_pressed_flag  = true;
+        if (pmu.isPekeyLongPressIrq())     pwr_long_flag     = true;
+        if (pmu.isPekeyPositiveIrq())      pwr_released_flag = true;
+        pmu.clearIrqStatus();
+    }
+}
+
+int  power_hal_battery_pct(void) { return cached_pct; }
+bool power_hal_is_charging(void) { return cached_charging; }
+bool power_hal_is_vbus_in(void)  { return cached_vbus; }
+
+bool power_hal_pwr_pressed(void) {
+    if (pwr_pressed_flag) { pwr_pressed_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_long_pressed(void) {
+    if (pwr_long_flag) { pwr_long_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_released(void) {
+    if (pwr_released_flag) { pwr_released_flag = false; return true; }
+    return false;
+}

--- a/firmware/src/boards/waveshare_lcd_183/touch.cpp
+++ b/firmware/src/boards/waveshare_lcd_183/touch.cpp
@@ -1,0 +1,65 @@
+#include "../../hal/touch_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// CST816 capacitive touch. Same FocalTech-style data layout as the AMOLED-1.8
+// reader (only this board has a single fixed controller, so no board_rev):
+//   reg 0x02:        low nibble = active finger count
+//   reg 0x03 / 0x04: X1 high (low nibble) + X1 low
+//   reg 0x05 / 0x06: Y1 high (low nibble) + Y1 low
+
+static volatile bool     touch_data_ready = false;
+static volatile bool     touch_pressed = false;
+static volatile uint16_t touch_x = 0;
+static volatile uint16_t touch_y = 0;
+
+static void IRAM_ATTR touch_isr(void) {
+    touch_data_ready = true;
+}
+
+static void touch_read_into_shared_state(void) {
+    Wire.beginTransmission(CST816_ADDR);
+    Wire.write(0x02);
+    if (Wire.endTransmission(false) != 0) { touch_pressed = false; return; }
+    if (Wire.requestFrom((uint8_t)CST816_ADDR, (uint8_t)5) != 5) { touch_pressed = false; return; }
+    uint8_t fingers = Wire.read() & 0x0F;
+    uint8_t xH = Wire.read();
+    uint8_t xL = Wire.read();
+    uint8_t yH = Wire.read();
+    uint8_t yL = Wire.read();
+    if (fingers == 0 || fingers > 5) {
+        touch_pressed = false;
+        return;
+    }
+    // ponytail: direct mapping. If taps land mirrored/swapped on the panel,
+    // flip here — e.g. touch_x = LCD_WIDTH-1-x, or swap x/y. Calibrate on first boot.
+    touch_x = ((uint16_t)(xH & 0x0F) << 8) | xL;
+    touch_y = ((uint16_t)(yH & 0x0F) << 8) | yL;
+    touch_pressed = true;
+}
+
+void touch_hal_init(void) {
+    // Verify the controller answers (CST816 chip-id is reg 0xA7).
+    Wire.beginTransmission(CST816_ADDR);
+    Wire.write(0xA7);
+    if (Wire.endTransmission(false) == 0 && Wire.requestFrom((uint8_t)CST816_ADDR, (uint8_t)1) == 1) {
+        Serial.printf("Touch CST816 ID=0x%02X (addr 0x%02X)\n", Wire.read(), CST816_ADDR);
+    } else {
+        Serial.printf("Touch ID read failed (addr 0x%02X)\n", CST816_ADDR);
+    }
+
+    pinMode(TP_INT, INPUT_PULLUP);
+    attachInterrupt(TP_INT, touch_isr, FALLING);
+    Serial.println("Touch attached on INT pin");
+}
+
+void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
+    if (touch_data_ready) {
+        touch_data_ready = false;
+        touch_read_into_shared_state();
+    }
+    *x = touch_x;
+    *y = touch_y;
+    *pressed = touch_pressed;
+}

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -15,7 +15,9 @@ LV_FONT_DECLARE(font_styrene_24);
 LV_FONT_DECLARE(font_styrene_20);
 LV_FONT_DECLARE(font_styrene_16);
 LV_FONT_DECLARE(font_styrene_14);
+LV_FONT_DECLARE(font_styrene_12);
 LV_FONT_DECLARE(font_mono_32);
+LV_FONT_DECLARE(font_mono_18);
 
 // Layout values computed from the active board's geometry. Populated once
 // in ui_init() and treated as const for the rest of the program. Adding a
@@ -25,6 +27,9 @@ struct Layout {
     int16_t scr_w, scr_h;
     int16_t margin;
     int16_t title_y;
+    int16_t title_x_off;   // TOP_MID x nudge for the title (clears the logo)
+    int16_t pill_pad;      // horizontal padding inside the Current/Weekly pills
+    int16_t pill_h;        // fixed pill height (0 = auto); fills the % row down to the bar
     int16_t content_y;
     int16_t content_w;
 
@@ -32,7 +37,17 @@ struct Layout {
     int16_t usage_panel_h;
     int16_t usage_panel_gap;
     int16_t usage_bar_y;
+    int16_t usage_bar_h;
     int16_t usage_reset_y;
+    const lv_font_t* usage_title_font;
+    const lv_font_t* usage_pct_font;       // normal-mode hero number
+    const lv_font_t* usage_pct_ent_font;   // enterprise spending number
+    const lv_font_t* usage_pill_font;      // "Current"/"Weekly" pill + "%" symbol
+    const lv_font_t* usage_reset_font;     // "Resets in …" + spending desc
+    const lv_font_t* usage_status_font;    // bottom animated status line
+
+    // Header images (logo + battery) scale: 256 = 1x. Small panels shrink them.
+    int16_t img_scale;
 
     // Bluetooth screen
     int16_t bt_info_panel_h;
@@ -54,6 +69,21 @@ static void compute_layout(const BoardCaps& c) {
     L.scr_h = c.height;
     L.margin = 20;
     L.title_y = 30;
+    L.title_x_off = 16;
+    L.pill_pad = 18;
+    L.pill_h = 0;   // big boards keep the pill's natural (auto) height
+
+    // Usage-screen fonts default to the full-size set (large + compact share
+    // them — this matches the values these screens were hardcoded to before
+    // the small tier existed, so the 480 and 368 boards are unchanged).
+    L.usage_title_font   = &font_tiempos_56;
+    L.usage_pct_font     = &font_styrene_48;
+    L.usage_pct_ent_font = &font_tiempos_56;
+    L.usage_pill_font    = &font_styrene_28;
+    L.usage_reset_font   = &font_styrene_28;
+    L.usage_status_font  = &font_mono_32;
+    L.usage_bar_h        = 24;
+    L.img_scale          = 256;   // 1x
 
     if (c.height >= 460) {
         // Large layout — tuned for 480x480 (AMOLED-2.16).
@@ -69,7 +99,7 @@ static void compute_layout(const BoardCaps& c) {
         L.bt_device_font   = &font_styrene_28;
         L.bt_credit_1_font = &font_styrene_24;
         L.bt_credit_2_font = &font_styrene_20;
-    } else {
+    } else if (c.height >= 320) {
         // Compact layout — tuned for 368x448 (AMOLED-1.8).
         L.content_y = 85;
         L.usage_panel_h = 130;
@@ -83,6 +113,35 @@ static void compute_layout(const BoardCaps& c) {
         L.bt_device_font   = &font_styrene_20;
         L.bt_credit_1_font = &font_styrene_16;
         L.bt_credit_2_font = &font_styrene_14;
+    } else {
+        // Small layout — tuned for 240x284 (LCD-1.83), ~0.65x of the 1.8.
+        L.margin = 14;
+        L.title_y = 18;
+        L.title_x_off = 0;
+        L.pill_pad = 8;
+        L.content_y = 54;
+        L.usage_panel_h = 92;
+        L.usage_panel_gap = 8;
+        L.usage_bar_y = 30;
+        L.usage_bar_h = 16;
+        L.usage_reset_y = 52;
+        // Pill fills the % row: top-aligned with the percentage, stopping ~4px
+        // short of the bar so its bottom margin matches the percentage's.
+        L.pill_h = L.usage_bar_y - 4;
+        L.usage_title_font   = &font_tiempos_34;
+        L.usage_pct_font     = &font_styrene_28;
+        L.usage_pct_ent_font = &font_tiempos_34;
+        L.usage_pill_font    = &font_styrene_16;
+        L.usage_reset_font   = &font_styrene_14;
+        L.usage_status_font  = &font_mono_18;
+        L.img_scale = 128;   // 0.5x — 80px logo → 40px, 48px battery → 24px
+        L.bt_info_panel_h = 90;
+        L.bt_reset_zone_h = 58;
+        L.bt_title_font    = &font_tiempos_34;
+        L.bt_status_font   = &font_styrene_24;
+        L.bt_device_font   = &font_styrene_16;
+        L.bt_credit_1_font = &font_styrene_14;
+        L.bt_credit_2_font = &font_styrene_12;
     }
 
     L.content_w = L.scr_w - 2 * L.margin;
@@ -267,15 +326,26 @@ static void init_icon_dsc_rgb565a8(lv_image_dsc_t* dsc, int w, int h, const uint
 static lv_obj_t* make_pill(lv_obj_t* parent, const char* text) {
     lv_obj_t* lbl = lv_label_create(parent);
     lv_label_set_text(lbl, text);
-    lv_obj_set_style_text_font(lbl, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(lbl, L.usage_pill_font, 0);
     lv_obj_set_style_text_color(lbl, COL_TEXT, 0);
     lv_obj_set_style_bg_color(lbl, COL_BAR_BG, 0);
     lv_obj_set_style_bg_opa(lbl, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(lbl, LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_pad_left(lbl, 18, 0);
-    lv_obj_set_style_pad_right(lbl, 18, 0);
-    lv_obj_set_style_pad_top(lbl, 6, 0);
-    lv_obj_set_style_pad_bottom(lbl, 6, 0);
+    lv_obj_set_style_pad_left(lbl, L.pill_pad, 0);
+    lv_obj_set_style_pad_right(lbl, L.pill_pad, 0);
+    if (L.pill_h > 0) {
+        // Fixed height to match the % row; center the text vertically so the
+        // pill consumes the same band (same top + bottom margin) as the number.
+        int text_h = lv_font_get_line_height(L.usage_pill_font);
+        int vpad = (L.pill_h - text_h) / 2;
+        if (vpad < 0) vpad = 0;
+        lv_obj_set_height(lbl, L.pill_h);
+        lv_obj_set_style_pad_top(lbl, vpad, 0);
+        lv_obj_set_style_pad_bottom(lbl, vpad, 0);
+    } else {
+        lv_obj_set_style_pad_top(lbl, 6, 0);
+        lv_obj_set_style_pad_bottom(lbl, 6, 0);
+    }
     return lbl;
 }
 
@@ -296,18 +366,18 @@ static lv_obj_t* make_usage_panel(lv_obj_t* parent, int y, const char* pill_text
 
     *out_pct = lv_label_create(panel);
     lv_label_set_text(*out_pct, "---%");
-    lv_obj_set_style_text_font(*out_pct, &font_styrene_48, 0);
+    lv_obj_set_style_text_font(*out_pct, L.usage_pct_font, 0);
     lv_obj_set_style_text_color(*out_pct, COL_TEXT, 0);
     lv_obj_set_pos(*out_pct, 0, 0);
 
     *out_pill = make_pill(panel, pill_text);
-    lv_obj_align(*out_pill, LV_ALIGN_TOP_RIGHT, 0, 1);
+    lv_obj_align(*out_pill, LV_ALIGN_TOP_RIGHT, 0, 0);
 
-    *out_bar = make_bar(panel, 0, L.usage_bar_y, L.content_w - 32, 24);
+    *out_bar = make_bar(panel, 0, L.usage_bar_y, L.content_w - 32, L.usage_bar_h);
 
     *out_reset = lv_label_create(panel);
     lv_label_set_text(*out_reset, "---");
-    lv_obj_set_style_text_font(*out_reset, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(*out_reset, L.usage_reset_font, 0);
     lv_obj_set_style_text_color(*out_reset, COL_DIM, 0);
     lv_obj_set_pos(*out_reset, 0, L.usage_reset_y);
 
@@ -381,9 +451,9 @@ static void init_usage_screen(lv_obj_t* scr) {
 
     lbl_title = lv_label_create(usage_container);
     lv_label_set_text(lbl_title, "Usage");
-    lv_obj_set_style_text_font(lbl_title, &font_tiempos_56, 0);
+    lv_obj_set_style_text_font(lbl_title, L.usage_title_font, 0);
     lv_obj_set_style_text_color(lbl_title, COL_TEXT, 0);
-    lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 16, L.title_y);
+    lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, L.title_x_off, L.title_y);
 
     // Usage panels (shown when connected) live in a transparent full-size group
     // so they can be toggled against the pairing hint as one unit.
@@ -403,13 +473,13 @@ static void init_usage_screen(lv_obj_t* scr) {
     // Enterprise-only overlays inside panel_session — hidden until enterprise data arrives
     lbl_session_pct_sym = lv_label_create(panel_session);
     lv_label_set_text(lbl_session_pct_sym, "%");
-    lv_obj_set_style_text_font(lbl_session_pct_sym, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(lbl_session_pct_sym, L.usage_pill_font, 0);
     lv_obj_set_style_text_color(lbl_session_pct_sym, COL_TEXT, 0);
     lv_obj_add_flag(lbl_session_pct_sym, LV_OBJ_FLAG_HIDDEN);
 
     lbl_spending_desc = lv_label_create(panel_session);
     lv_label_set_text(lbl_spending_desc, "of your monthly budget");
-    lv_obj_set_style_text_font(lbl_spending_desc, &font_styrene_28, 0);
+    lv_obj_set_style_text_font(lbl_spending_desc, L.usage_reset_font, 0);
     lv_obj_set_style_text_color(lbl_spending_desc, COL_DIM, 0);
     lv_obj_set_pos(lbl_spending_desc, 0, L.usage_reset_y);
     lv_obj_add_flag(lbl_spending_desc, LV_OBJ_FLAG_HIDDEN);
@@ -433,7 +503,7 @@ static void init_usage_screen(lv_obj_t* scr) {
     // Status line — always visible on the usage view. Driven by ui_tick_anim().
     lbl_anim = lv_label_create(usage_container);
     lv_label_set_text(lbl_anim, "");
-    lv_obj_set_style_text_font(lbl_anim, &font_mono_32, 0);
+    lv_obj_set_style_text_font(lbl_anim, L.usage_status_font, 0);
     lv_obj_set_style_text_color(lbl_anim, COL_ACCENT, 0);
     lv_obj_align(lbl_anim, LV_ALIGN_BOTTOM_MID, 0, -15);
 }
@@ -446,6 +516,9 @@ void ui_init(void) {
     lv_obj_t* scr = lv_screen_active();
     lv_obj_set_style_bg_color(scr, COL_BG, 0);
     lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
+    // Fixed dashboard — nothing should ever scroll. (Scaled header images leave
+    // an off-screen layout box that would otherwise make the screen draggable.)
+    lv_obj_clear_flag(scr, LV_OBJ_FLAG_SCROLLABLE);
 
     init_icon_dsc_rgb565a8(&logo_dsc, LOGO_WIDTH, LOGO_HEIGHT, logo_data);
     init_battery_icons();
@@ -457,13 +530,22 @@ void ui_init(void) {
         lv_obj_add_event_cb(splash_get_root(), global_click_cb, LV_EVENT_CLICKED, NULL);
     }
 
+    // Scale header images around their top-left so set_pos stays predictable.
+    int logo_w  = (LOGO_WIDTH  * L.img_scale) / 256;
+    int batt_w  = (48 * L.img_scale) / 256;   // battery icons are 48px wide
+
     logo_img = lv_image_create(scr);
     lv_image_set_src(logo_img, &logo_dsc);
-    lv_obj_set_pos(logo_img, L.margin, L.title_y - 10);
+    lv_image_set_pivot(logo_img, 0, 0);
+    lv_image_set_scale(logo_img, L.img_scale);
+    lv_obj_set_pos(logo_img, L.margin, L.title_y - (10 * L.img_scale) / 256);
 
     battery_img = lv_image_create(scr);
     lv_image_set_src(battery_img, &battery_dscs[0]);
-    lv_obj_set_pos(battery_img, L.scr_w - 48 - L.margin, L.title_y);
+    lv_image_set_pivot(battery_img, 0, 0);
+    lv_image_set_scale(battery_img, L.img_scale);
+    lv_obj_set_pos(battery_img, L.scr_w - batt_w - L.margin, L.title_y);
+    (void)logo_w;
 
 }
 
@@ -486,7 +568,7 @@ void ui_update(const UsageData* data) {
 
     if (data->enterprise) {
         // Spending box: big number-only label + small "%" symbol + desc + pace
-        lv_obj_set_style_text_font(lbl_session_pct, &font_tiempos_56, 0);
+        lv_obj_set_style_text_font(lbl_session_pct, L.usage_pct_ent_font, 0);
         lv_label_set_text(lbl_session_label, "Spending");
         lv_obj_add_flag(lbl_session_reset, LV_OBJ_FLAG_HIDDEN);
         lv_obj_clear_flag(lbl_session_pct_sym, LV_OBJ_FLAG_HIDDEN);
@@ -494,7 +576,7 @@ void ui_update(const UsageData* data) {
         lv_obj_add_flag(lbl_spending_status,   LV_OBJ_FLAG_HIDDEN);
         if (panel_weekly) lv_obj_clear_flag(panel_weekly, LV_OBJ_FLAG_HIDDEN);
     } else {
-        lv_obj_set_style_text_font(lbl_session_pct, &font_styrene_48, 0);
+        lv_obj_set_style_text_font(lbl_session_pct, L.usage_pct_font, 0);
         lv_label_set_text(lbl_session_label, "Current");
         lv_obj_clear_flag(lbl_session_reset, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(lbl_session_pct_sym, LV_OBJ_FLAG_HIDDEN);


### PR DESCRIPTION
…ier UI

New board folder boards/waveshare_lcd_183/ (240x284 ST7789P SPI, CST816 touch, AXP2101 PMU, QMI8658 IMU, no IO expander) plus a platformio env. Key calibration: LCD_ROW_OFFSET 0 (Waveshare's demo offset of 20 leaves an unwritten static band on the glass); backlight PWM on GPIO 40.

ui.cpp: add a third "small" layout tier (height < 320) scaling the usage screen ~0.65x from the 1.8, route the previously-hardcoded usage fonts through Layout, scale header logo/battery 0.5x, make Current/Weekly pills fill the percentage row, and disable screen scrolling.