### PR TITLE
Fix touch not tracking the auto-rotating display

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -20,6 +20,7 @@
 #include "hal/power_hal.h"
 #include "hal/imu_hal.h"
 #include "hal/sound_hal.h"
+#include "touch_rotate.h"
 
 static UsageData usage = {};
 
@@ -36,6 +37,20 @@ static UsageData usage = {};
 #endif
 static uint16_t* buf1 = nullptr;
 static uint16_t* buf2 = nullptr;
+
+static lv_display_t* g_disp = nullptr;   // for lv_display_set_rotation on IMU quadrant change
+
+// Map the board's IMU rotation quadrant to the LVGL rotation that lines touch
+// input up with the CPU-rotated display. (See touch_rotate.h — the display
+// rotates but touch reports native, so we let LVGL rotate the input to match.)
+static lv_display_rotation_t quadrant_to_rotation(uint8_t q) {
+    switch (q) {
+        case 1:  return LV_DISPLAY_ROTATION_270;
+        case 2:  return LV_DISPLAY_ROTATION_180;
+        case 3:  return LV_DISPLAY_ROTATION_90;
+        default: return LV_DISPLAY_ROTATION_0;
+    }
+}
 
 static uint32_t my_tick(void) { return millis(); }
 
@@ -59,10 +74,16 @@ static void rounder_cb(lv_event_t* e) {
 //           panel is dark, so pets/sleeves can't wake it overnight and LVGL
 //           can't quietly toggle splash<->usage on a black panel.
 static void my_touch_cb(lv_indev_t* indev, lv_indev_data_t* data) {
-    uint16_t x, y;
+    uint16_t rx, ry;
     bool pressed;
-    touch_hal_read(&x, &y, &pressed);
+    touch_hal_read(&rx, &ry, &pressed);
     const bool raw_pressed = pressed;
+
+    // Align the raw touch to the panel frame; LVGL applies the per-orientation
+    // rotation (lv_display_set_rotation, set from the IMU quadrant in loop()), so
+    // taps land correctly whatever way the display is turned.
+    uint16_t x, y;
+    touch_to_panel(rx, ry, &x, &y);
 
     if (IDLE_WAKE_ON_TOUCH) {
         static bool touch_was = false;
@@ -215,6 +236,7 @@ void setup() {
     buf2 = (uint16_t*)heap_caps_malloc(W * BUF_LINES * 2, LV_BUF_CAPS);
 
     lv_display_t* disp = lv_display_create(W, H);
+    g_disp = disp;
     lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
     lv_display_set_flush_cb(disp, my_flush_cb);
     lv_display_set_buffers(disp, buf1, buf2, W * BUF_LINES * 2,
@@ -292,6 +314,13 @@ void loop() {
     ble_tick();
     power_hal_tick();
     imu_hal_tick();
+    // Mirror the display auto-rotation into LVGL so it rotates touch input to
+    // match (see touch_rotate.h). Set before display_hal_tick invalidates.
+    {
+        static uint8_t last_q = 255;
+        uint8_t q = imu_hal_rotation_quadrant();
+        if (q != last_q) { lv_display_set_rotation(g_disp, quadrant_to_rotation(q)); last_q = q; }
+    }
     sound_hal_tick();
     splash_tick();
     // Rotation transition (blank + ramp) would fight the idle fade — skip

--- a/firmware/src/touch_rotate.cpp
+++ b/firmware/src/touch_rotate.cpp
@@ -1,0 +1,15 @@
+#include "touch_rotate.h"
+#include "hal/board_caps.h"
+
+// Fixed touch-controller -> physical-panel alignment (quadrant-independent).
+// The CST9220 is configured with swap+mirror (touch.cpp), which lands its output
+// a quarter turn off the panel; this single transform undoes that so the value we
+// hand LVGL is in the panel's own frame. LVGL's lv_display_rotate_point() then
+// applies the per-orientation rotation. (First-pass value; tune here if a specific
+// orientation is uniformly off — it's ONE transform for all four quadrants now.)
+void touch_to_panel(uint16_t raw_x, uint16_t raw_y, uint16_t* out_x, uint16_t* out_y) {
+    const int S = board_caps().width;   // square panel
+    *out_x = raw_y;
+    *out_y = S - 1 - raw_x;
+}
+

--- a/firmware/src/touch_rotate.h
+++ b/firmware/src/touch_rotate.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <stdint.h>
+
+// Orientation-aware touch, LVGL-owned rotation model.
+//
+// The AMOLED-2.16 auto-rotates the DISPLAY by IMU quadrant (the CO5300 can't
+// rotate in hardware, so display.cpp CPU-rotates the flush via rotate_strip), but
+// the touch controller keeps reporting in its fixed native frame. Left alone, taps
+// land in the wrong place whenever the device is turned.
+//
+// The fix is to mirror the display rotation into LVGL via lv_display_set_rotation()
+// (see main.cpp) and let LVGL rotate the touch point for hit-testing on its own
+// (lv_indev -> lv_display_rotate_point). Then all that's left here is one fixed,
+// quadrant-independent alignment from the touch controller's output to the panel
+// frame — LVGL applies the per-orientation rotation on top. Boards that don't
+// auto-rotate report quadrant 0, so this stays an identity there.
+
+void touch_to_panel(uint16_t raw_x, uint16_t raw_y, uint16_t* out_x, uint16_t* out_y);


### PR DESCRIPTION
Fixes a pre-existing bug on the AMOLED-2.16: the display auto-rotates (IMU-driven CPU pixel rotation in `display.cpp`, since the CO5300 can't rotate in hardware) but the touch point does **not** — the raw coordinate is fed straight to LVGL, so taps land in the wrong place whenever the device is turned. Only the un-rotated orientation is correct.

### Fix
Mirror the display's rotation into LVGL with `lv_display_set_rotation()` (set from `imu_hal_rotation_quadrant()` each loop) and let LVGL rotate the touch point for hit-testing itself (`lv_indev` → `lv_display_rotate_point`). All that remains is one fixed, quadrant-independent touch→panel alignment in the new `touch_rotate.{cpp,h}`; LVGL applies the per-orientation rotation on top — no per-quadrant calibration table.

- Display rotation (`rotate_strip`) is unchanged, and LVGL's matrix rotation stays off, so there's no double-rotation.
- Boards that don't auto-rotate report quadrant 0 → identity, no behavior change.

### Verification
Tested on an AMOLED-2.16 with a temporary logger: tapping the same on-screen corner in **all four orientations** maps to the same LVGL coordinate (it scattered before the fix). Builds clean on `waveshare_amoled_216`.

### Diff
Small and self-contained — `firmware/src/touch_rotate.{cpp,h}` (new) plus a handful of lines in `main.cpp` (3 files, +64/-2).
