### PR TITLE
Report battery percentage over BLE

### DIFF
--- a/firmware/src/ble.cpp
+++ b/firmware/src/ble.cpp
@@ -435,7 +435,7 @@ void ble_send_nack(void) {
 void ble_set_battery_level(int pct) {
     if (!hid_dev || pct < 0) return;
     if (pct > 100) pct = 100;
-    hid_dev->setBatteryLevel((uint8_t)pct, true);
+    hid_dev->setBatteryLevel((uint8_t)pct, state == BLE_STATE_CONNECTED);
 }
 
 void ble_request_refresh(void) {

--- a/firmware/src/ble.cpp
+++ b/firmware/src/ble.cpp
@@ -432,6 +432,12 @@ void ble_send_nack(void) {
     }
 }
 
+void ble_set_battery_level(int pct) {
+    if (!hid_dev || pct < 0) return;
+    if (pct > 100) pct = 100;
+    hid_dev->setBatteryLevel((uint8_t)pct, true);
+}
+
 void ble_request_refresh(void) {
     if (state == BLE_STATE_CONNECTED && req_char) {
         uint8_t v = 0x01;

--- a/firmware/src/ble.h
+++ b/firmware/src/ble.h
@@ -21,6 +21,8 @@ void ble_send_ack(void);
 void ble_send_nack(void);
 void ble_request_refresh(void);
 
+void ble_set_battery_level(int pct);
+
 // BLE HID keyboard
 void ble_keyboard_press(uint8_t key, uint8_t modifier);
 void ble_keyboard_release(void);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -362,10 +362,10 @@ void loop() {
     int  pct      = power_hal_battery_pct();
     bool charging = power_hal_is_charging();
     if (pct != last_pct || charging != last_charging) {
+        if (pct != last_pct) ble_set_battery_level(pct);
         last_pct = pct;
         last_charging = charging;
         ui_update_battery(pct, charging);
-        ble_set_battery_level(pct);
     }
 
     check_serial_cmd();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -365,6 +365,7 @@ void loop() {
         last_pct = pct;
         last_charging = charging;
         ui_update_battery(pct, charging);
+        ble_set_battery_level(pct);
     }
 
     check_serial_cmd();


### PR DESCRIPTION
Implement battery level reporting over BLE, allowing connected hosts to display the actual battery percentage instead of a constant 100%.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/29d93cce-07fb-41d5-bbee-5f4165ddb2dc" />
