### PR TITLE
fix(windows): end the BLE reconnect churn — widen supervision timeout (2s→6s) + crash-proof the daemon

### DIFF
--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -267,12 +267,21 @@ def _billing_period_info(now: float, reset_ts: str) -> dict:
         # raises OSError for pre-1970 dates on Windows — taking the whole poll
         # loop down. Bail out to the neutral default instead.
         return {"tp": 0, "pd": 30, "rd": ""}
-    dt_end = datetime.datetime.fromtimestamp(period_end)
-    prev_month = dt_end.month - 1 or 12
-    prev_year = dt_end.year if dt_end.month > 1 else dt_end.year - 1
-    prev_day = min(dt_end.day, calendar.monthrange(prev_year, prev_month)[1])
-    dt_start = dt_end.replace(year=prev_year, month=prev_month, day=prev_day)
-    period_start = dt_start.timestamp()
+    try:
+        dt_end = datetime.datetime.fromtimestamp(period_end)
+        prev_month = dt_end.month - 1 or 12
+        prev_year = dt_end.year if dt_end.month > 1 else dt_end.year - 1
+        prev_day = min(dt_end.day, calendar.monthrange(prev_year, prev_month)[1])
+        dt_start = dt_end.replace(year=prev_year, month=prev_month, day=prev_day)
+        period_start = dt_start.timestamp()
+    except (OSError, OverflowError, ValueError):
+        # Belt-and-braces beyond the <= 0 guard above (#104): Windows
+        # datetime.timestamp()/fromtimestamp() also raise OSError(22)/
+        # OverflowError/ValueError for out-of-range NON-zero values (e.g. a
+        # far-future "99999999999999" header, which overflows fromtimestamp).
+        # Garbage must never crash the daemon thread — degrade to the safe
+        # default instead (field report: OSError(22) killed the poll loop).
+        return {"tp": 0, "pd": 30, "rd": ""}
     period_len = period_end - period_start
     if period_len <= 0:
         return {"tp": 0, "pd": 30, "rd": ""}
@@ -540,8 +549,15 @@ async def connect_and_run(device, stop_event: asyncio.Event, tray_state=None) ->
         )
         try:
             await client.connect()
-        except (BleakError, asyncio.TimeoutError) as e:
-            log(f"Connection attempt {attempt + 1}/{CONNECT_RETRIES} failed: {e}")
+        except (BleakError, OSError, asyncio.TimeoutError, AssertionError) as e:
+            # WinRT service discovery inside connect() can surface a raw OSError
+            # (WinError) or even a bare AssertionError from bleak's FutureLike
+            # (assert self._result) when the peer drops the link mid-discovery —
+            # neither is wrapped as BleakError. Treat them as a normal failed
+            # attempt so the D-01 retry loop handles them, instead of letting an
+            # uncaught exception kill the daemon thread (the "daemon crashed"
+            # tray toast + silent polling stop, field report).
+            log(f"Connection attempt {attempt + 1}/{CONNECT_RETRIES} failed: {type(e).__name__}: {e}")
             try:
                 await client.disconnect()
             except BleakError:
@@ -625,7 +641,10 @@ async def connect_and_run(device, stop_event: asyncio.Event, tray_state=None) ->
         # so swallow both; the link tears down regardless once we exit.
         try:
             await client.disconnect()
-        except (BleakError, OSError):
+        except (BleakError, OSError, AssertionError):
+            # bleak's WinRT disconnect() also has bare asserts (e.g. assert char
+            # while tearing down notifications on an already-gone peer); swallow
+            # it too — the link tears down regardless once we exit.
             pass
 
     log("Device disconnected" if not stop_event.is_set() else "Stopping")

--- a/daemon/tests/test_windows_poll.py
+++ b/daemon/tests/test_windows_poll.py
@@ -33,8 +33,19 @@ def _make_mock_response(status_code=200, headers=None):
 
 
 def _run(coro):
-    """Run a coroutine synchronously for synchronous test functions."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    """Run a coroutine synchronously for synchronous test functions.
+
+    Use a fresh event loop per call rather than asyncio.get_event_loop():
+    on Python 3.12 that helper is deprecated and, once another test file
+    runs asyncio.run() (which closes the process-default loop), it returns
+    a closed loop here and every poll test raises RuntimeError. A private
+    loop keeps these tests order-independent in the full suite.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 # ---------------------------------------------------------------------------

