### PR TITLE
install.sh: interactive daemon config (config dirs, clock, chime)

### DIFF
--- a/install-mac.sh
+++ b/install-mac.sh
@@ -12,11 +12,130 @@ DAEMON_PY="$SCRIPT_DIR/daemon/claude_usage_daemon.py"
 LOG_DIR="$HOME/Library/Logs"
 LOG_OUT="$LOG_DIR/claude-usage-daemon.out.log"
 LOG_ERR="$LOG_DIR/claude-usage-daemon.err.log"
+CONFIG_FILE="$HOME/.config/claude-usage-monitor/config"
+
+# Render an absolute path under $HOME back to a ~ form for tidy config entries.
+_tilde() { case "$1" in "$HOME"/*) echo "~${1#"$HOME"}";; *) echo "$1";; esac; }
+
+# Echo the current value of a config key (trimmed), or empty if unset.
+current_config_value() {
+    [ -f "$CONFIG_FILE" ] || return 0
+    grep -E "^[[:space:]]*$1[[:space:]]*=" "$CONFIG_FILE" | tail -1 \
+        | tr -d '\r' \
+        | sed -E "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*//; s/[[:space:]]*(#.*)?$//"
+}
+
+# Insert or replace `key = value`, preserving every other key in the file.
+upsert_config_key() {
+    local key="$1" value="$2"
+    mkdir -p "$(dirname "$CONFIG_FILE")"
+    touch "$CONFIG_FILE"
+    grep -vE "^[[:space:]]*$key[[:space:]]*=" "$CONFIG_FILE" > "$CONFIG_FILE.tmp" 2>/dev/null || true
+    mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+    echo "$key = $value" >> "$CONFIG_FILE"
+}
+
+# Detect ~/.claude* config dirs and, if more than one is found, let the user pick
+# which plans to show. The daemon polls all chosen dirs and displays whichever is
+# active. macOS note: the default ~/.claude stores its token in Keychain (often no
+# .credentials.json file), so it always counts as a candidate; additional dirs are
+# recognised by their credentials file — matching the daemon's read_token_for.
+configure_config_dirs() {
+    local -a candidates=()
+    local d
+    for d in "$HOME"/.claude*; do
+        [ -d "$d" ] || continue
+        if [ -f "$d/.credentials.json" ] || [ "$d" = "$HOME/.claude" ]; then
+            candidates+=("$d")
+        fi
+    done
+
+    if [ ${#candidates[@]} -le 1 ]; then
+        echo "  One Claude config dir found — using the default (~/.claude)."
+        return 0
+    fi
+
+    echo "  Found multiple Claude config dirs. The daemon can poll several plans"
+    echo "  and show whichever one you're actively using."
+    if [ ! -t 0 ]; then
+        local list=""
+        for d in "${candidates[@]}"; do list="${list:+$list, }$(_tilde "$d")"; done
+        echo "  Non-interactive shell — skipping. To enable, add to $CONFIG_FILE:"
+        echo "    config_dirs = $list"
+        return 0
+    fi
+
+    local -a selected=()
+    local ans
+    for d in "${candidates[@]}"; do
+        if [ "$d" = "$HOME/.claude" ]; then
+            read -r -p "  Poll $(_tilde "$d")? [Y/n] " ans || ans=""
+            if [[ ! "$ans" =~ ^[Nn]$ ]]; then selected+=("$d"); fi
+        else
+            read -r -p "  Also poll $(_tilde "$d")? [y/N] " ans || ans=""
+            if [[ "$ans" =~ ^[Yy]$ ]]; then selected+=("$d"); fi
+        fi
+    done
+
+    if [ ${#selected[@]} -eq 0 ]; then
+        echo "  Nothing selected — leaving the default (~/.claude)."
+        return 0
+    fi
+    if [ ${#selected[@]} -eq 1 ] && [ "${selected[0]}" = "$HOME/.claude" ]; then
+        echo "  Default (~/.claude) only — no config change needed."
+        return 0
+    fi
+
+    local joined="" sd
+    for sd in "${selected[@]}"; do joined="${joined:+$joined, }$(_tilde "$sd")"; done
+
+    upsert_config_key config_dirs "$joined"
+    echo "  Wrote: config_dirs = $joined"
+    echo "  -> $CONFIG_FILE"
+}
+
+# Offer the optional clock display (shown in place of the "Usage" title). Only
+# writes the key when it actually changes the current/default value.
+configure_clock() {
+    [ -t 0 ] || return 0
+    local ans cur
+    cur=$(current_config_value clock)
+    read -r -p "  Show a clock instead of the \"Usage\" title? [off/auto/12/24] (default off) " ans || ans=""
+    ans=$(echo "$ans" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+    [ -z "$ans" ] && ans="off"
+    case "$ans" in
+        off|auto|12|24) ;;
+        *) echo "  Unrecognized '$ans' — leaving clock unchanged."; return 0 ;;
+    esac
+    if [ "$ans" = "off" ] && { [ -z "$cur" ] || [ "$cur" = "off" ]; }; then
+        echo "  Clock off (default)."
+        return 0
+    fi
+    upsert_config_key clock "$ans"
+    echo "  Set: clock = $ans"
+}
+
+# Offer the optional session-reset chime (sound through the board speaker).
+configure_chime() {
+    [ -t 0 ] || return 0
+    local ans cur
+    cur=$(current_config_value chime)
+    read -r -p "  Chime through the speaker when your 5h session limit resets? [y/N] " ans || ans=""
+    if [[ "$ans" =~ ^[Yy]$ ]]; then
+        upsert_config_key chime on
+        echo "  Set: chime = on"
+    elif [ "$cur" = "on" ]; then
+        upsert_config_key chime off
+        echo "  Set: chime = off"
+    else
+        echo "  Chime off (default)."
+    fi
+}
 
 echo "=== Clawdmeter macOS install ==="
 echo ""
 
-echo "[1/5] Checking prerequisites..."
+echo "[1/6] Checking prerequisites..."
 command -v curl >/dev/null || { echo "Error: curl is required"; exit 1; }
 
 # The daemon uses Python 3.10+ syntax (PEP 604 `X | None`). macOS ships an
@@ -59,7 +178,7 @@ fi
 echo "  OK"
 echo ""
 
-echo "[2/5] Creating Python virtualenv at daemon/.venv ..."
+echo "[2/6] Creating Python virtualenv at daemon/.venv ..."
 # Recreate the venv if it's missing or was built with an interpreter older
 # than 3.10 (e.g. a previous run that picked the system python3).
 if [ -d "$VENV_DIR" ] && ! py_ge_310 "$VENV_DIR/bin/python"; then
@@ -75,7 +194,7 @@ PYTHON_BIN="$VENV_DIR/bin/python"
 echo "  OK ($PYTHON_BIN)"
 echo ""
 
-echo "[3/5] Rendering launchd plist..."
+echo "[3/6] Rendering launchd plist..."
 mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
 sed \
     -e "s|__PYTHON_BIN__|${PYTHON_BIN}|g" \
@@ -88,7 +207,15 @@ sed \
 echo "  Installed: $PLIST_DST"
 echo ""
 
-echo "[4/5] Bluetooth permission check..."
+# Interactive daemon configuration: which plans to poll, plus the optional
+# clock display and session-reset chime. All re-read by the daemon each poll.
+echo "[4/6] Configuring the daemon..."
+configure_config_dirs
+configure_clock
+configure_chime
+echo ""
+
+echo "[5/6] Bluetooth permission check..."
 echo "  On first run the daemon will trigger a Bluetooth permission prompt."
 echo "  macOS only prompts for foreground processes — so we'll run it"
 echo "  interactively once below. Press Ctrl+C after you see 'Scanning...'"
@@ -123,7 +250,7 @@ if command -v blueutil >/dev/null 2>&1; then
 fi
 echo ""
 
-echo "[5/5] Loading launchd service..."
+echo "[6/6] Loading launchd service..."
 launchctl unload "$PLIST_DST" 2>/dev/null || true
 launchctl load -w "$PLIST_DST"
 echo "  Loaded."

--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,129 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SERVICE_NAME="claude-usage-daemon"
 SERVICE_FILE="$SCRIPT_DIR/daemon/$SERVICE_NAME.service"
 USER_SERVICE_DIR="$HOME/.config/systemd/user"
+CONFIG_FILE="$HOME/.config/claude-usage-monitor/config"
+
+# Render an absolute path under $HOME back to a ~ form for tidy config entries.
+_tilde() { case "$1" in "$HOME"/*) echo "~${1#"$HOME"}";; *) echo "$1";; esac; }
+
+# Echo the current value of a config key (trimmed), or empty if unset.
+current_config_value() {
+    [ -f "$CONFIG_FILE" ] || return 0
+    grep -E "^[[:space:]]*$1[[:space:]]*=" "$CONFIG_FILE" | tail -1 \
+        | tr -d '\r' \
+        | sed -E "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*//; s/[[:space:]]*(#.*)?$//"
+}
+
+# Insert or replace `key = value`, preserving every other key in the file.
+upsert_config_key() {
+    local key="$1" value="$2"
+    mkdir -p "$(dirname "$CONFIG_FILE")"
+    touch "$CONFIG_FILE"
+    grep -vE "^[[:space:]]*$key[[:space:]]*=" "$CONFIG_FILE" > "$CONFIG_FILE.tmp" 2>/dev/null || true
+    mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+    echo "$key = $value" >> "$CONFIG_FILE"
+}
+
+# Detect ~/.claude* config dirs that hold credentials and, if more than one is
+# found, let the user pick which plans to show. The daemon polls all chosen dirs
+# and displays whichever is active. Writes the `config_dirs` key, preserving any
+# other keys already in the config file. No-op (default ~/.claude) if only one
+# dir exists or the user opts out.
+configure_config_dirs() {
+    local -a candidates=()
+    local d
+    for d in "$HOME"/.claude*; do
+        [ -d "$d" ] && [ -f "$d/.credentials.json" ] && candidates+=("$d")
+    done
+
+    if [ ${#candidates[@]} -le 1 ]; then
+        echo "  One Claude config dir found — using the default (~/.claude)."
+        return 0
+    fi
+
+    echo "  Found multiple Claude config dirs. The daemon can poll several plans"
+    echo "  and show whichever one you're actively using."
+    if [ ! -t 0 ]; then
+        local list=""
+        for d in "${candidates[@]}"; do list="${list:+$list, }$(_tilde "$d")"; done
+        echo "  Non-interactive shell — skipping. To enable, add to $CONFIG_FILE:"
+        echo "    config_dirs = $list"
+        return 0
+    fi
+
+    local -a selected=()
+    local ans
+    for d in "${candidates[@]}"; do
+        if [ "$d" = "$HOME/.claude" ]; then
+            read -r -p "  Poll $(_tilde "$d")? [Y/n] " ans || ans=""
+            if [[ ! "$ans" =~ ^[Nn]$ ]]; then selected+=("$d"); fi
+        else
+            read -r -p "  Also poll $(_tilde "$d")? [y/N] " ans || ans=""
+            if [[ "$ans" =~ ^[Yy]$ ]]; then selected+=("$d"); fi
+        fi
+    done
+
+    if [ ${#selected[@]} -eq 0 ]; then
+        echo "  Nothing selected — leaving the default (~/.claude)."
+        return 0
+    fi
+    if [ ${#selected[@]} -eq 1 ] && [ "${selected[0]}" = "$HOME/.claude" ]; then
+        echo "  Default (~/.claude) only — no config change needed."
+        return 0
+    fi
+
+    local joined="" sd
+    for sd in "${selected[@]}"; do joined="${joined:+$joined, }$(_tilde "$sd")"; done
+
+    upsert_config_key config_dirs "$joined"
+    echo "  Wrote: config_dirs = $joined"
+    echo "  -> $CONFIG_FILE"
+}
+
+# Offer the optional clock display (shown in place of the "Usage" title). Only
+# writes the key when it actually changes the current/default value, so a user
+# pressing Enter through the installer never clutters the config with defaults.
+configure_clock() {
+    [ -t 0 ] || return 0
+    local ans cur
+    cur=$(current_config_value clock)
+    read -r -p "  Show a clock instead of the \"Usage\" title? [off/auto/12/24] (default off) " ans || ans=""
+    ans=$(echo "$ans" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+    [ -z "$ans" ] && ans="off"
+    case "$ans" in
+        off|auto|12|24) ;;
+        *) echo "  Unrecognized '$ans' — leaving clock unchanged."; return 0 ;;
+    esac
+    if [ "$ans" = "off" ] && { [ -z "$cur" ] || [ "$cur" = "off" ]; }; then
+        echo "  Clock off (default)."
+        return 0
+    fi
+    upsert_config_key clock "$ans"
+    echo "  Set: clock = $ans"
+}
+
+# Offer the optional session-reset chime (sound through the board speaker).
+configure_chime() {
+    [ -t 0 ] || return 0
+    local ans cur
+    cur=$(current_config_value chime)
+    read -r -p "  Chime through the speaker when your 5h session limit resets? [y/N] " ans || ans=""
+    if [[ "$ans" =~ ^[Yy]$ ]]; then
+        upsert_config_key chime on
+        echo "  Set: chime = on"
+    elif [ "$cur" = "on" ]; then
+        upsert_config_key chime off
+        echo "  Set: chime = off"
+    else
+        echo "  Chime off (default)."
+    fi
+}
 
 echo "=== Claude Usage Tracker - Install ==="
 echo ""
 
 # Check dependencies
-echo "[1/3] Checking dependencies..."
+echo "[1/4] Checking dependencies..."
 for cmd in curl awk bluetoothctl busctl; do
     command -v "$cmd" >/dev/null || { echo "Error: $cmd is required but not installed"; exit 1; }
 done
@@ -18,14 +135,22 @@ echo "  All dependencies found"
 echo ""
 
 # Install systemd user service with resolved path
-echo "[2/3] Installing systemd user service..."
+echo "[2/4] Installing systemd user service..."
 mkdir -p "$USER_SERVICE_DIR"
 DAEMON_BIN="$SCRIPT_DIR/daemon/$SERVICE_NAME.sh"
 sed "s|DAEMON_PATH|${DAEMON_BIN}|g" "$SERVICE_FILE" > "$USER_SERVICE_DIR/$SERVICE_NAME.service"
 systemctl --user daemon-reload
 
+# Interactive daemon configuration: which plans to poll, plus the optional
+# clock display and session-reset chime. All re-read by the daemon each poll.
+echo "[3/4] Configuring the daemon..."
+configure_config_dirs
+configure_clock
+configure_chime
+echo ""
+
 # Enable service
-echo "[3/3] Enabling service..."
+echo "[4/4] Enabling service..."
 systemctl --user enable "$SERVICE_NAME"
 
 echo ""


### PR DESCRIPTION
🤖 AI Generated:

Turns the Linux installer's setup step into a small config wizard:

- Detects `~/.claude*` dirs with credentials; when more than one exists, lets you pick which plans to poll → writes `config_dirs`. No-op for a single dir or a non-interactive shell.
- Prompts for the optional **clock** (`off/auto/12/24`) and session-reset **chime** (`y/N`) — existing daemon options (#72) that previously had to be hand-edited.

All writes go through one upsert helper that preserves other keys and is idempotent; pressing Enter through the defaults writes nothing.

**Depends on** #95 (the multi config-dir daemon) for `config_dirs` to do anything — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
