### PR TITLE
fix(amoled-18): amp_enable must not drive EXIO2 — it kills FT3168 touch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ See `~/.claude/projects/.../memory/` files for persistent context (user is an em
 
 ## Recent session highlights
 
+- **AMOLED-1.8 chime verified on hardware + EXIO2 touch-kill fix (2026-07-13).** The 1.8's `amp_enable` hook drove both GPIO 46 and XCA9554 EXIO2 ("the unused one is harmless") — but pulling EXIO2 low takes the FT3168 off the I2C bus (chip stops ACKing; IDF reports it as `ESP_ERR_INVALID_STATE`, which reads like a driver wedge and cost a long I2S red-herring chase). Amp enable is GPIO 46 only; EXIO2 must stay HIGH. Chime, touch, buttons, and BLE bond persistence all verified on a real 1.8.
 - **Device-abstraction refactor (2026-05-18).** All board-conditional code moved out of shared files into `boards/<name>/` and behind a HAL in `hal/`. ~30 `#ifdef BOARD_*` blocks went to zero. UI is responsive via `compute_layout()` driven by `board_caps()`. New ports add a folder + a PlatformIO env — no shared file edits.
 - Added second board port: Waveshare AMOLED-1.8 (368×448 portrait, SH8601, FT3168, XCA9554 IO expander).
 - Migrated from Panlee SC01 Plus (480×320 IPS) to Waveshare 2.16" AMOLED (480×480 square). Full hardware/library swap.

--- a/firmware/src/boards/waveshare_amoled_18/board.h
+++ b/firmware/src/boards/waveshare_amoled_18/board.h
@@ -41,15 +41,16 @@
 #define XCA9554_ADDR         0x20
 #define IOX_PIN_TP_RST       0     // EXIO0 → touch reset (active LOW)
 #define IOX_PIN_LCD_RST      1     // EXIO1 → display reset (active LOW)
-#define IOX_PIN_PA_EN        2     // EXIO2 → audio amp enable
+#define IOX_PIN_PA_EN        2     // EXIO2 — must stay HIGH; driving it low kills
+                                   // FT3168 touch (it is NOT a usable amp switch,
+                                   // the amp enable is SND_PA_PIN / GPIO 46)
 #define IOX_PIN_PWR_BTN      4     // EXIO4 → PWR button input, active HIGH
 
 // ---- Audio (ES8311 mono codec + speaker, I2S) ----
-// Same ES8311 + I2S path as the 2.16, different MCLK pin (16 vs 42). Amp enable
-// is ambiguous across 1.8 hardware revisions: Waveshare's V2 example drives a
-// plain GPIO 46, while this board's XCA9554 also exposes an amp-enable on EXIO2
-// (IOX_PIN_PA_EN above). sound.cpp drives BOTH to be revision-safe. Pins from
-// Waveshare's factory 15_ES8311 example. Untested on hardware in this repo.
+// Same ES8311 + I2S path as the 2.16, different MCLK pin (16 vs 42). Pins from
+// Waveshare's factory 15_ES8311 example, verified on hardware. Amp enable is
+// GPIO 46 only — do NOT use IOX_PIN_PA_EN (EXIO2) as an amp switch; pulling it
+// low kills the FT3168 touch controller on this revision (see sound.cpp).
 #define SND_I2S_MCLK         16
 #define SND_I2S_BCLK         9
 #define SND_I2S_WS           45     // LRCK

--- a/firmware/src/boards/waveshare_amoled_18/sound.cpp
+++ b/firmware/src/boards/waveshare_amoled_18/sound.cpp
@@ -5,20 +5,21 @@
 
 #include <Arduino.h>
 #include "../../chime.h"
-#include "io_expander.h"
 
 // AMOLED-1.8: ES8311 codec + speaker. Codec/I2S/playback live in the shared
 // chime engine (../../chime.cpp); this file supplies the board's pins and the
-// amp-enable hook. The amp enable differs by 1.8 hardware revision, so we drive
-// BOTH the direct GPIO (V2) and the XCA9554 EXIO2 line (see board.h) — driving
-// the unused one is harmless. io_expander is already up (board_init() ran it).
+// amp-enable hook. io_expander is already up (board_init() ran it).
 //
-// NOTE: not verified on hardware in this repo (no 1.8 board connected); the
-// dual amp-enable is the belt-and-suspenders fallback for that.
+// The amp enable is GPIO 46 ONLY. Do NOT drive XCA9554 EXIO2 low here: on the
+// SH8601+FT3168 revision, pulling EXIO2 low takes the FT3168 touch controller
+// off the I2C bus until EXIO2 is raised again (verified on hardware by
+// bisection — an earlier "drive both amp candidates, the unused one is
+// harmless" version of this hook silently killed touch for the whole session,
+// since amp_enable(false) runs at chime_init to park the amp off).
+// io_expander_init() parks EXIO2 HIGH and it must stay that way.
 
 static void amp_enable(bool on) {
-    digitalWrite(SND_PA_PIN, on ? HIGH : LOW);   // V2: direct GPIO 46
-    io_expander_set(IOX_PIN_PA_EN, on);          // V1: XCA9554 EXIO2
+    digitalWrite(SND_PA_PIN, on ? HIGH : LOW);   // GPIO 46
 }
 
 void sound_hal_init(void) {


### PR DESCRIPTION
## Summary

On the ESP32-S3-Touch-AMOLED-1.8 (SH8601 + FT3168 revision), touch has been dead from boot since the chime landed (2f94248). Root cause: the board's `amp_enable` hook drives **both** amp-enable candidates — GPIO 46 and XCA9554 **EXIO2** — on the assumption that "driving the unused one is harmless." It isn't: **pulling EXIO2 low takes the FT3168 touch controller off the I2C bus** until the line goes high again. Since `chime_init()` calls `amp_enable(false)` at boot to park the amp off, EXIO2 stayed low and touch never worked.

Fix: drive GPIO 46 only. EXIO2 is parked HIGH by `io_expander_init()` and must stay that way (this is also what the pre-chime firmware always did).

## How it was found (hardware bisection on a real 1.8)

The failure is deceptive: once the FT3168 vanishes, IDF's `i2c_master` returns `ESP_ERR_INVALID_STATE` on every transaction to 0x38, which looks like a wedged I2C driver rather than an unpowered chip. Bisection results:

| Build | Touch probe |
|---|---|
| chime fully skipped | ✅ `FT3168 ID=0x03` |
| I2S up, codec skipped (real pins) | ❌ |
| I2S on parked GPIOs 17/18/13 | ❌ |
| **amp lines only, no I2S/codec** | ❌ ← poison confirmed |
| GPIO 46 only, EXIO2 untouched | ✅ |
| **this PR (full chime + fix)** | ✅ |

A probe matrix after the failure showed 0x18/0x20/0x34 answering normally on both the raw HAL and `Wire` paths while only 0x38 failed — i.e. the bus and driver were fine, the chip was gone.

## Verified on hardware (SH8601 + FT3168 rev)

- Boot log clean: `chime: ES8311 ready` **and** `Touch FT3168 ID=0x03`, zero I2C errors
- Tap-to-switch UI and PWR button work with the chime engine fully initialized
- Chime audibly plays through the speaker via the real BLE path (session-reset payload with `"c":1`), so the "untested on hardware" caveat in sound.cpp is now covered
- BLE bond + owner persistence across power cycles unaffected

CLAUDE.md gets a session-highlights entry documenting the EXIO2 behavior so future sessions don't re-chase the I2S red herring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)