### PR TITLE
daemon: poll multiple Claude config dirs and show the active plan

### DIFF
--- a/daemon/claude-usage-daemon.sh
+++ b/daemon/claude-usage-daemon.sh
@@ -21,8 +21,46 @@ log() {
     echo "[$(date '+%H:%M:%S')] $1"
 }
 
-read_token() {
-    grep -o '"accessToken":"[^"]*"' "$HOME/.claude/.credentials.json" | cut -d'"' -f4
+# --- Multi config-dir support ---------------------------------------------
+# Claude Code can run against more than one config dir (e.g. ~/.claude for a
+# personal plan and ~/.claude-work for a work plan, selected via
+# CLAUDE_CONFIG_DIR). The daemon polls each configured dir's token every cycle
+# and shows whichever plan is "active" (the one whose usage moved most recently
+# — see poll()). Per-dir state persists across poll() calls for that decision.
+declare -A PREV_S       # last session % seen per dir (detects a rise = activity)
+declare -A LAST_ACTIVE  # poll-sequence number of the last observed rise (0 = never)
+POLL_SEQ=0              # monotonic poll counter — recency ordering that's immune to
+                        # wall-clock resolution and NTP steps (polls are 60s apart, but
+                        # a counter is unambiguous even if two land in the same second)
+
+# Read the `config_dirs` option: a comma-separated list of Claude config dirs.
+# Defaults to "~/.claude" so existing single-plan setups are unchanged. Tildes
+# and $HOME are expanded; blanks trimmed. Echoes one resolved dir per line.
+read_config_dirs() {
+    local raw=""
+    if [ -f "$CONFIG_FILE" ]; then
+        raw=$(grep -E '^[[:space:]]*config_dirs[[:space:]]*=' "$CONFIG_FILE" | tail -1 \
+            | tr -d '\r' \
+            | sed -E 's/^[[:space:]]*config_dirs[[:space:]]*=[[:space:]]*//; s/[[:space:]]*(#.*)?$//')
+    fi
+    [ -z "$raw" ] && raw="$HOME/.claude"
+    local IFS=','
+    local d
+    for d in $raw; do
+        d=$(echo "$d" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+        [ -z "$d" ] && continue
+        case "$d" in
+            "~")   d="$HOME" ;;
+            "~/"*) d="$HOME/${d#\~/}" ;;
+        esac
+        echo "$d"
+    done
+}
+
+# Read the OAuth access token from a specific config dir's credentials file.
+read_token_for() {
+    local dir="$1"
+    grep -o '"accessToken":"[^"]*"' "$dir/.credentials.json" 2>/dev/null | cut -d'"' -f4
 }
 
 # Read the `chime` option from the config file. Echoes one of: off|on.
@@ -234,9 +272,12 @@ write_gatt() {
         WriteValue "aya{sv}" "$count" $bytes 0 2>/dev/null
 }
 
-poll() {
-    local token
-    token=$(read_token) || { log "Error: could not read token"; return 1; }
+# Build the device payload for one OAuth token. Echoes the JSON payload on
+# success (empty + non-zero return on failure). Pure: no logging, no GATT write
+# — poll() owns picking the active plan and sending it.
+build_payload_for_token() {
+    local token="$1"
+    [ -z "$token" ] && return 1
     local now
     now=$(date +%s)
 
@@ -267,7 +308,7 @@ poll() {
         -H "Content-Type: application/json" \
         -H "User-Agent: claude-code/2.1.5" \
         -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}' \
-        2>/dev/null) || { log "Error: API call failed"; return 1; }
+        2>/dev/null) || return 1
 
     local s5h_util overage_util overage_reset status
     s5h_util=$(echo "$headers" | grep -i "anthropic-ratelimit-unified-5h-utilization" | tr -d '\r' | awk '{print $2}')
@@ -334,8 +375,67 @@ PYEOF
             }')
     fi
 