--- a/daemon/tests/test_windows_token.py
+++ b/daemon/tests/test_windows_token.py
@@ -141,6 +141,11 @@ def test_read_expiry_non_dict_json_returns_unknown(tmp_path, monkeypatch):
 
 # --- WR-02: D-06 redaction requirement must be tested ---
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="asserts the Linux/WSL 'WinRT unavailable' stderr warning, which is "
+    "correctly suppressed on native Windows (sys.platform == 'win32')",
+)
 def test_main_emits_linux_warning(monkeypatch):
     """__main__ prints a non-fatal stderr warning on non-Windows platforms (new async runner).
 
@@ -172,6 +177,11 @@ def test_main_emits_linux_warning(monkeypatch):
         )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="asserts the Linux/WSL 'WinRT unavailable' stderr warning, which is "
+    "correctly suppressed on native Windows (sys.platform == 'win32')",
+)
 def test_main_emits_linux_warning_before_loop(monkeypatch):
     """__main__ stderr warning appears before the async scan loop starts on Linux/WSL."""
     import signal as _signal

--- a/daemon/tray_windows.py
+++ b/daemon/tray_windows.py
@@ -190,19 +190,36 @@ def main() -> None:
     ts = TrayState()
     icon = pystray.Icon("Clawdmeter", images["scanning"], "Clawdmeter")
 
-    # --- background thread: asyncio loop ---
+    # Set by the Quit handler so the supervisor below knows a clean stop was
+    # requested and must NOT resurrect the loop.
+    _quit_requested = threading.Event()
+
+    # --- background thread: asyncio loop (supervised, auto-restart on crash) ---
     def _run_daemon() -> None:
-        # daemon=True thread: an unhandled exception here would vanish silently
-        # and freeze the tray on its last state forever (the field "frozen tray"
-        # failure mode). Surface it instead — log the traceback to the rotating
-        # file and flip the tray to an actionable error state.
-        try:
-            _asyncio.run(daemon_main(tray_state=ts))
-        except Exception as e:  # last-resort thread guard
-            import traceback
-            daemon_log(f"Daemon thread crashed: {e!r}")
-            daemon_log(traceback.format_exc())
-            ts.set_error(f"daemon crashed: {type(e).__name__}")
+        # A crash used to END this daemon=True thread for good: polling stopped
+        # silently and the tray froze on its last state until the user manually
+        # relaunched (the field "frozen tray" / "sticky error" mode — one transient
+        # bleak assert turned into an outage). Now we SUPERVISE it: log the
+        # traceback, flip the tray to an actionable error, then restart the loop
+        # with capped backoff. A CLEAN return means Quit was requested (main()'s
+        # loop exited on stop_event), so we stay down and do NOT restart.
+        backoff = 2
+        while not _quit_requested.is_set():
+            try:
+                _asyncio.run(daemon_main(tray_state=ts))
+                return  # clean exit == Quit requested; stay down
+            except Exception as e:  # last-resort thread guard
+                import traceback
+                daemon_log(f"Daemon thread crashed: {e!r}")
+                daemon_log(traceback.format_exc())
+                ts.set_error(f"daemon crashed: {type(e).__name__}")
+            if _quit_requested.is_set():
+                return
+            daemon_log(f"Restarting daemon loop in {backoff}s after crash")
+            # Interruptible sleep: a Quit during backoff wakes us immediately.
+            if _quit_requested.wait(timeout=backoff):
+                return
+            backoff = min(backoff * 2, 30)
 
     daemon_thread = threading.Thread(target=_run_daemon, daemon=True)
     daemon_thread.start()
@@ -219,6 +236,10 @@ def main() -> None:
         # the device sits frozen on stale data instead of returning to its waiting
         # screen (SC#3 field report). The timeout caps the block so Quit can never
         # hang if a WinRT disconnect wedges (rare) — we exit anyway as a fallback.
+        #
+        # Set _quit_requested FIRST so the supervisor loop in _run_daemon never
+        # resurrects the daemon after we signal stop (Quit must be final).
+        _quit_requested.set()
         if ts.loop is not None and ts.stop_event is not None:
             ts.loop.call_soon_threadsafe(ts.stop_event.set)
             daemon_thread.join(timeout=6.0)

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -27,6 +27,19 @@ build_flags =
     -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
     -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
     -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    ; Peripheral Preferred Connection Parameters (GAP 0x2A04) — the accessory's
+    ; steady-state preference per Microsoft's Bluetooth accessory guidelines:
+    ; interval 15-30ms (HID-snappy), latency 0, supervision timeout 6s.
+    ; Captured on hardware: Windows honors a long timeout (9.6s) while only its
+    ; HID driver holds the link, but clamps to 2s whenever an app GATT session
+    ; (the daemon) is active — PPCP documents our preference and governs the
+    ; HID-only steady state; it does NOT override that 2s clamp. Units:
+    ; interval ×1.25ms, timeout ×10ms. Windows caches GATT per bond, so a
+    ; re-pair is needed for changes here to be seen.
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MIN_CONN_INTERVAL=12
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MAX_CONN_INTERVAL=24
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SLAVE_LATENCY=0
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SUPERVISION_TMO=600
     ; LVGL config via build flags
     -DLV_CONF_SKIP
     -DLV_COLOR_DEPTH=16
@@ -84,6 +97,12 @@ build_flags =
     -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
     -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
     -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    ; Peripheral Preferred Connection Parameters — see the waveshare_amoled_216
+    ; env for the full rationale (Windows supervision-timeout churn fix).
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MIN_CONN_INTERVAL=12
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MAX_CONN_INTERVAL=24
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SLAVE_LATENCY=0
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SUPERVISION_TMO=600
     ; LVGL config via build flags
     -DLV_CONF_SKIP
     -DLV_COLOR_DEPTH=16
@@ -151,6 +170,12 @@ build_flags =
     -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
     -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
     -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    ; Peripheral Preferred Connection Parameters — see the waveshare_amoled_216
+    ; env for the full rationale (Windows supervision-timeout churn fix).
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MIN_CONN_INTERVAL=12
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MAX_CONN_INTERVAL=24
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SLAVE_LATENCY=0
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SUPERVISION_TMO=600
     -DLV_CONF_SKIP
     -DLV_COLOR_DEPTH=16
     -DLV_USE_LOG=0
@@ -219,6 +244,12 @@ build_flags =
     -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
     -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
     -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    ; Peripheral Preferred Connection Parameters — see the waveshare_amoled_216
+    ; env for the full rationale (Windows supervision-timeout churn fix).
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MIN_CONN_INTERVAL=12
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MAX_CONN_INTERVAL=24
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SLAVE_LATENCY=0
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SUPERVISION_TMO=600
     -DLV_CONF_SKIP
     -DLV_COLOR_DEPTH=16
     -DLV_USE_LOG=0

--- a/firmware/src/ble.cpp
+++ b/firmware/src/ble.cpp
@@ -64,6 +64,14 @@ static NimBLECharacteristic* req_char = nullptr;
 
 static ble_state_t state = BLE_STATE_INIT;
 static bool need_advertise = false;
+
+// One-shot supervision-timeout pushback (see onConnParamsUpdate). Written by
+// NimBLE host-task callbacks, consumed by ble_tick() on the loop task.
+static const uint16_t CONN_HANDLE_NONE  = 0xFFFF;
+static const uint16_t DESIRED_TIMEOUT   = 600;   // ×10ms = 6s, matches PPCP
+static volatile uint16_t param_fix_handle = CONN_HANDLE_NONE;  // pending retry
+static volatile uint32_t param_fix_at_ms  = 0;                 // when to send it
+static volatile uint16_t param_fix_spent  = CONN_HANDLE_NONE;  // one per connection
 static char rx_buf[BLE_BUF_SIZE];
 static volatile bool data_ready = false;
 static volatile bool has_received_data = false;
@@ -175,6 +183,13 @@ class ServerCallbacks : public NimBLEServerCallbacks {
         Serial.printf("BLE: connected from %s (active=%u)\n",
             info.getAddress().toString().c_str(),
             (unsigned)s->getConnectedCount());
+        // Log negotiated link timing — the difference between guessing and
+        // knowing when debugging disconnects (e.g. reason=520 supervision
+        // timeouts are only explainable next to the negotiated timeout).
+        // Units: interval ×1.25ms, timeout ×10ms, latency = skippable events.
+        Serial.printf("BLE: connparams itvl=%u(%.2fms) lat=%u timeout=%u(%ums)\n",
+            info.getConnInterval(), info.getConnInterval() * 1.25f,
+            info.getConnLatency(), info.getConnTimeout(), info.getConnTimeout() * 10);
         // Keep advertising while a connection slot is still free so a second
         // central (e.g. the host daemon alongside an OS-held HID link) can
         // discover and connect. NimBLE auto-stops advertising on each accept.
@@ -187,8 +202,34 @@ class ServerCallbacks : public NimBLEServerCallbacks {
         // Only flip the UI state to DISCONNECTED when the last client leaves.
         if (s->getConnectedCount() == 0) state = BLE_STATE_DISCONNECTED;
         need_advertise = true;
+        // Drop any pending/spent param pushback for this handle — NimBLE
+        // reuses conn handles, so stale state would leak onto the next link.
+        if (param_fix_handle == info.getConnHandle()) param_fix_handle = CONN_HANDLE_NONE;
+        if (param_fix_spent  == info.getConnHandle()) param_fix_spent  = CONN_HANDLE_NONE;
         Serial.printf("BLE: disconnected (reason=%d, remaining=%u)\n",
             reason, (unsigned)s->getConnectedCount());
+    }
+
+    // Centrals re-negotiate parameters mid-connection. Windows in particular
+    // clamps the supervision timeout to 2s once an app GATT session goes
+    // active (captured on hardware; it honors 9.6s while only its HID driver
+    // holds the link) — and a 2s window is tight enough that ordinary radio
+    // gaps kill the link (HCI 0x208 → reason=520), which was the constant
+    // daemon reconnect churn. Push back ONCE per connection: schedule a
+    // deferred LL connection-parameter request for the same interval range but
+    // a 6s timeout (the mechanism Microsoft's accessory guidelines prescribe).
+    // Deferred ~2s so it can't race the central's own in-flight update
+    // transaction (Windows has a documented late-instant bug there), and
+    // one-shot so a central that re-clamps doesn't trigger an update war.
+    void onConnParamsUpdate(NimBLEConnInfo& info) override {
+        Serial.printf("BLE: connparams update itvl=%u(%.2fms) lat=%u timeout=%u(%ums)\n",
+            info.getConnInterval(), info.getConnInterval() * 1.25f,
+            info.getConnLatency(), info.getConnTimeout(), info.getConnTimeout() * 10);
+        if (info.getConnTimeout() < DESIRED_TIMEOUT &&
+            info.getConnHandle() != param_fix_spent) {
+            param_fix_handle = info.getConnHandle();
+            param_fix_at_ms  = millis() + 2000;
+        }
     }
 
     // Lock the board to a single owner machine. The first machine to bond
@@ -198,6 +239,14 @@ class ServerCallbacks : public NimBLEServerCallbacks {
         std::string id = info.getIdAddress().toString();
         Serial.printf("BLE: auth complete peer=%s bonded=%d enc=%d\n",
             id.c_str(), info.isBonded() ? 1 : 0, info.isEncrypted() ? 1 : 0);
+        // Bonded reconnects START at the central's clamped parameters (no
+        // later update event fires), so the supervision-timeout pushback must
+        // also arm here, not just in onConnParamsUpdate.
+        if (info.getConnTimeout() < DESIRED_TIMEOUT &&
+            info.getConnHandle() != param_fix_spent) {
+            param_fix_handle = info.getConnHandle();
+            param_fix_at_ms  = millis() + 2000;
+        }
         if (id == ZERO_ADDR) return;
         if (!owner_set) {
             claim_owner(id);
@@ -320,6 +369,17 @@ void ble_tick(void) {
     if (need_advertise) {
         need_advertise = false;
         start_advertising();
+    }
+    // Deferred one-shot supervision-timeout pushback (see onConnParamsUpdate).
+    if (param_fix_handle != CONN_HANDLE_NONE &&
+        (int32_t)(millis() - param_fix_at_ms) >= 0) {
+        uint16_t h = param_fix_handle;
+        param_fix_handle = CONN_HANDLE_NONE;
+        param_fix_spent  = h;
+        if (server && server->getConnectedCount() > 0) {
+            Serial.println("BLE: requesting 6s supervision timeout");
+            server->updateConnParams(h, 12, 24, 0, DESIRED_TIMEOUT);
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

On native Windows 11, the device churns through BLE connections — the daemon log shows hundreds of `Connecting → Connected → Refresh subscription unavailable: [WinError -2147023673] The operation was canceled by the user → Device disconnected` cycles per day, most connections dying **sub-second** during the CCCD subscribe, with occasional ~30s survivals. Underneath, every ~15–45 min a bleak WinRT fault escaped the daemon's exception handling and **permanently killed the polling thread** — the tray showed "Error: daemon crashed: AssertionError" and the device sat frozen on stale data until manual relaunch.

### Environment where this reproduces

- Native Windows 11 (no WSL), Python 3.12, bleak 3.0.2, winrt 3.2.1
- Waveshare ESP32-S3-Touch-AMOLED-2.16 (the README's reference board)
- Device **within 2–3 feet of the host, no line-of-sight obstruction** — this is not a range problem
- Other BLE devices on the same host work fine at 20 ft through walls

The trigger is environmental RF sensitivity, not distance: with the stock 2s Windows supervision timeout, simply **picking the device up and turning it** near the host reliably killed the link (reason=520 in the serial log), and in normal stationary desk use it dropped periodically for no visible reason. If your desk happens to have clean RF and a friendly geometry you will never see this — which is likely why it hasn't been reported: macOS centrals already run ~30ms/6s (immune by default), and Windows users without local interference never get close to a 2s gap. For anyone with unknown interference sources, a metal-heavy desk, a rear-panel Bluetooth adapter, or just unlucky antenna orientation, the device is effectively unusable on Windows without this fix — and nothing in the UI or logs tells them why.

Two distinct layers, both fixed here:

1. **Firmware/link layer:** every single disconnect in serial captures was `reason=520` (0x208 = **supervision timeout**). Windows as a BLE central imposes `interval=15ms latency=0 supervision-timeout=2s` on every bonded reconnect, and clamps back to 2s whenever an app GATT session goes active — while it happily runs **9.6s** when only its HID driver holds the link (all values captured on hardware via new conn-params logging). A 2s window is tight enough that ordinary orientation changes near the host — deep RF nulls from the board's PCB antenna being shadowed — kill the link during normal handling.

2. **Daemon/host layer:** bleak 3.0.2's WinRT backend raises a **bare `AssertionError`** (`FutureLike.result`, a completion race provoked by the flaky link) and raw `OSError` during connect/service-discovery — neither wrapped as `BleakError`, so they escaped `connect_and_run`'s `except (BleakError, asyncio.TimeoutError)` and killed the thread. A separate one-shot crash: `datetime.timestamp()` on Windows raises `OSError(22)` for a garbage/zero `anthropic-ratelimit-unified-overage-reset` header (`_billing_period_info`). And the tray's `_run_daemon` had no restart path — any crash was permanent.

## How it was found

Serial capture (`pio device monitor`) during live churn, with temporary conn-params + loop-timing instrumentation:

| Hypothesis | Verdict | Evidence |
|---|---|---|
| Owner-lock force-disconnecting on unresolved RPA (leading theory going in) | ❌ refuted | 0 `rejecting non-owner` lines across all captures; auth always `bonded=1 enc=1`; peer identity address stable across reconnects |
| CPU starvation blocking the BLE stack | ❌ refuted | every `loop()` tick timed: max ~119ms (LVGL splash render 82ms steady); NimBLE host runs in its own task |
| Stale/asymmetric bond state | ❌ refuted | full unpair + re-pair → churn resumed within ~6 min |
| Supervision timeout too tight | ✅ confirmed | all disconnects `reason=520`; Windows negotiates 2s (`connparams itvl=12(15.00ms) lat=0 timeout=200(2000ms)` on every bonded reconnect); moving the device 2 ft from the host triggered 520s on demand |

What didn't work: requesting relaxed params **immediately** in `onAuthenticationComplete` — Windows answered the update transaction but kept its 2s. (Windows also has a documented late-instant bug in its param-update path — Microsoft Q&A 848142 — that can itself cause 0x08 disconnects, so param-update traffic is kept to one deferred request.)

## Fix

**Firmware** (shared `ble.cpp` + all four board envs):

- **PPCP characteristic** (GAP 0x2A04) via `MYNEWT_VAL_BLE_SVC_GAP_PPCP_*` build flags: interval 15–30ms, latency 0, supervision timeout 6s — the accessory's declared steady-state preference per Microsoft's Bluetooth accessory guidelines (range includes 15/30ms as they require). Windows caches GATT per bond, so PPCP changes are seen after a re-pair.
- **One-shot deferred connection-parameter request:** when a connection runs at a timeout below 6s (armed in `onAuthenticationComplete` for bonded reconnects that *start* clamped, and in `onConnParamsUpdate` for post-pairing clamps), `ble_tick()` sends a single LL request ~2s later for 15–30ms / 0 / 6s. Deferred so it can't race the central's own in-flight update; a spent-handle guard makes it one request per connection, so a central that re-clamps can't trigger an update war.
- Negotiated conn params are now logged on connect and on every update — `reason=520` is only diagnosable next to the negotiated timeout.

The resulting steady state (30ms/6s) is exactly what macOS centrals already use — this brings the Windows link to parity with the platform where nobody reports churn. The single-owner security lock is deliberately untouched.

**Daemon** (`claude_usage_daemon_windows.py`, `tray_windows.py`):

- `connect_and_run` treats bleak's bare `AssertionError`/`OSError` as a normal failed attempt feeding the existing retry loop (and swallows the `disconnect()` teardown assert on an already-gone peer).
- `_billing_period_info` guards the Windows `timestamp()`/`fromtimestamp()` range errors and degrades to the safe default payload.
- `_run_daemon` is now a supervisor: crash → log traceback → tray error state → restart with capped backoff (2s→30s). Quit sets a `_quit_requested` event *before* signalling stop, so a clean shutdown is never resurrected and the backoff wait is Quit-interruptible.

## Testing

- ✅ `pytest daemon/tests/`: **114 passed, 2 skipped** (Windows 11, Python 3.12). Includes 2 test-harness fixes found during verification: `test_windows_poll._run()` now uses a fresh event loop per call (the old `asyncio.get_event_loop()` returned a closed loop once another test file's `asyncio.run()` closed the process default — 17 order-dependent false failures), and the two Linux/WSL-warning tests `skipif` on win32 (they assert a warning that is correctly suppressed on native Windows).
- ✅ All four board envs compile: `waveshare_amoled_216`, `waveshare_amoled_18`, `waveshare_amoled_216_c6`, `waveshare_amoled_18_c6`.
- ✅ Hardware-verified on **Waveshare ESP32-S3-Touch-AMOLED-2.16 + Windows 11** (bleak 3.0.2, winrt 3.2.1):
  - Windows now *initiates* reconnects at `itvl=48(60ms)` fresh-pair and settles at `itvl=24(30.00ms) lat=0 timeout=600(6000ms)` — captured across many reconnect cycles.
  - A forced-null disconnect (device held in an RF-shadowed orientation) measurably takes the **full 6s** instead of 2s.
  - Field test in the reproducing environment (device 2–3 ft from host, known-flaky RF): pre-fix, gentle handling killed the link in ≤2s and the daemon log accumulated 393 connection attempts / 163 losses over 2 days. Post-fix, on battery in its usual desk spot: **~25 min stable, a single 7-second self-healed blip** (disconnect → reconnected → fresh data in 7s); survives being carried and rotated around the host; killing the link now requires deliberately holding it in an antenna-shadowed orientation for the full 6s window. The tray survived hundreds of forced flaps (including a zombie-link storm) with zero crashes.
- ⚠️ Not hardware-tested: the other three boards (compile-only) and macOS/Linux centrals (reasoned: macOS already runs ≥6s timeouts, so the pushback never arms; PPCP is standard and advisory).

## Out of scope / related

- #16 specced a firmware supervision timeout (item B) that was never landed — this PR completes that item with measured evidence.
- #88 (Windows stale-bond self-heal) and #89 (unbounded `start_notify`) are adjacent Windows-daemon issues, not addressed here.
- Follow-up feature proposal: on-device BLE signal-strength bars (RSSI), which would have made this diagnosis visible at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)