### PR TITLE
Add optional Windows UART serial transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,21 @@ pip install -r daemon\requirements-windows.txt
 python daemon\claude_usage_daemon_windows.py        # runs in the foreground; Ctrl+C to stop
 ```
 
+### Optional USB/UART transport
+
+Boards with a USB-to-UART bridge such as CH340 can receive the same usage payload
+over their physical COM port without Bluetooth pairing. This is an opt-in transport;
+the installer and tray application continue to use BLE by default.
+
+```powershell
+pip install -r daemon\requirements-windows-serial.txt
+python daemon\claude_usage_daemon_serial_windows.py
+```
+
+The daemon ignores Bluetooth COM ports, probes physical USB serial ports with the
+`identify` command, and reconnects if the cable is unplugged. Set
+`CLAWDMETER_SERIAL_PORT=COM3` to select a port explicitly.
+
 ### Tray icon and menu
 
 The icon's corner bubble shows state — **green** Connected, **amber** Scanning, **red** Error — and hovering shows the status (`Connected · last update HH:MM`). A notification fires once when it enters Error (e.g. an expired token). Right-click for the menu:

--- a/daemon/claude_usage_daemon_serial_windows.py
+++ b/daemon/claude_usage_daemon_serial_windows.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Claude usage daemon using the ESP32 USB serial connection on Windows."""
+
+import asyncio
+import json
+import os
+import time
+from collections.abc import Iterable
+
+import serial
+from serial.tools import list_ports
+
+from daemon.claude_usage_daemon_windows import (
+    AuthError,
+    POLL_INTERVAL,
+    TICK,
+    log,
+    poll_api,
+    read_token,
+)
+
+BAUD_RATE = 115200
+IDENTIFY_TIMEOUT = 4.0
+ACK_TIMEOUT = 2.0
+
+
+def candidate_serial_ports(ports: Iterable[object] | None = None) -> list[str]:
+    """Return physical USB serial ports, excluding Windows Bluetooth COM ports."""
+    if override := os.environ.get("CLAWDMETER_SERIAL_PORT"):
+        return [override.strip().upper()]
+
+    detected = list(list_ports.comports() if ports is None else ports)
+    candidates: list[str] = []
+    for port in detected:
+        description = str(getattr(port, "description", "")).lower()
+        hwid = str(getattr(port, "hwid", "")).lower()
+        is_bluetooth = "bluetooth" in description or "bthenum" in hwid
+        is_usb = getattr(port, "vid", None) is not None or "usb" in hwid
+        if is_usb and not is_bluetooth:
+            candidates.append(str(port.device).upper())
+    return candidates
+
+
+def is_clawdmeter_identity(line: str) -> bool:
+    try:
+        value = json.loads(line)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return isinstance(value, dict) and value.get("device") == "Clawdmeter"
+
+
+class SerialSession:
+    def __init__(self, port: serial.Serial) -> None:
+        self.port: serial.Serial = port
+
+    def write_payload(self, payload: dict[str, object]) -> bool:
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n"
+        log(f"Sending by USB serial: {data.decode().strip()}")
+        try:
+            self.port.write(data)
+            self.port.flush()
+            deadline = time.monotonic() + ACK_TIMEOUT
+            while time.monotonic() < deadline:
+                line = self.port.readline().decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    reply = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(reply, dict) and "ack" in reply:
+                    return reply["ack"] is True
+        except (OSError, serial.SerialException) as exc:
+            log(f"USB serial write failed: {exc}")
+        return False
+
+    def close(self) -> None:
+        try:
+            self.port.close()
+        except (OSError, serial.SerialException):
+            pass
+
+
+def _open_port(device: str) -> SerialSession | None:
+    port = serial.Serial()
+    port.port = device
+    port.baudrate = BAUD_RATE
+    port.timeout = 0.25
+    port.write_timeout = 2.0
+    port.dtr = False
+    port.rts = False
+    try:
+        port.open()
+        deadline = time.monotonic() + IDENTIFY_TIMEOUT
+        next_request = 0.0
+        while time.monotonic() < deadline:
+            now = time.monotonic()
+            if now >= next_request:
+                port.write(b"identify\n")
+                port.flush()
+                next_request = now + 0.5
+            line = port.readline().decode("utf-8", errors="replace").strip()
+            if is_clawdmeter_identity(line):
+                log(f"Clawdmeter identified on {device}")
+                return SerialSession(port)
+    except (OSError, serial.SerialException) as exc:
+        log(f"Could not open {device}: {exc}")
+    try:
+        port.close()
+    except (OSError, serial.SerialException):
+        pass
+    return None
+
+
+def find_clawdmeter_session() -> SerialSession | None:
+    for device in candidate_serial_ports():
+        if session := _open_port(device):
+            return session
+    return None
+
+
+async def connect_and_run(session: SerialSession) -> None:
+    last_poll = 0.0
+    try:
+        while True:
+            if time.time() - last_poll >= POLL_INTERVAL:
+                token = read_token()
+                if not token:
+                    log("No token; skipping poll")
+                else:
+                    try:
+                        payload = await poll_api(token)
+                    except AuthError:
+                        log("Token expired; run claude login")
+                        payload = None
+                    if payload is not None:
+                        if not await asyncio.to_thread(session.write_payload, payload):
+                            log("USB serial acknowledgement failed; reconnecting")
+                            return
+                        last_poll = time.time()
+            await asyncio.sleep(TICK)
+    finally:
+        await asyncio.to_thread(session.close)
+
+
+async def main() -> None:
+    log("=== Claude Usage Tracker Daemon (USB serial, Windows) ===")
+    backoff = 1
+    while True:
+        session = await asyncio.to_thread(find_clawdmeter_session)
+        if session is None:
+            log(f"Clawdmeter USB serial not found, retrying in {backoff}s...")
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30)
+            continue
+
+        await connect_and_run(session)
+        backoff = 1
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        log("Daemon stopping")

--- a/daemon/requirements-windows-serial.txt
+++ b/daemon/requirements-windows-serial.txt
@@ -1,0 +1,2 @@
+-r requirements-windows.txt
+pyserial

--- a/daemon/tests/test_windows_serial.py
+++ b/daemon/tests/test_windows_serial.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Tests for the Windows USB serial transport."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from daemon.claude_usage_daemon_serial_windows import (
+    SerialSession,
+    candidate_serial_ports,
+    is_clawdmeter_identity,
+)
+
+
+def test_candidate_serial_ports_prefers_real_usb_ports(monkeypatch):
+    ports = [
+        SimpleNamespace(device="COM10", description="Standard Serial over Bluetooth", hwid="BTHENUM", vid=None),
+        SimpleNamespace(device="COM3", description="USB-SERIAL CH340", hwid="USB VID:PID=1A86:7523", vid=0x1A86),
+    ]
+
+    monkeypatch.delenv("CLAWDMETER_SERIAL_PORT", raising=False)
+
+    assert candidate_serial_ports(ports) == ["COM3"]
+
+
+def test_candidate_serial_ports_honors_explicit_override(monkeypatch):
+    monkeypatch.setenv("CLAWDMETER_SERIAL_PORT", "COM7")
+
+    assert candidate_serial_ports([]) == ["COM7"]
+
+
+def test_identity_requires_clawdmeter_device_name():
+    assert is_clawdmeter_identity('{"device":"Clawdmeter","board":"ESP32-2432S024C"}')
+    assert not is_clawdmeter_identity('{"ready":true}')
+    assert not is_clawdmeter_identity("boot noise")
+
+
+def test_serial_session_sends_compact_json_line_and_accepts_ack():
+    port = MagicMock()
+    port.readline.side_effect = [b"debug line\r\n", b'{"ack":true}\r\n']
+    session = SerialSession(port)
+    payload = {"s": 12.5, "w": 34.0, "ok": True}
+
+    assert session.write_payload(payload)
+    assert port.write.call_args.args[0] == (
+        json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n"
+    )
+
+
+def test_serial_session_rejects_negative_ack():
+    port = MagicMock()
+    port.readline.return_value = b'{"ack":false}\n'
+
+    assert not SerialSession(port).write_payload({"s": 1})

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -124,10 +124,30 @@ static bool parse_json(const char* json, UsageData* out) {
     return true;
 }
 
+static bool apply_usage_json(const char* json) {
+    if (!parse_json(json, &usage)) return false;
+
+    int g_before = usage_rate_group();
+    bool session_reset = usage_rate_sample(usage.session_pct);
+    int g_after = usage_rate_group();
+    if (session_reset && usage.chime) {
+        Serial.println("session reset detected - chime");
+        sound_hal_play_reset();
+    }
+    if (g_after != g_before) {
+        Serial.printf("usage rate: group %d -> %d (s=%.2f%%)\n",
+            g_before, g_after, usage.session_pct);
+        if (splash_is_active()) splash_pick_for_current_rate();
+    }
+    ui_update(&usage);
+    return true;
+}
+
 // ---- Serial command buffer ----
-#define CMD_BUF_SIZE 64
+#define CMD_BUF_SIZE 384
 static char cmd_buf[CMD_BUF_SIZE];
 static int cmd_pos = 0;
+static bool serial_usage_screen_shown = false;
 
 static void send_screenshot() {
 #ifndef BOARD_HAS_PSRAM
@@ -172,8 +192,24 @@ static void check_serial_cmd() {
         char c = Serial.read();
         if (c == '\n' || c == '\r') {
             cmd_buf[cmd_pos] = '\0';
-            if (strcmp(cmd_buf, "screenshot") == 0) send_screenshot();
-            else if (strcmp(cmd_buf, "buzz") == 0)  sound_hal_play_reset();
+            if (strcmp(cmd_buf, "screenshot") == 0) {
+                send_screenshot();
+            } else if (strcmp(cmd_buf, "buzz") == 0) {
+                sound_hal_play_reset();
+            } else if (strcmp(cmd_buf, "identify") == 0) {
+                Serial.printf("{\"device\":\"Clawdmeter\",\"board\":\"%s\"}\n",
+                              board_caps().name);
+            } else if (cmd_buf[0] == '{') {
+                if (apply_usage_json(cmd_buf)) {
+                    if (!serial_usage_screen_shown) {
+                        ui_show_screen(SCREEN_USAGE);
+                        serial_usage_screen_shown = true;
+                    }
+                    Serial.println("{\"ack\":true}");
+                } else {
+                    Serial.println("{\"ack\":false}");
+                }
+            }
             cmd_pos = 0;
         } else if (cmd_pos < CMD_BUF_SIZE - 1) {
             cmd_buf[cmd_pos++] = c;
@@ -233,7 +269,7 @@ void setup() {
     ui_update_battery(power_hal_battery_pct(), power_hal_is_charging());
     ui_show_screen(SCREEN_SPLASH);
 
-    Serial.printf("Dashboard ready (%s, %dx%d), waiting for data on BLE...\n",
+    Serial.printf("Dashboard ready (%s, %dx%d), waiting for data on BLE or USB serial...\n",
         board_caps().name, W, H);
 }
 
@@ -371,23 +407,7 @@ void loop() {
     check_serial_cmd();
 
     if (ble_has_data()) {
-        if (parse_json(ble_get_data(), &usage)) {
-            int g_before = usage_rate_group();
-            bool session_reset = usage_rate_sample(usage.session_pct);
-            int g_after = usage_rate_group();
-            // 5-hour session limit refilled → chime so the user knows they can
-            // use Claude again (no-op on boards without a buzzer). Gated on the
-            // daemon's opt-in `chime` config; the `buzz` serial cmd ignores it.
-            if (session_reset && usage.chime) {
-                Serial.println("session reset detected — chime");
-                sound_hal_play_reset();
-            }
-            if (g_after != g_before) {
-                Serial.printf("usage rate: group %d -> %d (s=%.2f%%)\n",
-                    g_before, g_after, usage.session_pct);
-                if (splash_is_active()) splash_pick_for_current_rate();
-            }
-            ui_update(&usage);
+        if (apply_usage_json(ble_get_data())) {
             ble_send_ack();
         } else {
             ble_send_nack();

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -663,12 +663,12 @@ void ui_update(const UsageData* data) {
 static void update_view_state(void) {
     if (!usage_group || !pair_group || !idle_group) return;
     int v;
-    if (!s_ble_connected) {
-        v = 0;  // pairing hint
-    } else if (data_received && (lv_tick_get() - last_data_ms) < DATA_FRESH_MS) {
-        v = 2;  // live usage
+    if (data_received && (lv_tick_get() - last_data_ms) < DATA_FRESH_MS) {
+        v = 2;
+    } else if (!s_ble_connected) {
+        v = 0;
     } else {
-        v = 1;  // idle / Zzz
+        v = 1;
     }
     if (v == view_state) return;
     view_state = v;
@@ -720,7 +720,11 @@ void ui_tick_anim(void) {
 
     // Status text by priority. Whimsical messages only when connected & settled.
     const char* text;
-    if (!s_ble_connected) {
+    if (view_state == 2 && !s_ble_connected) {
+        text = (now - last_data_ms < 5000)
+            ? "Updated"
+            : anim_messages[anim_msg_idx];
+    } else if (!s_ble_connected) {
         text = "Waiting";              // advertising / waiting for a host connection
     } else if (view_state == 1) {      // idle — alternate so it reads as alive AND data-less
         text = (anim_msg_idx & 1) ? "No data" : "Listening";


### PR DESCRIPTION
## Scope

Adds an **opt-in Windows UART serial transport** for the existing Claude usage payload:

- keeps BLE enabled and unchanged as the default transport
- accepts line-delimited usage JSON through the firmware's existing `Serial` command path
- adds `identify` and JSON ACK/NACK replies so a host can safely probe physical COM ports
- adds a Windows daemon that filters out Bluetooth COM ports, identifies the Clawdmeter before sending, and reconnects after disconnects
- allows `CLAWDMETER_SERIAL_PORT=COM3` as an explicit override
- shows fresh serial data even when no BLE client is connected

The tray installer continues to use BLE. UART serial is started explicitly with:

```powershell
pip install -r daemon\requirements-windows-serial.txt
python daemon\claude_usage_daemon_serial_windows.py
```

This is intentionally only the UART transport extracted from #118. It contains no board HAL, Codex/Fable data, Activity screen, session payloads, or carousel UI.

## Relationship to #26

I reviewed #26 and its Windows hardware-testing comment before preparing this PR.

#26 is a native USB CDC variant for Linux/macOS that replaces the BLE data link and removes/stubs BLE functionality. The Windows follow-up in its discussion ports that CDC branch and includes larger session payload work.

This PR is narrower and additive:

- targets Windows physical COM ports, including classic ESP32 boards behind a CH340 USB-to-UART bridge
- applies to current `main`
- leaves BLE and BLE HID behavior intact
- sends only the existing compact usage payload
- uses the current firmware serial command loop rather than introducing a replacement transport stack

It is meant to cover the classic-ESP32/CH340 case while following the maintainer's feedback on #26 that transports should remain optional.

## Testing

### Automated/build validation performed by the agent on this exact branch

```text
python -m pytest daemon/tests/test_windows_serial.py daemon/tests/test_windows_reconnect.py -q
30 passed, 1 warning
```

The warning is an existing asyncio mock resource warning in
`test_windows_reconnect.py`; there were no test failures.

```text
python -m ruff check daemon/claude_usage_daemon_serial_windows.py daemon/tests/test_windows_serial.py
All checks passed

python -m compileall -q daemon/claude_usage_daemon_serial_windows.py
success

pio run -d firmware -e waveshare_lcd_154 -j 1
SUCCESS
RAM 31.7% (103856 / 327680)
Flash 27.6% (1810134 / 6553600)

git diff --check
clean
```

### Manual hardware QA performed by Gustavo

On Windows with a physical ESP32-2432S024C connected through its CH340 bridge on
`COM3`, the daemon from this focused branch:

1. ignored the Bluetooth COM ports,
2. opened `COM3`,
3. received the expected Clawdmeter identity,
4. sent a compact usage JSON line, and
5. received `{"ack":true}`.

Observed output:

```text
Clawdmeter identified on COM3
Sending by USB serial: {"s":19,"sr":64,"w":46,"wr":5154,"st":"allowed","acct":"pro","ok":true}
IDENTIFY_AND_ACK_OK
```

After the focused test, the existing tray daemon was restarted and verified to
identify `COM3` and resume periodic updates.

The exact focused firmware was compiled as shown above. The physical board was
running the integration firmware from #118, which contains the same identify,
usage JSON, and ACK path plus the unrelated dashboard extensions; the reduced
firmware was not reflashed for this test.

Supersedes only the Windows UART-serial portion of closed PR #118.

