### PR TITLE
Show per-model weekly usage (Fable/Opus row) via the token-free OAuth usage endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,8 @@ See `~/.claude/projects/.../memory/` files for persistent context (user is an em
 
 Bash daemon (`daemon/claude-usage-daemon.sh`) reads OAuth token, polls Anthropic API, sends JSON over BLE GATT. Run with `systemctl --user start claude-usage-daemon`. The unit file's `ExecStart` is the absolute path to the script — repoint it when switching between the worktree and the main checkout.
 
+**Polling paths (macOS/Windows Python daemons):** `poll_usage_endpoint()` first — GET `/api/oauth/usage` (token-free; same buckets as the headers plus per-model `weekly_scoped` limits, sent as payload `"m"`/`"mn"`). Undocumented endpoint, so any failure or non-Pro/Max shape falls back to `poll_api()` (1-token `/v1/messages`, rate-limit headers) — which also remains the sole path that detects Enterprise accounts and (on Windows) the sole raiser of `AuthError` for the token-expired toast. A 429 from the usage endpoint benches it for 15 min (`USAGE_ENDPOINT_COOLDOWN_S`) — it was reverted once before over rate limiting (PRs #29/#37); don't remove the cooldown. The bash daemon still uses only the header method (no `m`/`mn`).
+
 **Discovery & resilience:**
 
 - Connects by name (`"Clawdmeter"`) on first run, caches resolved MAC at `~/.config/claude-usage-monitor/ble-address`. ESP32 BLE addresses are factory-burned per-chip, so swapping any board invalidates the cache.

--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ reg delete "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" /v Clawdmeter /f
 ## How it works
 
 1. The daemon reads your Claude Code OAuth token — from the macOS Keychain (service `Claude Code-credentials`) on macOS, or from `~/.claude/.credentials.json` on Linux (`%USERPROFILE%\.claude\.credentials.json` on Windows).
-2. It makes a minimal API call to `api.anthropic.com/v1/messages` — one token of Haiku, basically free.
-3. The usage numbers come straight out of the response headers (`anthropic-ratelimit-unified-5h-utilization` and friends).
+2. It polls `api.anthropic.com/api/oauth/usage` (macOS/Windows daemons) — the same endpoint the Claude Code client's `/usage` view reads. It costs zero tokens and also carries per-model weekly limits (the "Fable"/"Opus" row on the display). Heads-up: this endpoint isn't publicly documented, so it could change; if the call fails for any reason the daemon automatically falls back to the original method — a minimal call to `api.anthropic.com/v1/messages` (one token of Haiku, basically free) whose response headers (`anthropic-ratelimit-unified-5h-utilization` and friends) carry the same session/weekly numbers, minus the per-model bucket. The Linux bash daemon still uses the header method.
 4. The daemon connects to the ESP32 over BLE and writes a JSON payload to the GATT RX characteristic.
 5. The firmware parses it and updates the LVGL dashboard.
 6. The firmware also tracks the rate of change of session % over a 5-minute window and picks splash animations from the matching mood group.

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Claude Usage Tracker Daemon (BLE) — macOS port of claude-usage-daemon.sh.
 
-Polls Claude API rate-limit headers and writes a JSON payload to the
-ESP32 "Clawdmeter" peripheral over a custom GATT service. Uses
-bleak (CoreBluetooth backend on macOS).
+Polls the OAuth usage endpoint (token-free; also carries per-model weekly
+limits), falling back to the Claude API rate-limit headers, and writes a
+JSON payload to the ESP32 "Clawdmeter" peripheral over a custom GATT
+service. Uses bleak (CoreBluetooth backend on macOS).
 """
 
 import asyncio
@@ -374,6 +375,16 @@ def add_clock_fields(payload: dict) -> None:
     payload["tf"] = tf
 
 
+# After a 429 from the usage endpoint, skip it for this long and let the
+# message-call fallback carry polling. The endpoint was tried once before
+# (PR #29) and reverted (PR #37) after a rate-limit report — the cooldown
+# ensures a rate-limited endpoint is never hammered on every cycle, and the
+# fixed 60s poll cadence (vs the old 5s retry loop implicated in #29) bounds
+# request volume in the first place.
+USAGE_ENDPOINT_COOLDOWN_S = 900
+_usage_endpoint_cooldown_until = 0.0
+
+
 async def poll_usage_endpoint(token: str) -> dict | None:
     """Poll the OAuth usage endpoint (token-free) and build the BLE payload.
 
@@ -381,9 +392,16 @@ async def poll_usage_endpoint(token: str) -> dict | None:
     (5h session + 7d weekly) plus per-model scoped weekly limits ("m"/"mn"
     below) — and unlike poll_api() it doesn't spend a 1-token message call per
     poll. Returns None on any failure or unexpected shape so the caller can
-    fall back to poll_api() (e.g. Enterprise accounts, where the spending
-    limit only surfaces in the overage headers).
+    fall back to poll_api(); auth errors are also just a None here — poll_api
+    remains the sole authority on token validity. The Pro/Max shape check
+    requires BOTH the 5h and 7d buckets: Enterprise spending-limit accounts
+    have no weekly concept, so a missing bucket routes them (and any future
+    unknown shape) to the fallback rather than misclassifying them as "pro".
     """
+    global _usage_endpoint_cooldown_until
+    now = time.time()
+    if now < _usage_endpoint_cooldown_until:
+        return None   # rate-limit cooldown active — fallback carries this cycle
     headers = {
         "Authorization": f"Bearer {token}",
         "anthropic-beta": API_HEADERS_TEMPLATE["anthropic-beta"],
@@ -395,6 +413,11 @@ async def poll_usage_endpoint(token: str) -> dict | None:
     except httpx.HTTPError as e:
         log(f"Usage endpoint failed: {e}")
         return None
+    if resp.status_code == 429:
+        _usage_endpoint_cooldown_until = now + USAGE_ENDPOINT_COOLDOWN_S
+        log(f"Usage endpoint rate-limited (429) — cooling down for "
+            f"{USAGE_ENDPOINT_COOLDOWN_S // 60} min, using API fallback")
+        return None
     if resp.status_code != 200:
         log(f"Usage endpoint HTTP {resp.status_code}: {resp.text[:200]}")
         return None
@@ -404,17 +427,19 @@ async def poll_usage_endpoint(token: str) -> dict | None:
         return None
     five = data.get("five_hour") or {}
     seven = data.get("seven_day") or {}
-    if five.get("utilization") is None:
-        return None   # shape we don't understand (Enterprise?) — use the fallback
-
-    now = time.time()
+    if five.get("utilization") is None or seven.get("utilization") is None:
+        return None   # not the full Pro/Max shape (Enterprise?) — use the fallback
 
     def reset_minutes_iso(iso: str | None) -> int:
         if not iso:
             return 0
         try:
-            ts = datetime.datetime.fromisoformat(iso).timestamp()
-        except ValueError:
+            # Python < 3.11 can't parse a literal "Z" suffix; normalize first.
+            ts = datetime.datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp()
+        except (ValueError, OSError, OverflowError):
+            # Same guard set as _billing_period_info(): out-of-range values
+            # raise OSError/OverflowError on Windows-family platforms, and
+            # garbage must never take down the poll loop.
             return 0
         mins = (ts - now) / 60.0
         return int(round(mins)) if mins > 0 else 0

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -41,6 +41,7 @@ SAVED_ADDR_FILE = Path.home() / ".config" / "claude-usage-monitor" / "ble-addres
 CONFIG_FILE = Path.home() / ".config" / "claude-usage-monitor" / "config"
 
 API_URL = "https://api.anthropic.com/v1/messages"
+USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 API_HEADERS_TEMPLATE = {
     "anthropic-version": "2023-06-01",
     "anthropic-beta": "oauth-2025-04-20",
@@ -373,6 +374,83 @@ def add_clock_fields(payload: dict) -> None:
     payload["tf"] = tf
 
 
+async def poll_usage_endpoint(token: str) -> dict | None:
+    """Poll the OAuth usage endpoint (token-free) and build the BLE payload.
+
+    GET /api/oauth/usage returns the same buckets the rate-limit headers carry
+    (5h session + 7d weekly) plus per-model scoped weekly limits ("m"/"mn"
+    below) — and unlike poll_api() it doesn't spend a 1-token message call per
+    poll. Returns None on any failure or unexpected shape so the caller can
+    fall back to poll_api() (e.g. Enterprise accounts, where the spending
+    limit only surfaces in the overage headers).
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "anthropic-beta": API_HEADERS_TEMPLATE["anthropic-beta"],
+        "User-Agent": API_HEADERS_TEMPLATE["User-Agent"],
+    }
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as http:
+            resp = await http.get(USAGE_URL, headers=headers)
+    except httpx.HTTPError as e:
+        log(f"Usage endpoint failed: {e}")
+        return None
+    if resp.status_code != 200:
+        log(f"Usage endpoint HTTP {resp.status_code}: {resp.text[:200]}")
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    five = data.get("five_hour") or {}
+    seven = data.get("seven_day") or {}
+    if five.get("utilization") is None:
+        return None   # shape we don't understand (Enterprise?) — use the fallback
+
+    now = time.time()
+
+    def reset_minutes_iso(iso: str | None) -> int:
+        if not iso:
+            return 0
+        try:
+            ts = datetime.datetime.fromisoformat(iso).timestamp()
+        except ValueError:
+            return 0
+        mins = (ts - now) / 60.0
+        return int(round(mins)) if mins > 0 else 0
+
+    def pct_of(v) -> int:
+        try:
+            return max(0, min(100, int(round(float(v)))))
+        except (TypeError, ValueError):
+            return 0
+
+    payload = {
+        "s": pct_of(five.get("utilization")),
+        "sr": reset_minutes_iso(five.get("resets_at")),
+        "w": pct_of(seven.get("utilization")),
+        "wr": reset_minutes_iso(seven.get("resets_at")),
+        "st": "allowed" if pct_of(five.get("utilization")) < 100 else "rejected",
+        "acct": "pro",
+        "ok": True,
+    }
+    # Per-model scoped weekly limit (e.g. "Fable" / "Opus"): the limits array
+    # carries kind == "weekly_scoped" entries with the model's display name.
+    for lim in data.get("limits") or []:
+        if lim.get("kind") != "weekly_scoped":
+            continue
+        scope = lim.get("scope") or {}
+        model = (scope.get("model") or {}).get("display_name")
+        if not model:
+            continue
+        payload["m"] = pct_of(lim.get("percent"))
+        payload["mn"] = str(model)[:15]
+        break   # firmware shows one scoped bucket; first entry wins
+    add_chime_field(payload)
+    add_clock_fields(payload)
+    return payload
+
+
 async def poll_api(token: str) -> dict | None:
     headers = dict(API_HEADERS_TEMPLATE)
     headers["Authorization"] = f"Bearer {token}"
@@ -518,7 +596,11 @@ async def poll_active_payload(selector: PlanSelector = _SELECTOR) -> dict | None
         if not token:
             log(f"No token in {d}; skipping")
             continue
-        payload = await poll_api(token)
+        # Prefer the token-free usage endpoint; fall back to the 1-token
+        # message call (whose overage headers still cover Enterprise accounts).
+        payload = await poll_usage_endpoint(token)
+        if payload is None:
+            payload = await poll_api(token)
         if payload is not None:
             payloads[d] = payload
             sessions[d] = int(payload.get("s", 0) or 0)

--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -2,8 +2,9 @@
 """Claude Usage Tracker Daemon — Windows (Phase 2).
 
 Reads the Claude OAuth token from the native-Windows credentials path and
-polls the Anthropic API for rate-limit utilization data. BLE glue added in
-later plans.
+polls the OAuth usage endpoint (token-free; also carries per-model weekly
+limits), falling back to the Anthropic API rate-limit headers. BLE glue
+added in later plans.
 """
 
 import asyncio
@@ -184,17 +185,35 @@ def add_clock_fields(payload: dict) -> None:
     payload["tf"] = tf
 
 
+# After a 429 from the usage endpoint, skip it for this long and let the
+# message-call fallback carry polling. The endpoint was tried once before
+# (PR #29) and reverted (PR #37) after a rate-limit report — the cooldown
+# ensures a rate-limited endpoint is never hammered on every cycle, and the
+# fixed 60s poll cadence (vs the old 5s retry loop implicated in #29) bounds
+# request volume in the first place.
+USAGE_ENDPOINT_COOLDOWN_S = 900
+_usage_endpoint_cooldown_until = 0.0
+
+
 async def poll_usage_endpoint(token: str) -> dict | None:
     """Poll the OAuth usage endpoint (token-free) and build the BLE payload.
 
     GET /api/oauth/usage returns the same buckets the rate-limit headers carry
     (5h session + 7d weekly) plus per-model scoped weekly limits ("m"/"mn"
     below) — and unlike poll_api() it doesn't spend a 1-token message call per
-    poll. Returns None on any failure or unexpected shape so the caller can
-    fall back to poll_api() (e.g. Enterprise accounts, where the spending
-    limit only surfaces in the overage headers). Raises AuthError on a real
-    401/403 so the tray toast behavior is preserved.
+    poll. Returns None on ANY failure — including 401/403 — so the caller
+    falls back to poll_api(): a genuinely dead token then still raises
+    AuthError from poll_api's proven 401/403 path (SC#5 toast contract), while
+    an endpoint-specific rejection never fires the "token expired" toast.
+    The Pro/Max shape check requires BOTH the 5h and 7d buckets: Enterprise
+    spending-limit accounts have no weekly concept, so a missing bucket routes
+    them (and any future unknown shape) to the fallback rather than
+    misclassifying them as "pro".
     """
+    global _usage_endpoint_cooldown_until
+    now = time.time()
+    if now < _usage_endpoint_cooldown_until:
+        return None   # rate-limit cooldown active — fallback carries this cycle
     headers = {
         "Authorization": f"Bearer {token}",
         "anthropic-beta": API_HEADERS_TEMPLATE["anthropic-beta"],
@@ -206,9 +225,11 @@ async def poll_usage_endpoint(token: str) -> dict | None:
     except httpx.HTTPError as e:
         log(f"Usage endpoint failed: {e}")
         return None
-    if resp.status_code in (401, 403):
-        log(f"Usage endpoint HTTP {resp.status_code}: {resp.text[:200]}")
-        raise AuthError(resp.status_code)
+    if resp.status_code == 429:
+        _usage_endpoint_cooldown_until = now + USAGE_ENDPOINT_COOLDOWN_S
+        log(f"Usage endpoint rate-limited (429) — cooling down for "
+            f"{USAGE_ENDPOINT_COOLDOWN_S // 60} min, using API fallback")
+        return None
     if resp.status_code != 200:
         log(f"Usage endpoint HTTP {resp.status_code}: {resp.text[:200]}")
         return None
@@ -218,17 +239,19 @@ async def poll_usage_endpoint(token: str) -> dict | None:
         return None
     five = data.get("five_hour") or {}
     seven = data.get("seven_day") or {}
-    if five.get("utilization") is None:
-        return None   # shape we don't understand (Enterprise?) — use the fallback
-
-    now = time.time()
+    if five.get("utilization") is None or seven.get("utilization") is None:
+        return None   # not the full Pro/Max shape (Enterprise?) — use the fallback
 
     def reset_minutes_iso(iso: str | None) -> int:
         if not iso:
             return 0
         try:
-            ts = datetime.datetime.fromisoformat(iso).timestamp()
-        except (ValueError, OSError):
+            # Python < 3.11 can't parse a literal "Z" suffix; normalize first.
+            ts = datetime.datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp()
+        except (ValueError, OSError, OverflowError):
+            # Same guard set as _billing_period_info(): out-of-range values
+            # raise OSError/OverflowError on Windows, and garbage must never
+            # take down the poll loop.
             return 0
         mins = (ts - now) / 60.0
         return int(round(mins)) if mins > 0 else 0

--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -47,6 +47,7 @@ RECONNECT_BACKOFF_CAP = 8  # D-05: fast-reconnect cap (seconds); keeps stacked r
 CONFIG_FILE = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local")) / "Clawdmeter" / "config"
 
 API_URL = "https://api.anthropic.com/v1/messages"
+USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 API_HEADERS_TEMPLATE = {
     "anthropic-version": "2023-06-01",
     "anthropic-beta": "oauth-2025-04-20",
@@ -181,6 +182,87 @@ def add_clock_fields(payload: dict) -> None:
     tf = 24 if clock == "24" else 12 if clock == "12" else detect_hour_format()
     payload["t"] = int(time.time()) + time.localtime().tm_gmtoff
     payload["tf"] = tf
+
+
+async def poll_usage_endpoint(token: str) -> dict | None:
+    """Poll the OAuth usage endpoint (token-free) and build the BLE payload.
+
+    GET /api/oauth/usage returns the same buckets the rate-limit headers carry
+    (5h session + 7d weekly) plus per-model scoped weekly limits ("m"/"mn"
+    below) — and unlike poll_api() it doesn't spend a 1-token message call per
+    poll. Returns None on any failure or unexpected shape so the caller can
+    fall back to poll_api() (e.g. Enterprise accounts, where the spending
+    limit only surfaces in the overage headers). Raises AuthError on a real
+    401/403 so the tray toast behavior is preserved.
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "anthropic-beta": API_HEADERS_TEMPLATE["anthropic-beta"],
+        "User-Agent": API_HEADERS_TEMPLATE["User-Agent"],
+    }
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as http:
+            resp = await http.get(USAGE_URL, headers=headers)
+    except httpx.HTTPError as e:
+        log(f"Usage endpoint failed: {e}")
+        return None
+    if resp.status_code in (401, 403):
+        log(f"Usage endpoint HTTP {resp.status_code}: {resp.text[:200]}")
+        raise AuthError(resp.status_code)
+    if resp.status_code != 200:
+        log(f"Usage endpoint HTTP {resp.status_code}: {resp.text[:200]}")
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    five = data.get("five_hour") or {}
+    seven = data.get("seven_day") or {}
+    if five.get("utilization") is None:
+        return None   # shape we don't understand (Enterprise?) — use the fallback
+
+    now = time.time()
+
+    def reset_minutes_iso(iso: str | None) -> int:
+        if not iso:
+            return 0
+        try:
+            ts = datetime.datetime.fromisoformat(iso).timestamp()
+        except (ValueError, OSError):
+            return 0
+        mins = (ts - now) / 60.0
+        return int(round(mins)) if mins > 0 else 0
+
+    def pct_of(v) -> int:
+        try:
+            return max(0, min(100, int(round(float(v)))))
+        except (TypeError, ValueError):
+            return 0
+
+    payload = {
+        "s": pct_of(five.get("utilization")),
+        "sr": reset_minutes_iso(five.get("resets_at")),
+        "w": pct_of(seven.get("utilization")),
+        "wr": reset_minutes_iso(seven.get("resets_at")),
+        "st": "allowed" if pct_of(five.get("utilization")) < 100 else "rejected",
+        "acct": "pro",
+        "ok": True,
+    }
+    # Per-model scoped weekly limit (e.g. "Fable" / "Opus"): the limits array
+    # carries kind == "weekly_scoped" entries with the model's display name.
+    for lim in data.get("limits") or []:
+        if lim.get("kind") != "weekly_scoped":
+            continue
+        scope = lim.get("scope") or {}
+        model = (scope.get("model") or {}).get("display_name")
+        if not model:
+            continue
+        payload["m"] = pct_of(lim.get("percent"))
+        payload["mn"] = str(model)[:15]
+        break   # firmware shows one scoped bucket; first entry wins
+    add_chime_field(payload)
+    add_clock_fields(payload)
+    return payload
 
 
 async def poll_api(token: str) -> dict | None:
@@ -602,7 +684,12 @@ async def connect_and_run(device, stop_event: asyncio.Event, tray_state=None) ->
                         tray_state.set_error("token expired — run claude login")
                 else:
                     try:
-                        payload = await poll_api(token)
+                        # Prefer the token-free usage endpoint; fall back to
+                        # the 1-token message call (whose overage headers
+                        # still cover Enterprise accounts).
+                        payload = await poll_usage_endpoint(token)
+                        if payload is None:
+                            payload = await poll_api(token)
                     except AuthError:
                         # Real 401/403 — token genuinely needs a refresh.
                         if tray_state:

--- a/daemon/tests/test_usage_endpoint.py
+++ b/daemon/tests/test_usage_endpoint.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Unit tests for poll_usage_endpoint (macOS + Windows daemons).
+
+Covers the token-free /api/oauth/usage polling path: nominal Pro/Max
+payloads with per-model scoped weekly limits ("m"/"mn"), fallback signaling
+(None) for non-Pro/Max shapes and errors, the 429 cooldown, the no-AuthError
+contract on 401/403 (poll_api stays the sole authority on token validity),
+and malformed resets_at handling. Parametrized over both Python daemons so
+the two implementations can't drift apart.
+
+All tests mock httpx so no real network calls are made.
+
+Run: python -m pytest daemon/tests/test_usage_endpoint.py -x -q
+"""
+import asyncio
+import copy
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import daemon.claude_usage_daemon as mac_daemon
+import daemon.claude_usage_daemon_windows as win_daemon
+
+DAEMONS = [
+    pytest.param(mac_daemon, id="macos"),
+    pytest.param(win_daemon, id="windows"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _usage_body(now: float) -> dict:
+    """A realistic /api/oauth/usage response body (Pro/Max shape, one scoped
+    per-model weekly limit), shaped after a live capture."""
+    iso_5h = _iso(now + 3600)     # 60 minutes out
+    iso_7d = _iso(now + 86400)    # 1440 minutes out
+    return {
+        "five_hour": {"utilization": 42.0, "resets_at": iso_5h},
+        "seven_day": {"utilization": 10.0, "resets_at": iso_7d},
+        "limits": [
+            {"kind": "session", "group": "session", "percent": 42,
+             "resets_at": iso_5h, "scope": None},
+            {"kind": "weekly_all", "group": "weekly", "percent": 10,
+             "resets_at": iso_7d, "scope": None},
+            {"kind": "weekly_scoped", "group": "weekly", "percent": 66,
+             "resets_at": iso_7d,
+             "scope": {"model": {"id": None, "display_name": "Fable"},
+                       "surface": None}},
+        ],
+    }
+
+
+def _iso(epoch: float) -> str:
+    return (
+        time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(epoch)) + "+00:00"
+    )
+
+
+def _make_mock_response(status_code=200, body=None, text="mocked"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    if body is not None:
+        resp.json = MagicMock(return_value=body)
+    else:
+        resp.json = MagicMock(side_effect=ValueError("not json"))
+    return resp
+
+
+def _patch_get(mock_resp):
+    async def fake_get(*args, **kwargs):
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = fake_get
+    return patch("httpx.AsyncClient", return_value=mock_client)
+
+
+def _run(coro):
+    """Fresh event loop per call — keeps tests order-independent (see
+    test_windows_poll.py for the 3.12 get_event_loop rationale)."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown():
+    """The 429 cooldown is module-level state; clear it around every test."""
+    mac_daemon._usage_endpoint_cooldown_until = 0.0
+    win_daemon._usage_endpoint_cooldown_until = 0.0
+    yield
+    mac_daemon._usage_endpoint_cooldown_until = 0.0
+    win_daemon._usage_endpoint_cooldown_until = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Nominal path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod", DAEMONS)
+def test_nominal_payload_with_scoped_model(mod):
+    now = time.time()
+    resp = _make_mock_response(200, _usage_body(now))
+    with _patch_get(resp):
+        payload = _run(mod.poll_usage_endpoint("fake-token"))
+
+    assert payload is not None
+    assert payload["s"] == 42
+    assert payload["w"] == 10
+    assert payload["st"] == "allowed"
+    assert payload["acct"] == "pro"
+    assert payload["ok"] is True
+    assert payload["m"] == 66
+    assert payload["mn"] == "Fable"
+    assert abs(payload["sr"] - 60) <= 1
+    assert abs(payload["wr"] - 1440) <= 1
+
+
+@pytest.mark.parametrize("mod", DAEMONS)
+def test_model_name_truncated_to_15_chars(mod):
+    body = _usage_body(time.time())
+    body["limits"][2]["scope"]["model"]["display_name"] = "A" * 40
+    with _patch_get(_make_mock_response(200, body)):
+        payload = _run(mod.poll_usage_endpoint("fake-token"))
+    assert payload is not None
+    assert payload["mn"] == "A" * 15   # fits firmware's char model_name[16]
+
+
+@pytest.mark.parametrize("mod", DAEMONS)
+def test_first_named_scoped_limit_wins(mod):
+    body = _usage_body(time.time())
+    nameless = copy.deepcopy(body["limits"][2])
+    nameless["scope"]["model"]["display_name"] = None
+    second = copy.deepcopy(body["limits"][2])
+    second["percent"] = 90
+    second["scope"]["model"]["display_name"] = "Opus"
+    body["limits"] = body["limits"][:2] + [nameless, body["limits"][2], second]
+    with _patch_get(_make_mock_response(200, body)):
+        payload = _run(mod.poll_usage_endpoint("fake-token"))
+    assert payload is not None
+    assert payload["m"] == 66          # nameless entry skipped, first named wins
+    assert payload["mn"] == "Fable"
+
+
+@pytest.mark.parametrize("mod", DAEMONS)
+def test_no_scoped_limit_omits_model_fields(mod):
+    body = _usage_body(time.time())
+    body["limits"] = body["limits"][:2]
+    with _patch_get(_make_mock_response(200, body)):
+        payload = _run(mod.poll_usage_endpoint("fake-token"))
+    assert payload is not None
+    assert "m" not in payload          # firmware hides the row when absent
+    assert "mn" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Fallback signaling — every non-Pro/Max outcome must return None so the
+# caller falls back to poll_api (which owns Enterprise detection and, on
+# Windows, the AuthError toast contract).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod", DAEMONS)
+@pytest.mark.parametrize("missing", ["five_hour", "seven_day"])
+def test_missing_bucket_falls_back(mod, missing):
+    body = _usage_body(time.time())
+    body[missing] = None               # e.g. Enterprise shape
+    with _patch_get(_make_mock_response(200, body)):
+        assert _run(mod.poll_usage_endpoint("fake-token")) is None
+
+
+@pytest.mark.parametrize("mod", DAEMONS)
+@pytest.mark.parametrize("status", [401, 403, 500, 503])
+def test_http_errors_fall_back_without_raising(mod, status):
+    with _patch_get(_make_mock_response(status, None, text="err")):
+        assert _run(mod.poll_usage_endpoint("fake-token")) is None
+
+
+@pytest.mark.parametrize("mod", DAEMONS)
+def test_non_json_body_falls_back(mod):
+    with _patch_get(_make_mock_response(200, None)):
+        assert _run(mod.poll_usage_endpoint("fake-token")) is None
+
+
+# ---------------------------------------------------------------------------
+# 429 cooldown — a rate-limited endpoint must not be retried every cycle
+# (regression guard for the PR #29 / #37 rate-limit incident).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod", DAEMONS)
+def test_429_sets_cooldown_and_skips_next_poll(mod):
+    with _patch_get(_make_mock_response(429, None, text="rate limited")):
+        assert _run(mod.poll_usage_endpoint("fake-token")) is None
+    assert mod._usage_endpoint_cooldown_until > time.time()
+
+    # Next poll inside the cooldown must not touch the network at all.
+    async def explode(*args, **kwargs):
+        raise AssertionError("endpoint polled during cooldown")
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = explode
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        assert _run(mod.poll_usage_endpoint("fake-token")) is None
+
+
+@pytest.mark.parametrize("mod", DAEMONS)
+def test_cooldown_expires(mod):
+    mod._usage_endpoint_cooldown_until = time.time() - 1   # already expired
+    resp = _make_mock_response(200, _usage_body(time.time()))
+    with _patch_get(resp):
+        assert _run(mod.poll_usage_endpoint("fake-token")) is not None
+
+
+# ---------------------------------------------------------------------------
+# resets_at robustness — garbage must degrade to 0, never raise
+# (same guard class as _billing_period_info; see PRs #104 / #106).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod", DAEMONS)
+@pytest.mark.parametrize("bad_iso", [
+    "not-a-date",
+    "99999-01-01T00:00:00+00:00",       # out of range for fromisoformat
+    "",
+    None,
+])
+def test_malformed_resets_at_degrades_to_zero(mod, bad_iso):
+    body = _usage_body(time.time())
+    body["five_hour"]["resets_at"] = bad_iso
+    body["seven_day"]["resets_at"] = bad_iso
+    with _patch_get(_make_mock_response(200, body)):
+        payload = _run(mod.poll_usage_endpoint("fake-token"))
+    assert payload is not None
+    assert payload["sr"] == 0
+    assert payload["wr"] == 0
+
+
+@pytest.mark.parametrize("mod", DAEMONS)
+def test_z_suffix_resets_at_parses(mod):
+    now = time.time()
+    body = _usage_body(now)
+    body["five_hour"]["resets_at"] = (
+        time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(now + 3600)) + "Z"
+    )
+    with _patch_get(_make_mock_response(200, body)):
+        payload = _run(mod.poll_usage_endpoint("fake-token"))
+    assert payload is not None
+    assert abs(payload["sr"] - 60) <= 1

--- a/firmware/src/data.h
+++ b/firmware/src/data.h
@@ -6,6 +6,9 @@ struct UsageData {
     int session_reset_mins;  // minutes until reset
     float weekly_pct;        // 7-day utilization (Pro/Max only; 0 for Enterprise)
     int weekly_reset_mins;   // minutes until weekly reset (Pro/Max only)
+    bool has_model;          // a per-model scoped weekly bucket is present
+    float model_pct;         // scoped 7-day utilization (e.g. Fable/Opus)
+    char model_name[16];     // scoped model display name from the daemon
     char status[16];         // "allowed", "limited", etc.
     bool chime;              // play the session-reset chime; false unless daemon opts in
     bool enterprise;         // true = Enterprise spending-limit account

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -110,6 +110,9 @@ static bool parse_json(const char* json, UsageData* out) {
     out->session_reset_mins = doc["sr"] | -1;
     out->weekly_pct = doc["w"] | 0.0f;
     out->weekly_reset_mins = doc["wr"] | -1;
+    out->has_model = !doc["m"].isNull();   // absent (old daemon) → single-bar weekly
+    out->model_pct = doc["m"] | 0.0f;
+    strlcpy(out->model_name, doc["mn"] | "", sizeof(out->model_name));
     strlcpy(out->status, doc["st"] | "unknown", sizeof(out->status));
     out->chime = doc["c"] | false;   // absent (old daemon / chime off) → stay silent
     const char* acct = doc["acct"] | "pro";

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -37,8 +37,10 @@ struct Layout {
     int16_t usage_reset_y;
     // Split-weekly mode: when the daemon reports a per-model scoped weekly
     // bucket ("m"/"mn"), the weekly panel adds a slim model row between the
-    // main bar and the reset line. Everything fits inside usage_panel_h by
-    // tightening the internal spacing — no panel or screen layout shifts.
+    // main bar and the reset line. The panel grows to split_panel_h so the
+    // main bar keeps the same y as the session panel's — the two bars stay
+    // on one visual grid; every breakpoint has clearance below for the growth.
+    int16_t split_panel_h;           // weekly panel height in split mode
     int16_t split_bar_y;             // main weekly bar y in split mode
     int16_t model_row_y;             // model name/pct labels y
     int16_t model_bar_y;             // slim model bar y
@@ -121,13 +123,14 @@ static void compute_layout(const BoardCaps& c) {
         L.usage_panel_gap = 16;
         L.usage_bar_y = 56;
         L.usage_reset_y = 94;
-        L.split_bar_y = 44;
-        L.model_row_y = 76;
-        L.model_bar_y = 82;
-        L.model_bar_h = 14;
+        L.split_panel_h = 162;
+        L.split_bar_y = 56;
+        L.model_row_y = 88;
+        L.model_bar_y = 94;
+        L.model_bar_h = 12;
         L.model_name_w = 96;
         L.model_pct_w = 60;
-        L.split_reset_y = 110;
+        L.split_reset_y = 118;
         L.model_font = &font_styrene_24;
         L.bt_info_panel_h = 160;
         L.bt_reset_zone_h = 110;
@@ -143,13 +146,14 @@ static void compute_layout(const BoardCaps& c) {
         L.usage_panel_gap = 12;
         L.usage_bar_y = 48;
         L.usage_reset_y = 78;
-        L.split_bar_y = 42;
-        L.model_row_y = 70;
-        L.model_bar_y = 75;
+        L.split_panel_h = 146;
+        L.split_bar_y = 48;
+        L.model_row_y = 80;
+        L.model_bar_y = 85;
         L.model_bar_h = 10;
         L.model_name_w = 86;
         L.model_pct_w = 54;
-        L.split_reset_y = 96;
+        L.split_reset_y = 106;
         L.model_font = &font_styrene_20;
         L.bt_info_panel_h = 140;
         L.bt_reset_zone_h = 90;
@@ -169,13 +173,14 @@ static void compute_layout(const BoardCaps& c) {
         L.usage_panel_gap = 6;
         L.usage_bar_y = 30;
         L.usage_reset_y = 46;
-        L.split_bar_y = 24;
-        L.model_row_y = 40;
-        L.model_bar_y = 43;
+        L.split_panel_h = 82;
+        L.split_bar_y = 30;
+        L.model_row_y = 46;
+        L.model_bar_y = 49;
         L.model_bar_h = 8;
         L.model_name_w = 52;
         L.model_pct_w = 38;
-        L.split_reset_y = 56;
+        L.split_reset_y = 62;
         L.model_font = &font_styrene_12;
         L.bar_h = 12;
         L.panel_pad_x = 10;
@@ -724,6 +729,7 @@ void ui_update(const UsageData* data) {
     // the main bar + reset line into their split-mode positions; single-bar
     // layout is restored whenever the daemon stops reporting a scoped bucket.
     bool split = data->has_model && !data->enterprise;
+    lv_obj_set_height(panel_weekly, split ? L.split_panel_h : L.usage_panel_h);
     lv_obj_set_y(bar_weekly, split ? L.split_bar_y : L.usage_bar_y);
     lv_obj_set_y(lbl_weekly_reset, split ? L.split_reset_y : L.usage_reset_y);
     if (split) {

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -35,6 +35,18 @@ struct Layout {
     int16_t usage_panel_gap;
     int16_t usage_bar_y;
     int16_t usage_reset_y;
+    // Split-weekly mode: when the daemon reports a per-model scoped weekly
+    // bucket ("m"/"mn"), the weekly panel adds a slim model row between the
+    // main bar and the reset line. Everything fits inside usage_panel_h by
+    // tightening the internal spacing — no panel or screen layout shifts.
+    int16_t split_bar_y;             // main weekly bar y in split mode
+    int16_t model_row_y;             // model name/pct labels y
+    int16_t model_bar_y;             // slim model bar y
+    int16_t model_bar_h;             // slim model bar height
+    int16_t model_name_w;            // reserved width for the model name column
+    int16_t model_pct_w;             // reserved width for the model pct column
+    int16_t split_reset_y;           // reset line y in split mode
+    const lv_font_t* model_font;     // model row name + pct font
     int16_t bar_h;
     int16_t panel_pad_x, panel_pad_y;
     int16_t pill_pad_x, pill_pad_y;
@@ -109,6 +121,14 @@ static void compute_layout(const BoardCaps& c) {
         L.usage_panel_gap = 16;
         L.usage_bar_y = 56;
         L.usage_reset_y = 94;
+        L.split_bar_y = 44;
+        L.model_row_y = 76;
+        L.model_bar_y = 82;
+        L.model_bar_h = 14;
+        L.model_name_w = 96;
+        L.model_pct_w = 60;
+        L.split_reset_y = 110;
+        L.model_font = &font_styrene_24;
         L.bt_info_panel_h = 160;
         L.bt_reset_zone_h = 110;
         L.bt_title_font    = &font_tiempos_56;
@@ -123,6 +143,14 @@ static void compute_layout(const BoardCaps& c) {
         L.usage_panel_gap = 12;
         L.usage_bar_y = 48;
         L.usage_reset_y = 78;
+        L.split_bar_y = 42;
+        L.model_row_y = 70;
+        L.model_bar_y = 75;
+        L.model_bar_h = 10;
+        L.model_name_w = 86;
+        L.model_pct_w = 54;
+        L.split_reset_y = 96;
+        L.model_font = &font_styrene_20;
         L.bt_info_panel_h = 140;
         L.bt_reset_zone_h = 90;
         L.bt_title_font    = &font_tiempos_34;
@@ -141,6 +169,14 @@ static void compute_layout(const BoardCaps& c) {
         L.usage_panel_gap = 6;
         L.usage_bar_y = 30;
         L.usage_reset_y = 46;
+        L.split_bar_y = 24;
+        L.model_row_y = 40;
+        L.model_bar_y = 43;
+        L.model_bar_h = 8;
+        L.model_name_w = 52;
+        L.model_pct_w = 38;
+        L.split_reset_y = 56;
+        L.model_font = &font_styrene_12;
         L.bar_h = 12;
         L.panel_pad_x = 10;
         L.panel_pad_y = 6;
@@ -208,6 +244,10 @@ static lv_obj_t* bar_weekly;
 static lv_obj_t* lbl_weekly_pct;
 static lv_obj_t* lbl_weekly_label;
 static lv_obj_t* lbl_weekly_reset;
+// Per-model scoped weekly row (split-weekly mode); hidden until data arrives.
+static lv_obj_t* lbl_model_name = nullptr;
+static lv_obj_t* bar_model = nullptr;
+static lv_obj_t* lbl_model_pct = nullptr;
 static lv_obj_t* panel_session = nullptr;
 static lv_obj_t* panel_weekly = nullptr;
 // Enterprise-only widgets inside panel_session
@@ -527,6 +567,31 @@ static void init_usage_screen(lv_obj_t* scr) {
     // Recolor enabled so enterprise period box can color pace and reset separately
     lv_label_set_recolor(lbl_weekly_reset, true);
 
+    // Per-model scoped weekly row (e.g. "Fable"): name + slim bar + pct, sitting
+    // between the main weekly bar and the reset line. Hidden until the daemon
+    // reports a scoped bucket; ui_update() shifts bar/reset into split positions.
+    int model_bar_w = (L.content_w - 2 * L.panel_pad_x)
+                      - L.model_name_w - L.model_pct_w;
+    lbl_model_name = lv_label_create(panel_weekly);
+    lv_label_set_text(lbl_model_name, "");
+    lv_obj_set_style_text_font(lbl_model_name, L.model_font, 0);
+    lv_obj_set_style_text_color(lbl_model_name, COL_DIM, 0);
+    lv_obj_set_width(lbl_model_name, L.model_name_w - 6);
+    lv_label_set_long_mode(lbl_model_name, LV_LABEL_LONG_DOT);
+    lv_obj_set_pos(lbl_model_name, 0, L.model_row_y);
+    lv_obj_add_flag(lbl_model_name, LV_OBJ_FLAG_HIDDEN);
+
+    bar_model = make_bar(panel_weekly, L.model_name_w, L.model_bar_y,
+                         model_bar_w, L.model_bar_h);
+    lv_obj_add_flag(bar_model, LV_OBJ_FLAG_HIDDEN);
+
+    lbl_model_pct = lv_label_create(panel_weekly);
+    lv_label_set_text(lbl_model_pct, "---%");
+    lv_obj_set_style_text_font(lbl_model_pct, L.model_font, 0);
+    lv_obj_set_style_text_color(lbl_model_pct, COL_TEXT, 0);
+    lv_obj_align(lbl_model_pct, LV_ALIGN_TOP_RIGHT, 0, L.model_row_y);
+    lv_obj_add_flag(lbl_model_pct, LV_OBJ_FLAG_HIDDEN);
+
     build_pair_group(usage_container);
     build_idle_group(usage_container);
 
@@ -653,6 +718,28 @@ void ui_update(const UsageData* data) {
         lv_obj_set_style_bg_color(bar_weekly, pct_color(data->weekly_pct), LV_PART_INDICATOR);
         format_reset_time(data->weekly_reset_mins, buf, sizeof(buf));
         lv_label_set_text(lbl_weekly_reset, buf);
+    }
+
+    // Split-weekly mode: show the per-model scoped row (e.g. Fable) and shift
+    // the main bar + reset line into their split-mode positions; single-bar
+    // layout is restored whenever the daemon stops reporting a scoped bucket.
+    bool split = data->has_model && !data->enterprise;
+    lv_obj_set_y(bar_weekly, split ? L.split_bar_y : L.usage_bar_y);
+    lv_obj_set_y(lbl_weekly_reset, split ? L.split_reset_y : L.usage_reset_y);
+    if (split) {
+        int m_pct = (int)(data->model_pct + 0.5f);
+        lv_label_set_text(lbl_model_name,
+                          data->model_name[0] ? data->model_name : "Model");
+        lv_label_set_text_fmt(lbl_model_pct, "%d%%", m_pct);
+        lv_bar_set_value(bar_model, m_pct, LV_ANIM_ON);
+        lv_obj_set_style_bg_color(bar_model, pct_color(data->model_pct), LV_PART_INDICATOR);
+        lv_obj_clear_flag(lbl_model_name, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(bar_model, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(lbl_model_pct, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_add_flag(lbl_model_name, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(bar_model, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(lbl_model_pct, LV_OBJ_FLAG_HIDDEN);
     }
 }
 


### PR DESCRIPTION
## What

Claude Code's `/usage` view shows a per-model weekly limit alongside the all-models one (e.g. "Current week (Fable)"). This PR brings that to the device, and switches the Python daemons to a token-free data source:

- The **weekly panel** gains a slim per-model row — model name + bar + percent — between the main weekly bar and the reset line. The name comes from the API (`Fable`, `Opus`, …), so it adapts to whatever plan the account has. When no scoped bucket is reported (old daemon, or the unchanged bash daemon), the single-bar layout is exactly as before.
- The **macOS and Windows daemons** poll `GET /api/oauth/usage` — the endpoint the Claude Code client itself reads for `/usage`. It returns the same 5h/7d buckets as the rate-limit headers, plus the per-model scoped weekly limits, and costs zero tokens (the message-call approach burns ~1,440 tokens/day at the 60s cadence).

New payload fields (absent = firmware hides the row): `"m"` = scoped weekly percent, `"mn"` = model display name (truncated to 15 chars for the firmware's buffer).

## Layout rationale

A third full panel would overflow every breakpoint, so the model row lives inside the weekly panel. In split mode the weekly panel grows slightly taller (`split_panel_h`, per breakpoint) rather than squeezing its contents: this keeps the main weekly bar at the **same y offset as the session panel's bar**, so the two panels' repeated structure (pill → big % → bar → reset line) stays on one visual grid. Every breakpoint has clearance below the weekly panel for the growth, and the height is restored whenever split mode ends.

## The endpoint history — called out explicitly

`/api/oauth/usage` was adopted once before (#29) and reverted (#37) after a rate-limit report. That incident involved a 5s retry loop that re-hammered the endpoint on every failure. This PR's approach differs in three ways:

1. **Fixed 60s cadence** — the endpoint is hit at most once per poll cycle per config dir, never in a retry loop.
2. **429 cooldown** — a rate-limit response benches the endpoint for 15 minutes (`USAGE_ENDPOINT_COOLDOWN_S`) while the fallback carries polling, with a regression test asserting no network calls happen during cooldown.
3. **Automatic fallback** — any failure or unrecognized shape falls back to the existing `/v1/messages` header method that cycle, so behavior can never be worse than today.

The endpoint is still undocumented and could change shape; the fallback is the safety net for that too (related: #42 — the headers themselves have been renamed before).

Two deliberate contract decisions, since this endpoint is unproven for edge cases:

- **Enterprise accounts**: the endpoint is only trusted when the response has **both** `five_hour` and `seven_day` utilization (Enterprise has no weekly concept). Anything else routes to `poll_api()`, which remains the sole authority on Enterprise detection.
- **Windows toast**: `poll_usage_endpoint()` never raises `AuthError` — on 401/403 it returns `None` and falls back, so a genuinely dead token still fires the "token expired" toast from `poll_api()`'s proven path, and an endpoint-specific rejection can never fire a false toast.

The Linux bash daemon is unchanged (still header-based, no per-model row) — parsing nested JSON in bash without a jq dependency felt out of scope. Happy to file a parity follow-up issue like #97/#98.

## Testing

- Live on a Max account: endpoint polled every 60s across an extended session; values match the header method; ~0.3s round trip.
- **Hardware-verified on all three layout breakpoints**, all with identical canned data for apples-to-apples comparison:
  - **Large (480×480)** — ESP32-C6-Touch-AMOLED-2.16, live daemon data:

    ![Large layout on AMOLED-2.16](https://raw.githubusercontent.com/jkbdco/Clawdmeter/assets-pr128/per-model-weekly-c6.png)
  - **Compact (368×448)** — ESP32-S3-Touch-AMOLED-1.8, on-device framebuffer capture via the `screenshot` serial command:

    ![Compact layout on AMOLED-1.8](https://raw.githubusercontent.com/jkbdco/Clawdmeter/assets-pr128/compact-split-368x448.png)
  - **Small (240×240)** — rendered via a temporary geometry override on the same S3 hardware and captured from the framebuffer (no 1.54 unit on hand; the capture exercises the exact layout code path):

    ![Small layout](https://raw.githubusercontent.com/jkbdco/Clawdmeter/assets-pr128/small-split-240x240.png)
- **Old-daemon compatibility on hardware**: an unmodified header-method daemon pushing to the new firmware renders the unchanged single-bar weekly (verified incidentally when one connected mid-test).
- **Unit tests**: `daemon/tests/test_usage_endpoint.py`, parametrized over both Python daemons (36 cases: nominal + scoped-model parsing, name truncation vs the firmware buffer, fallback signaling for every non-Pro/Max outcome, 429 cooldown incl. no-network-during-cooldown, malformed `resets_at` degradation per the #104/#106 guard precedent). Full daemon suite passes.
- All seven firmware envs build; three regression-built on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
