### PR TITLE
daemon: scope OAuth token read to claudeAiOauth (fix invalid Bearer when other OAuth integrations present)

### DIFF
--- a/daemon/claude-usage-daemon.sh
+++ b/daemon/claude-usage-daemon.sh
@@ -58,9 +58,14 @@ read_config_dirs() {
 }
 
 # Read the OAuth access token from a specific config dir's credentials file.
+# The file can hold many "accessToken" fields — one per OAuth integration (MCP
+# servers, design tools, etc.) — so we must isolate the claudeAiOauth object
+# first and pull ITS accessToken. A bare grep for "accessToken" would return
+# every token concatenated, yielding an invalid Bearer header and constant 401s.
 read_token_for() {
     local dir="$1"
-    grep -o '"accessToken":"[^"]*"' "$dir/.credentials.json" 2>/dev/null | cut -d'"' -f4
+    grep -o '"claudeAiOauth"[[:space:]]*:[[:space:]]*{[^}]*}' "$dir/.credentials.json" 2>/dev/null \
+        | grep -o '"accessToken":"[^"]*"' | head -1 | cut -d'"' -f4
 }
 
 # Read the `chime` option from the config file. Echoes one of: off|on.

--- a/daemon/tests/test_bash_token.sh
+++ b/daemon/tests/test_bash_token.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Regression test for read_token_for() in claude-usage-daemon.sh.
+#
+# A real ~/.claude/.credentials.json holds many "accessToken" fields — one per
+# OAuth integration (MCP servers, design tools) plus the Claude subscription
+# token under claudeAiOauth. read_token_for() must return ONLY the claudeAiOauth
+# token; concatenating all of them produces an invalid Bearer header and every
+# API call 401s (symptom: device shows "unknown"/0% forever).
+set -u
+
+DAEMON="$(dirname "$0")/../claude-usage-daemon.sh"
+
+# Pull just the read_token_for function body out of the daemon (sourcing the
+# whole file would start the daemon loop) and eval it here.
+eval "$(awk '/^read_token_for\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$DAEMON")"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cat > "$TMP/.credentials.json" <<'JSON'
+{"mcpOAuth":{"contentful|abc":{"accessToken":"mcp-contentful-TOKEN","expiresAt":0}},
+"claudeAiOauth":{"accessToken":"sk-ant-oat01-CLAUDE-REAL","refreshToken":"rt","expiresAt":1783620177377,"scopes":["a","b"],"subscriptionType":"max"},
+"designOauth":{"accessToken":"sk-ant-oat01-DESIGN-WRONG","refreshToken":"rt2"}}
+JSON
+
+got="$(read_token_for "$TMP")"
+want="sk-ant-oat01-CLAUDE-REAL"
+
+if [ "$got" = "$want" ]; then
+    echo "PASS: read_token_for returned the claudeAiOauth token"
+    exit 0
+else
+    echo "FAIL: expected [$want]"
+    echo "      got      [$got]"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

`read_token_for()` in `daemon/claude-usage-daemon.sh` extracts the Claude OAuth token with:

```bash
grep -o '"accessToken":"[^"]*"' "$dir/.credentials.json" | cut -d'"' -f4
```

`~/.claude/.credentials.json` holds a separate `"accessToken"` field for **every** OAuth integration — MCP servers (Stripe, Contentful, etc.), design tools, plus the Claude subscription token under `claudeAiOauth`. The un-scoped grep returns *all* of them, so `$token` becomes several tokens joined by newlines and the resulting `Authorization: Bearer …` header is invalid.

Every Anthropic API call then returns `401` with **no `anthropic-ratelimit-*` headers**, so the daemon drops into its empty enterprise fallback and the device displays `"unknown"` / `0%` indefinitely. Setups predating the addition of any other OAuth integration are unaffected, which is why this surfaces only after a user connects an MCP server.

## Fix

Isolate the `claudeAiOauth` object first, then pull its `accessToken`:

```bash
grep -o '"claudeAiOauth"[[:space:]]*:[[:space:]]*{[^}]*}' "$dir/.credentials.json" \
    | grep -o '"accessToken":"[^"]*"' | head -1 | cut -d'"' -f4
```

No new dependencies. The Python daemons already parse the credentials structurally and select the nested `claudeAiOauth` object, so they're unaffected and unchanged.

## Test

Adds `daemon/tests/test_bash_token.sh`, which extracts the real `read_token_for()` from the daemon and runs it against a realistic multi-token fixture (MCP + claudeAiOauth + design). Fails on the old code (returns all three tokens), passes on the new.

## Verification

Reproduced live: before the fix the daemon sent `{"s":0,...,"st":"unknown","acct":"ent",...}` on every poll; the direct API call returned `HTTP 401`. After the fix the same call returns `HTTP 200` with full rate-limit headers and the daemon sends real data — `{"s":9,"sr":81,"w":54,"wr":4821,"st":"allowed","acct":"pro",...}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)