### PR TITLE
Add ESP32-2432S024C board support

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -397,3 +397,61 @@ lib_deps =
     lvgl/lvgl@^9.2.0
     bblanchon/ArduinoJson@^7.0.0
     h2zero/NimBLE-Arduino@^2.1.1
+
+
+[env:esp32_2432s024c]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32dev
+framework = arduino
+board_upload.flash_size = 4MB
+board_upload.maximum_size = 4194304
+board_build.partitions = huge_app.csv
+upload_speed = 460800
+monitor_speed = 115200
+
+build_src_filter =
+    +<*>
+    -<boards/>
+    +<boards/esp32_2432s024c/>
+
+build_flags =
+    -DBOARD_ESP32_2432S024C
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=0
+
+; The display library declares SD and seesaw for optional shields/examples.
+; Neither is used by this board, and the generic SD package is not ESP32-safe.
+lib_ignore =
+    Adafruit seesaw Library
+    SD
+
+lib_deps =
+    adafruit/Adafruit GFX Library@^1.12.6
+    adafruit/Adafruit ST7735 and ST7789 Library@^1.11.0
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1
+
+
+[env:esp32_2432s024c_landscape]
+extends = env:esp32_2432s024c
+build_flags =
+    ${env:esp32_2432s024c.build_flags}
+    -DBOARD_LANDSCAPE

--- a/firmware/src/boards/esp32_2432s024c/board.h
+++ b/firmware/src/boards/esp32_2432s024c/board.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#define BOARD_NAME "ESP32-2432S024C"
+
+#define LCD_NATIVE_WIDTH 240
+#define LCD_NATIVE_HEIGHT 320
+
+#ifdef BOARD_LANDSCAPE
+#define LCD_WIDTH 320
+#define LCD_HEIGHT 240
+#define LCD_ROTATION 3
+#else
+#define LCD_WIDTH 240
+#define LCD_HEIGHT 320
+#define LCD_ROTATION 0
+#endif
+
+#define LCD_SCLK 14
+#define LCD_MOSI 13
+#define LCD_MISO 12
+#define LCD_CS 15
+#define LCD_DC 2
+#define LCD_RESET -1
+#define LCD_BACKLIGHT 27
+
+#define IIC_SDA 33
+#define IIC_SCL 32
+
+#define TP_INT -1
+#define TP_RESET 25
+#define TP_ADDR 0x15
+
+#define BTN_PWR_GPIO 0
+
+#define BOARD_HAS_SECONDARY_BUTTON 0
+#define BOARD_HAS_ROTATION 0
+#define BOARD_HAS_IMU 0
+#define BOARD_HAS_BATTERY 0
+#define BOARD_HAS_IO_EXPANDER 0
+#define BOARD_HAS_SOUND 0

--- a/firmware/src/boards/esp32_2432s024c/board_init.cpp
+++ b/firmware/src/boards/esp32_2432s024c/board_init.cpp
@@ -1,0 +1,15 @@
+#include "board.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+extern "C" void board_init(void) {
+    Wire.begin(IIC_SDA, IIC_SCL);
+    Wire.setClock(400000);
+
+    pinMode(TP_RESET, OUTPUT);
+    digitalWrite(TP_RESET, LOW);
+    delay(10);
+    digitalWrite(TP_RESET, HIGH);
+    delay(50);
+}