-    log "Sending: $payload"
-    write_gatt "$RX_CHAR_PATH" "$payload" || { log "Write failed"; return 1; }
+    printf '%s' "$payload"
+    return 0
+}
+
+# Extract the integer session % ("s") from a built payload, or 0.
+_payload_session_pct() {
+    echo "$1" | grep -o '"s":[0-9]*' | head -1 | cut -d: -f2
+}
+
+# Poll every configured config dir, decide which plan is "active", and send
+# that plan's payload. "Active" = the plan whose session % rose most recently
+# (recent API activity); a rise stamps LAST_ACTIVE so the choice is sticky and
+# survives window resets (a drop to 0 isn't activity). Before any rise is seen
+# (startup), fall back to the plan with the highest current session %.
+poll() {
+    POLL_SEQ=$((POLL_SEQ + 1))
+
+    local -a dirs
+    mapfile -t dirs < <(read_config_dirs)
+
+    local -A cycle_payload cycle_s
+    local dir token payload s
+    for dir in "${dirs[@]}"; do
+        token=$(read_token_for "$dir")
+        if [ -z "$token" ]; then
+            log "No token in $dir; skipping"
+            continue
+        fi
+        payload=$(build_payload_for_token "$token") || { log "API call failed for $dir"; continue; }
+        [ -z "$payload" ] && continue
+        s=$(_payload_session_pct "$payload"); s=${s:-0}
+        cycle_payload["$dir"]="$payload"
+        cycle_s["$dir"]="$s"
+        # A rise in session % since the previous poll means this plan was just used.
+        if [ -n "${PREV_S[$dir]:-}" ] && (( s > PREV_S[$dir] )); then
+            LAST_ACTIVE["$dir"]=$POLL_SEQ
+        fi
+        PREV_S["$dir"]="$s"
+    done
+
+    if [ ${#cycle_payload[@]} -eq 0 ]; then
+        log "No usable config dir this cycle"
+        return 1
+    fi
+
+    # Pick the active dir: most recent activity wins; ties (and the no-activity
+    # startup case) broken by highest current session %.
+    local best_dir="" best_active=-1 best_s=-1 a
+    for dir in "${!cycle_payload[@]}"; do
+        a=${LAST_ACTIVE[$dir]:-0}
+        s=${cycle_s[$dir]}
+        if (( a > best_active )) || (( a == best_active && s > best_s )); then
+            best_active=$a; best_s=$s; best_dir=$dir
+        fi
+    done
+
+    if [ ${#dirs[@]} -gt 1 ]; then
+        log "Active plan: $best_dir (s=$best_s)"
+    fi
+    log "Sending: ${cycle_payload[$best_dir]}"
+    write_gatt "$RX_CHAR_PATH" "${cycle_payload[$best_dir]}" || { log "Write failed"; return 1; }
     return 0
 }
 

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -37,7 +37,7 @@ CONNECT_TIMEOUT = 20.0
 # macOS: token lives in Keychain (service "Claude Code-credentials").
 # Linux: token lives in ~/.claude/.credentials.json.
 KEYCHAIN_SERVICE = "Claude Code-credentials"
-CREDENTIALS_PATH = Path.home() / ".claude" / ".credentials.json"
+DEFAULT_CONFIG_DIR = Path.home() / ".claude"
 SAVED_ADDR_FILE = Path.home() / ".config" / "claude-usage-monitor" / "ble-address"
 CONFIG_FILE = Path.home() / ".config" / "claude-usage-monitor" / "config"
 
@@ -117,19 +117,49 @@ def _read_token_keychain() -> str | None:
     return _extract_access_token(out.stdout)
 
 
-def _read_token_file() -> str | None:
+def read_config_dirs() -> list[Path]:
+    """Claude config dirs to poll, from the `config_dirs` option (comma list).
+
+    Defaults to [~/.claude] so existing single-plan setups are unchanged. ~ is
+    expanded. Mirrors the Linux bash daemon's read_config_dirs.
+    """
+    raw = ""
     try:
-        raw = CREDENTIALS_PATH.read_text()
+        if CONFIG_FILE.exists():
+            for line in CONFIG_FILE.read_text().splitlines():
+                line = line.split("#", 1)[0].strip()
+                if "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                if key.strip().lower() == "config_dirs":
+                    raw = val.strip()
+    except OSError:
+        pass
+    if not raw:
+        return [DEFAULT_CONFIG_DIR]
+    dirs = [Path(p.strip()).expanduser() for p in raw.split(",") if p.strip()]
+    return dirs or [DEFAULT_CONFIG_DIR]
+
+
+def read_token_for(config_dir: Path) -> str | None:
+    """Read the OAuth token for one config dir.
+
+    Linux: each dir keeps its own ``<dir>/.credentials.json``. macOS: the default
+    install stores the token in Keychain with no file, so for the default dir we
+    fall back to Keychain when no file is present — preserving existing
+    single-plan macOS behavior. Additional macOS dirs are read from their files;
+    a work plan whose token lives only in the single Keychain entry can't be told
+    apart there (documented follow-up).
+    """
+    cred = config_dir / ".credentials.json"
+    try:
+        if cred.exists():
+            return _extract_access_token(cred.read_text())
     except OSError as e:
-        log(f"Error reading credentials: {e}")
-        return None
-    return _extract_access_token(raw)
-
-
-def read_token() -> str | None:
-    if sys.platform == "darwin":
+        log(f"Error reading credentials in {config_dir}: {e}")
+    if sys.platform == "darwin" and config_dir == DEFAULT_CONFIG_DIR:
         return _read_token_keychain()
-    return _read_token_file()
+    return None
 
 
 def load_cached_address() -> str | None:
@@ -461,6 +491,61 @@ def _billing_period_info(now: float, reset_ts: str) -> dict:
     }
 
 
+class PlanSelector:
+    """Decide which config dir's plan is "active" across polls.
+
+    "Active" = the plan whose session % rose most recently (recent API activity).
+    A rise stamps a monotonic poll counter, so the choice is sticky and a window
+    reset (a drop to 0) isn't mistaken for use. Before any rise is seen (startup)
+    the highest current session % wins. Mirrors the Linux bash daemon.
+    """
+
+    def __init__(self) -> None:
+        self.prev_s: dict[Path, int] = {}
+        self.last_active: dict[Path, int] = {}
+        self.seq = 0
+
+    def choose(self, sessions: dict[Path, int]) -> Path:
+        """Update state from this cycle's {dir: session_pct} and return the active dir."""
+        self.seq += 1
+        for d, s in sessions.items():
+            if d in self.prev_s and s > self.prev_s[d]:
+                self.last_active[d] = self.seq
+            self.prev_s[d] = s
+        # Most recent activity wins; ties (and the startup case) break by highest %.
+        return max(sessions, key=lambda d: (self.last_active.get(d, 0), sessions[d]))
+
+
+# Module-level so the active-plan state survives reconnects.
+_SELECTOR = PlanSelector()
+
+
+async def poll_active_payload(selector: PlanSelector = _SELECTOR) -> dict | None:
+    """Poll every configured config dir and return the active plan's payload.
+
+    Returns None when no dir yields a usable payload this cycle. A single
+    configured dir (the default) collapses to exactly the old single-poll path.
+    """
+    dirs = read_config_dirs()
+    payloads: dict[Path, dict] = {}
+    sessions: dict[Path, int] = {}
+    for d in dirs:
+        token = read_token_for(d)
+        if not token:
+            log(f"No token in {d}; skipping")
+            continue
+        payload = await poll_api(token)
+        if payload is not None:
+            payloads[d] = payload
+            sessions[d] = int(payload.get("s", 0) or 0)
+    if not payloads:
+        return None
+    active = selector.choose(sessions)
+    if len(dirs) > 1:
+        log(f"Active plan: {active} (s={sessions[active]})")
+    return payloads[active]
+
+
 class Session:
     def __init__(self, client: BleakClient) -> None:
         self.client = client
@@ -629,15 +714,12 @@ async def connect_and_run(target, stop_event: asyncio.Event) -> bool:
             elapsed = now - last_poll
             if session.refresh_requested.is_set() or elapsed >= POLL_INTERVAL:
                 session.refresh_requested.clear()
-                token = read_token()
-                if not token:
-                    log("No token; skipping poll")
-                else:
-                    payload = await poll_api(token)
-                    if payload is not None:
-                        if await session.write_payload(payload):
-                            last_poll = time.time()
-                            used_successfully = True
+                payload = await poll_active_payload()
+                if payload is None:
+                    log("No usable config dir this cycle")
+                elif await session.write_payload(payload):
+                    last_poll = time.time()
+                    used_successfully = True
 
             try:
                 await asyncio.wait_for(session.refresh_requested.wait(), timeout=TICK)

--- a/daemon/config.example
+++ b/daemon/config.example
@@ -6,6 +6,17 @@
 #
 # The daemon re-reads it on every poll, so edits take effect within ~60s — no restart needed.
 
+# Poll more than one Claude config dir and show whichever plan is currently
+# active. Use this if you run separate plans from different config dirs (e.g. a
+# personal plan in ~/.claude and a work plan in ~/.claude-work, selected via
+# CLAUDE_CONFIG_DIR). Comma-separated; ~ is expanded.
+#   - The daemon polls every listed dir each cycle and displays the plan whose
+#     usage rose most recently (i.e. the one you're actively using). Before any
+#     change is seen it shows the plan with the highest current usage.
+#   - Unset (default) = just ~/.claude, unchanged single-plan behavior.
+#   - install.sh can detect your ~/.claude* dirs and fill this in for you.
+# config_dirs = ~/.claude, ~/.claude-work
+
 # Play a sound on the device when your 5-hour session limit resets, so you know
 # you can use Claude again without watching the screen.
 #   off = silent (default)

--- a/daemon/tests/test_macos_multidir.py
+++ b/daemon/tests/test_macos_multidir.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Unit tests for the macOS/Linux daemon's multi config-dir active-plan support.
+
+Covers read_config_dirs, read_token_for, PlanSelector, and poll_active_payload.
+
+Run: python -m pytest daemon/tests/test_macos_multidir.py -x -q
+"""
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import daemon.claude_usage_daemon as mod
+from daemon.claude_usage_daemon import PlanSelector, read_config_dirs, read_token_for
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# read_config_dirs
+# ---------------------------------------------------------------------------
+
+def test_config_dirs_defaults_to_claude_when_unset(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "CONFIG_FILE", tmp_path / "config")  # absent
+    assert read_config_dirs() == [mod.DEFAULT_CONFIG_DIR]
+
+
+def test_config_dirs_defaults_when_key_absent(tmp_path, monkeypatch):
+    cfg = tmp_path / "config"
+    cfg.write_text("clock = auto\nchime = on\n")
+    monkeypatch.setattr(mod, "CONFIG_FILE", cfg)
+    assert read_config_dirs() == [mod.DEFAULT_CONFIG_DIR]
+
+
+def test_config_dirs_parses_comma_list_and_expands_tilde(tmp_path, monkeypatch):
+    cfg = tmp_path / "config"
+    cfg.write_text("config_dirs = ~/.claude, ~/.claude-work  # two plans\n")
+    monkeypatch.setattr(mod, "CONFIG_FILE", cfg)
+    assert read_config_dirs() == [Path.home() / ".claude", Path.home() / ".claude-work"]
+
+
+# ---------------------------------------------------------------------------
+# read_token_for
+# ---------------------------------------------------------------------------
+
+def test_token_for_reads_dir_credentials_file(tmp_path):
+    (tmp_path / ".credentials.json").write_text('{"claudeAiOauth":{"accessToken":"TOK_X"}}')
+    assert read_token_for(tmp_path) == "TOK_X"
+
+
+def test_token_for_missing_file_non_default_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod.sys, "platform", "linux")
+    assert read_token_for(tmp_path) is None  # no file, not the default dir
+
+
+def test_token_for_default_dir_falls_back_to_keychain_on_macos(tmp_path, monkeypatch):
+    # An empty dir standing in as the default: no file present -> Keychain.
+    monkeypatch.setattr(mod, "DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(mod.sys, "platform", "darwin")
+    with patch.object(mod, "_read_token_keychain", return_value="TOK_KEYCHAIN"):
+        assert read_token_for(tmp_path) == "TOK_KEYCHAIN"
+
+
+def test_token_for_file_wins_over_keychain(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(mod.sys, "platform", "darwin")
+    (tmp_path / ".credentials.json").write_text('{"accessToken":"TOK_FILE"}')
+    with patch.object(mod, "_read_token_keychain", return_value="TOK_KEYCHAIN"):
+        assert read_token_for(tmp_path) == "TOK_FILE"
+
+
+# ---------------------------------------------------------------------------
+# PlanSelector — the "active = recent API activity" rule
+# ---------------------------------------------------------------------------
+
+A, B = Path("/a"), Path("/b")
+
+
+def test_selector_startup_picks_highest_util():
+    sel = PlanSelector()
+    assert sel.choose({A: 10, B: 30}) == B  # no history yet -> highest %
+
+
+def test_selector_switches_on_rise():
+    sel = PlanSelector()
+    sel.choose({A: 10, B: 30})           # startup -> B
+    assert sel.choose({A: 20, B: 30}) == A  # A rose 10->20 -> A active
+
+
+def test_selector_sticky_when_no_movement():
+    sel = PlanSelector()
+    sel.choose({A: 10, B: 30})
+    sel.choose({A: 20, B: 30})           # A active
+    assert sel.choose({A: 20, B: 30}) == A  # nothing moved -> still A (not higher B)
+
+
+def test_selector_reset_to_zero_is_not_activity():
+    sel = PlanSelector()
+    sel.choose({A: 10, B: 30})
+    sel.choose({A: 20, B: 30})           # A active
+    sel.choose({A: 20, B: 45})           # B rose -> B active
+    assert sel.choose({A: 20, B: 0}) == B   # B window reset (drop) isn't a rise -> stays B
+
+
+def test_selector_larger_rise_wins_same_cycle():
+    sel = PlanSelector()
+    sel.choose({A: 10, B: 10})           # seed
+    assert sel.choose({A: 12, B: 40}) == B  # both rose same cycle -> higher % breaks tie
+
+
+# ---------------------------------------------------------------------------
+# poll_active_payload — integration over the helpers
+# ---------------------------------------------------------------------------
+
+def test_poll_active_payload_picks_active_and_skips_tokenless(monkeypatch):
+    dirs = [A, B]
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: dirs)
+    monkeypatch.setattr(mod, "read_token_for", lambda d: {A: "tA", B: None}[d])  # B has no token
+
+    async def fake_poll(token):
+        return {"s": 25, "ok": True} if token == "tA" else None
+
+    sel = PlanSelector()
+    with patch.object(mod, "poll_api", new=AsyncMock(side_effect=fake_poll)):
+        payload = _run(mod.poll_active_payload(sel))
+    assert payload == {"s": 25, "ok": True}  # only A had a token
+
+
+def test_poll_active_payload_returns_none_when_all_fail(monkeypatch):
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: None)
+    with patch.object(mod, "poll_api", new=AsyncMock(return_value=None)):
+        assert _run(mod.poll_active_payload(PlanSelector())) is None
+
+
+def test_poll_active_payload_selects_higher_util_plan(monkeypatch):
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: {A: "tA", B: "tB"}[d])
+
+    async def fake_poll(token):
+        return {"s": 12, "ok": True} if token == "tA" else {"s": 40, "ok": True}
+
+    with patch.object(mod, "poll_api", new=AsyncMock(side_effect=fake_poll)):
+        payload = _run(mod.poll_active_payload(PlanSelector()))
+    assert payload["s"] == 40  # startup -> highest util plan (B)


### PR DESCRIPTION
🤖 AI Generated:

Adds optional multi config-dir support to the **Linux (bash)** and **macOS/Linux (Python)** daemons. Set `config_dirs` in `~/.config/claude-usage-monitor/config` to a comma list (e.g. `~/.claude, ~/.claude-work`); the daemon polls each plan every cycle and shows whichever is **active**. Unset = just `~/.claude`, unchanged single-plan behavior.

**"Active" = recent API activity:** the plan whose 5h session % rose most recently, tracked with a monotonic poll counter so the choice is sticky and a window reset (drop to 0) isn't mistaken for use. At startup the highest current usage wins.

**Tokens per dir:** `<dir>/.credentials.json` on Linux; on macOS the default `~/.claude` falls back to Keychain when no file is present (preserves current behavior), additional dirs read their files.

**Tests:** 15 Python unit tests (selector rule, dir parsing, token resolution, integration). The bash daemon mirrors the same logic.

**Follow-up (out of scope):** the **Windows daemon** (`claude_usage_daemon_windows.py`) does not yet support this — open for whoever wants to add Windows parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
