### PR TITLE
Fix: guard billing period against pre-1970 reset_ts (Windows OSError)

### DIFF
--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -450,6 +450,12 @@ def _billing_period_info(now: float, reset_ts: str) -> dict:
         period_end = float(reset_ts)
     except ValueError:
         return {"tp": 0, "pd": 30}
+    if period_end <= 0:
+        # reset_ts defaults to "0" when the overage-reset header is absent.
+        # fromtimestamp(0) is 1970; stepping a month back lands in 1969, and
+        # datetime.timestamp() raises OSError for pre-1970 dates on Windows.
+        # Benign on macOS/Linux, but guard here too to keep the daemons parallel.
+        return {"tp": 0, "pd": 30}
     dt_end = datetime.datetime.fromtimestamp(period_end)
     prev_month = dt_end.month - 1 or 12
     prev_year = dt_end.year if dt_end.month > 1 else dt_end.year - 1

--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -260,6 +260,13 @@ def _billing_period_info(now: float, reset_ts: str) -> dict:
         period_end = float(reset_ts)
     except ValueError:
         return {"tp": 0, "pd": 30, "rd": ""}
+    if period_end <= 0:
+        # reset_ts defaults to "0" whenever the overage-reset header is absent
+        # (e.g. a 200 that simply carries no billing headers). fromtimestamp(0)
+        # is 1970; stepping one month back lands in 1969, and datetime.timestamp()
+        # raises OSError for pre-1970 dates on Windows — taking the whole poll
+        # loop down. Bail out to the neutral default instead.
+        return {"tp": 0, "pd": 30, "rd": ""}
     dt_end = datetime.datetime.fromtimestamp(period_end)
     prev_month = dt_end.month - 1 or 12
     prev_year = dt_end.year if dt_end.month > 1 else dt_end.year - 1


### PR DESCRIPTION
## What

`_billing_period_info` crashes on Windows when the overage-reset header is absent. `reset_ts` then defaults to `"0"`, so the function builds from the 1970 epoch, steps one month back to 1969, and `datetime.timestamp()` raises `OSError: [Errno 22]` for pre-1970 dates on Windows — which takes down the whole poll loop.

## Fix

Return the neutral default when `period_end <= 0`, before the date math. The same guard is mirrored in the macOS daemon for parity (benign there, since Unix `timestamp()` accepts pre-1970 dates, but keeps the two daemons identical).

## Test

This makes the **existing** `test_windows_poll.py::test_missing_utilization_headers_default_to_zero` pass on Windows — no new test is added. That file goes 16 → 17 passing on Windows; it already passes on Linux CI, where pre-1970 timestamps don't raise.