--- a/firmware/src/boards/esp32_2432s024c/caps.cpp
+++ b/firmware/src/boards/esp32_2432s024c/caps.cpp
@@ -1,0 +1,14 @@
+#include "../../hal/board_caps.h"
+#include "board.h"
+
+static const BoardCaps caps = {
+    .name = BOARD_NAME,
+    .width = LCD_WIDTH,
+    .height = LCD_HEIGHT,
+    .button_count = 0,
+    .has_rotation = false,
+    .has_battery = false,
+    .has_imu = false,
+};
+
+const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/esp32_2432s024c/display.cpp
+++ b/firmware/src/boards/esp32_2432s024c/display.cpp
@@ -1,0 +1,86 @@
+#include "../../hal/display_hal.h"
+#include "board.h"
+
+#include <Adafruit_ST7789.h>
+#include <Arduino.h>
+#include <SPI.h>
+
+static SPIClass display_spi(HSPI);
+static Adafruit_ST7789 display(
+    &display_spi,
+    LCD_CS,
+    LCD_DC,
+    LCD_RESET
+);
+
+static int32_t clamp_coordinate(int32_t value, int32_t maximum) {
+    if (value < 0) {
+        return 0;
+    }
+    if (value > maximum) {
+        return maximum;
+    }
+    return value;
+}
+
+void display_hal_init(void) {
+    display_spi.begin(LCD_SCLK, LCD_MISO, LCD_MOSI, LCD_CS);
+    if (!ledcAttach(LCD_BACKLIGHT, 5000, 8)) {
+        Serial.println("Backlight PWM attach failed");
+    }
+}
+
+void display_hal_begin(void) {
+    display.init(LCD_NATIVE_WIDTH, LCD_NATIVE_HEIGHT, SPI_MODE0);
+    display.setSPISpeed(40000000);
+    display.setRotation(LCD_ROTATION);
+    // The panel uses BGR and needs MY instead of MX in portrait to avoid
+    // mirroring. Rotation 3 additionally needs MX and MV.
+    uint8_t madctl = LCD_ROTATION == 3 ? 0xE8 : 0x88;
+    display.sendCommand(ST77XX_MADCTL, &madctl, 1);
+    display.invertDisplay(false);
+    display.fillScreen(ST77XX_BLACK);
+    display_hal_set_brightness(200);
+    Serial.printf(
+        "Display ST7789 ready (%dx%d %s, HSPI 40MHz)\n",
+        LCD_WIDTH,
+        LCD_HEIGHT,
+#ifdef BOARD_LANDSCAPE
+        "landscape"
+#else
+        "portrait"
+#endif
+    );
+}
+
+void display_hal_set_brightness(uint8_t level) {
+    ledcWrite(LCD_BACKLIGHT, level);
+}
+
+void display_hal_fill_screen(uint16_t color) {
+    display.fillScreen(color);
+}
+
+void display_hal_draw_bitmap(
+    int32_t x,
+    int32_t y,
+    int32_t width,
+    int32_t height,
+    const uint16_t* pixels
+) {
+    display.drawRGBBitmap(x, y, pixels, width, height);
+}
+
+void display_hal_tick(void) {}
+
+void display_hal_round_area(
+    int32_t* x1,
+    int32_t* y1,
+    int32_t* x2,
+    int32_t* y2
+) {
+    *x1 = clamp_coordinate(*x1, LCD_WIDTH - 1);
+    *y1 = clamp_coordinate(*y1, LCD_HEIGHT - 1);
+    *x2 = clamp_coordinate(*x2, LCD_WIDTH - 1);
+    *y2 = clamp_coordinate(*y2, LCD_HEIGHT - 1);
+}

--- a/firmware/src/boards/esp32_2432s024c/imu.cpp
+++ b/firmware/src/boards/esp32_2432s024c/imu.cpp
@@ -1,0 +1,5 @@
+#include "../../hal/imu_hal.h"
+
+void imu_hal_init(void) {}
+void imu_hal_tick(void) {}
+uint8_t imu_hal_rotation_quadrant(void) { return 0; }

--- a/firmware/src/boards/esp32_2432s024c/input.cpp
+++ b/firmware/src/boards/esp32_2432s024c/input.cpp
@@ -1,0 +1,8 @@
+#include "../../hal/input_hal.h"
+
+void input_hal_init(void) {}
+
+bool input_hal_is_held(InputButton button) {
+    (void)button;
+    return false;
+}

--- a/firmware/src/boards/esp32_2432s024c/power.cpp
+++ b/firmware/src/boards/esp32_2432s024c/power.cpp
@@ -1,0 +1,58 @@
+#include "../../hal/power_hal.h"
+#include "board.h"
+
+#include <Arduino.h>
+
+static bool button_down = false;
+static bool long_press_sent = false;
+static uint32_t button_down_since_ms = 0;
+static bool pressed_flag = false;
+static bool long_pressed_flag = false;
+static bool released_flag = false;
+
+void power_hal_init(void) {
+    pinMode(BTN_PWR_GPIO, INPUT_PULLUP);
+    button_down = digitalRead(BTN_PWR_GPIO) == LOW;
+    button_down_since_ms = millis();
+}
+
+void power_hal_tick(void) {
+    const bool down = digitalRead(BTN_PWR_GPIO) == LOW;
+    const uint32_t now_ms = millis();
+
+    if (down && !button_down) {
+        button_down = true;
+        long_press_sent = false;
+        button_down_since_ms = now_ms;
+    } else if (down && !long_press_sent &&
+               now_ms - button_down_since_ms >= 1500) {
+        long_press_sent = true;
+        long_pressed_flag = true;
+    } else if (!down && button_down) {
+        pressed_flag = pressed_flag || !long_press_sent;
+        released_flag = true;
+        button_down = false;
+    }
+}
+
+int power_hal_battery_pct(void) { return -1; }
+bool power_hal_is_charging(void) { return false; }
+bool power_hal_is_vbus_in(void) { return true; }
+
+bool power_hal_pwr_pressed(void) {
+    const bool value = pressed_flag;
+    pressed_flag = false;
+    return value;
+}
+
+bool power_hal_pwr_long_pressed(void) {
+    const bool value = long_pressed_flag;
+    long_pressed_flag = false;
+    return value;
+}
+
+bool power_hal_pwr_released(void) {
+    const bool value = released_flag;
+    released_flag = false;
+    return value;
+}

--- a/firmware/src/boards/esp32_2432s024c/sound.cpp
+++ b/firmware/src/boards/esp32_2432s024c/sound.cpp
@@ -1,0 +1,5 @@
+#include "../../hal/sound_hal.h"
+
+void sound_hal_init(void) {}
+void sound_hal_tick(void) {}
+void sound_hal_play_reset(void) {}

--- a/firmware/src/boards/esp32_2432s024c/touch.cpp
+++ b/firmware/src/boards/esp32_2432s024c/touch.cpp
@@ -1,0 +1,62 @@
+#include "../../hal/touch_hal.h"
+#include "board.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+static bool read_touch_sample(uint8_t* data, size_t size) {
+    Wire.beginTransmission(TP_ADDR);
+    Wire.write(0x01);
+    if (Wire.endTransmission(false) != 0) {
+        return false;
+    }
+
+    if (Wire.requestFrom(TP_ADDR, static_cast<uint8_t>(size)) != size) {
+        return false;
+    }
+
+    for (size_t index = 0; index < size; ++index) {
+        data[index] = Wire.read();
+    }
+    return true;
+}
+
+void touch_hal_init(void) {
+    Wire.beginTransmission(TP_ADDR);
+    Wire.write(0xA7);
+    if (Wire.endTransmission(false) == 0 &&
+        Wire.requestFrom(TP_ADDR, static_cast<uint8_t>(1)) == 1) {
+        Serial.printf("Touch CST816/CST820 ID=0x%02X (addr 0x%02X)\n",
+                      Wire.read(), TP_ADDR);
+        return;
+    }
+
+    Serial.printf("Touch probe failed (addr 0x%02X)\n", TP_ADDR);
+}
+
+void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
+    uint8_t data[6] = {};
+    if (!read_touch_sample(data, sizeof(data))) {
+        *pressed = false;
+        return;
+    }
+
+    const uint8_t fingers = data[1] & 0x0F;
+    if (fingers == 0 || fingers > 5) {
+        *pressed = false;
+        return;
+    }
+
+    const uint16_t raw_x =
+        (static_cast<uint16_t>(data[2] & 0x0F) << 8) | data[3];
+    const uint16_t raw_y =
+        (static_cast<uint16_t>(data[4] & 0x0F) << 8) | data[5];
+#ifdef BOARD_LANDSCAPE
+    *x = 319 - min(raw_y, static_cast<uint16_t>(319));
+    *y = 239 - min(raw_x, static_cast<uint16_t>(239));
+#else
+    *x = min(raw_x, static_cast<uint16_t>(239));
+    *y = min(raw_y, static_cast<uint16_t>(319));
+#endif
+    *pressed = true;
+}

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -116,7 +116,7 @@ static void compute_layout(const BoardCaps& c) {
         L.bt_device_font   = &font_styrene_28;
         L.bt_credit_1_font = &font_styrene_24;
         L.bt_credit_2_font = &font_styrene_20;
-    } else if (c.height >= 300) {
+    } else if (c.height > 320) {
         // Compact layout — tuned for 368x448 (AMOLED-1.8).
         L.content_y = 85;
         L.usage_panel_h = 130;

--- a/tests/test_esp32_2432s024c_contract.py
+++ b/tests/test_esp32_2432s024c_contract.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_platformio_environment_targets_verified_board() -> None:
+    ini = (ROOT / "firmware/platformio.ini").read_text(encoding="utf-8")
+    assert "[env:esp32_2432s024c]" in ini
+    section = ini.split("[env:esp32_2432s024c]", 1)[1]
+    assert "board = esp32dev" in section
+    assert "board_build.partitions = huge_app.csv" in section
+    assert "+<boards/esp32_2432s024c/>" in section
+    assert "-DBOARD_HAS_PSRAM" not in section.split("[env:", 1)[0]
+    assert "lib_ignore =" in section
+    assert "Adafruit seesaw Library" in section
+    assert "SD" in section
+    assert "[env:esp32_2432s024c_landscape]" in ini
+    assert "-DBOARD_LANDSCAPE" in ini
+
+
+def test_board_header_matches_verified_pins() -> None:
+    header = (
+        ROOT / "firmware/src/boards/esp32_2432s024c/board.h"
+    ).read_text(encoding="utf-8")
+    expected = {
+        "LCD_SCLK": "14",
+        "LCD_MOSI": "13",
+        "LCD_MISO": "12",
+        "LCD_CS": "15",
+        "LCD_DC": "2",
+        "LCD_BACKLIGHT": "27",
+        "IIC_SDA": "33",
+        "IIC_SCL": "32",
+        "TP_RESET": "25",
+        "TP_ADDR": "0x15",
+        "BTN_PWR_GPIO": "0",
+    }
+    for name, value in expected.items():
+        assert f"#define {name}" in header
+        assert value in header.split(f"#define {name}", 1)[1].splitlines()[0]
+    assert "#define LCD_NATIVE_WIDTH 240" in header
+    assert "#define LCD_NATIVE_HEIGHT 320" in header
+    assert "#define LCD_WIDTH 320" in header
+    assert "#define LCD_HEIGHT 240" in header
+    assert "#define LCD_WIDTH 240" in header
+    assert "#define LCD_HEIGHT 320" in header
+    assert "#define LCD_ROTATION 3" in header
+
+
+def test_small_layout_covers_portrait_height() -> None:
+    ui = (ROOT / "firmware/src/ui.cpp").read_text(encoding="utf-8")
+    assert "} else if (c.height > 320) {" in ui
+
+
+def test_board_hal_is_complete_and_uses_st7789() -> None:
+    board_dir = ROOT / "firmware/src/boards/esp32_2432s024c"
+    expected_sources = {
+        "board_init.cpp",
+        "caps.cpp",
+        "display.cpp",
+        "imu.cpp",
+        "input.cpp",
+        "power.cpp",
+        "sound.cpp",
+        "touch.cpp",
+    }
+    assert expected_sources <= {path.name for path in board_dir.glob("*.cpp")}
+
+    display = (board_dir / "display.cpp").read_text(encoding="utf-8")
+    assert "Adafruit_ST7789" in display
+    assert "HSPI" in display
+    assert "LCD_BACKLIGHT" in display
+    assert "drawRGBBitmap" in display


### PR DESCRIPTION
## Scope

Adds a board HAL for the low-cost ESP32-2432S024C (2.4-inch, 240x320, classic ESP32, 4 MB flash, no PSRAM) with:

- ST7789 display support, including the panel's BGR color order
- CST820 capacitive touch support
- always-on USB power behavior and BOOT-button input
- portrait (`esp32_2432s024c`) and USB-left landscape (`esp32_2432s024c_landscape`) PlatformIO targets
- fixed coordinate transforms for display and touch in both orientations
- contract tests for the verified pinout and build targets

This is intentionally only the board port extracted from #118. It does **not** include the Windows serial daemon, Codex/Fable screens, Activity screen, carousel, or documentation gallery.

## Hardware used

- Board marking/model: ESP32-2432S024C
- ESP32 (classic), 4 MB flash, no PSRAM
- 2.4-inch 240x320 ST7789 display
- CST820 capacitive touch controller
- CH340 USB-to-UART bridge

## Testing

### Automated/build validation performed by the agent on this exact branch

```text
python -m pytest tests/test_esp32_2432s024c_contract.py -q
4 passed

pio run -d firmware -e esp32_2432s024c -j 1
SUCCESS
RAM 32.2% (105468 / 327680)
Flash 42.2% (1328479 / 3145728)

pio run -d firmware -e esp32_2432s024c_landscape -j 1
SUCCESS
RAM 32.2% (105468 / 327680)
Flash 42.2% (1328631 / 3145728)

git diff --check
clean
```

### Manual hardware QA performed by Gustavo

The board HAL and the same portrait/landscape transforms were tested on the physical ESP32-2432S024C while developing the larger integration branch:

- display initialized and remained powered from USB
- orange Clawd artwork and UI colors rendered correctly after BGR correction
- portrait and USB-left landscape orientation were readable (not upside down or mirrored)
- capacitive touch navigation worked on both left and right sides
- the 240x320/320x240 UI fit on the panel

The focused branch was rebuilt from `main` and validated automatically as listed above; it was not reflashed after removing the unrelated dashboard features.

Physical result from the integration branch:

![ESP32-2432S024C running Clawdmeter](https://raw.githubusercontent.com/Atzingen/Clawdmeter/esp32-2432s024c-codex/docs/images/esp32-2432s024c/claude-fable-dashboard.jpg)

## Existing PRs reviewed

- #120: touch orientation work for an auto-rotating board. This port uses fixed compile-time portrait/landscape transforms for a different controller and does not add auto-rotation.
- #108: another small-display board. This PR keeps the current upstream small-display layout and only adjusts the breakpoint so the 240x320 portrait target uses it.
- #26 and #40: transport alternatives. No transport changes are included here.
- #22: Activity screen. No Activity implementation is included here.

Supersedes only the board-support portion of closed PR #118.

