### PR TITLE
fix(daemon): don't let a stale .credentials.json shadow the live token

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ After flashing, open **System Settings → Bluetooth** and click *Connect* next 
 
 ### Install the daemon
 
-The daemon reads your Claude OAuth token from the macOS Keychain (service `Claude Code-credentials`), polls usage every 60 s, and pushes it to the display over BLE.
+The daemon reads your Claude OAuth token from the macOS Keychain (service `Claude Code-credentials`), polls usage every 60 s, and pushes it to the display over BLE. A `~/.claude/.credentials.json` file takes priority when present and unexpired — an expired one is ignored so it can't shadow the Keychain entry Claude Code keeps refreshed. If the log shows `API HTTP 401 … OAuth access token has expired` every cycle, re-run `claude login`.
 
 ```bash
 ./install-mac.sh

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -77,7 +77,7 @@ def _extract_access_token(blob: str) -> str | None:
         # direct: {"accessToken": "..."}
         tok = data.get("accessToken")
         if isinstance(tok, str) and tok.strip():
-            return tok
+            return tok.strip()
         # nested: {"claudeAiOauth": {"accessToken": "..."}}. claudeAiOauth is
         # tried FIRST — a real blob holds one accessToken per OAuth integration
         # (MCP servers, design tools) and any of those as a Bearer 401s. Same
@@ -86,10 +86,10 @@ def _extract_access_token(blob: str) -> str | None:
             if isinstance(v, dict):
                 tok = v.get("accessToken")
                 if isinstance(tok, str) and tok.strip():
-                    return tok
+                    return tok.strip()
     m = re.search(r'"accessToken"\s*:\s*"([^"]+)"', blob)
     if m and m.group(1).strip():
-        return m.group(1)
+        return m.group(1).strip()
     # Raw token (no JSON wrapper) — must look plausible (sk-ant-... etc.)
     if re.fullmatch(r"[A-Za-z0-9_\-.~+/=]{20,}", blob):
         return blob
@@ -180,8 +180,11 @@ def read_token_for(config_dir: Path) -> str | None:
         if cred.exists():
             blob = cred.read_text()
             if not _oauth_expired(blob):
-                return _extract_access_token(blob)
-            log(f"Ignoring expired token in {cred} (re-run `claude login` if this persists)")
+                token = _extract_access_token(blob)
+                if token is not None:
+                    return token
+            else:
+                log(f"Ignoring expired token in {cred} (re-run `claude login` if this persists)")
     except OSError as e:
         log(f"Error reading credentials in {config_dir}: {e}")
     if sys.platform == "darwin" and config_dir == DEFAULT_CONFIG_DIR:

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -75,19 +75,39 @@ def _extract_access_token(blob: str) -> str | None:
         data = None
     if isinstance(data, dict):
         # direct: {"accessToken": "..."}
-        if isinstance(data.get("accessToken"), str):
-            return data["accessToken"]
-        # nested: {"claudeAiOauth": {"accessToken": "..."}}
-        for v in data.values():
-            if isinstance(v, dict) and isinstance(v.get("accessToken"), str):
-                return v["accessToken"]
+        tok = data.get("accessToken")
+        if isinstance(tok, str) and tok.strip():
+            return tok
+        # nested: {"claudeAiOauth": {"accessToken": "..."}}. claudeAiOauth is
+        # tried FIRST — a real blob holds one accessToken per OAuth integration
+        # (MCP servers, design tools) and any of those as a Bearer 401s. Same
+        # rule as the bash daemon's read_token_for (tests/test_bash_token.sh).
+        for v in (data.get("claudeAiOauth"), *data.values()):
+            if isinstance(v, dict):
+                tok = v.get("accessToken")
+                if isinstance(tok, str) and tok.strip():
+                    return tok
     m = re.search(r'"accessToken"\s*:\s*"([^"]+)"', blob)
-    if m:
+    if m and m.group(1).strip():
         return m.group(1)
     # Raw token (no JSON wrapper) — must look plausible (sk-ant-... etc.)
     if re.fullmatch(r"[A-Za-z0-9_\-.~+/=]{20,}", blob):
         return blob
     return None
+
+
+def _oauth_expired(blob: str) -> bool:
+    """True iff the blob's claudeAiOauth.expiresAt is already in the past.
+
+    expiresAt is JS-convention epoch milliseconds. An absent or unparseable
+    expiry counts as not-expired — trying a token and reading the API's answer
+    beats skipping a good one.
+    """
+    try:
+        exp = json.loads(blob)["claudeAiOauth"]["expiresAt"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return False
+    return isinstance(exp, (int, float)) and exp / 1000 <= time.time()
 
 
 def _read_token_keychain() -> str | None:
@@ -149,11 +169,19 @@ def read_token_for(config_dir: Path) -> str | None:
     single-plan macOS behavior. Additional macOS dirs are read from their files;
     a work plan whose token lives only in the single Keychain entry can't be told
     apart there (documented follow-up).
+
+    An expired file is skipped rather than returned: on macOS a leftover
+    .credentials.json shadows the Keychain entry that Claude Code actually
+    keeps refreshed, so preferring the file means every poll 401s
+    ("OAuth access token has expired") forever with nothing to self-heal it.
     """
     cred = config_dir / ".credentials.json"
     try:
         if cred.exists():
-            return _extract_access_token(cred.read_text())
+            blob = cred.read_text()
+            if not _oauth_expired(blob):
+                return _extract_access_token(blob)
+            log(f"Ignoring expired token in {cred} (re-run `claude login` if this persists)")
     except OSError as e:
         log(f"Error reading credentials in {config_dir}: {e}")
     if sys.platform == "darwin" and config_dir == DEFAULT_CONFIG_DIR:

--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -428,14 +428,17 @@ def _extract_access_token(blob: str) -> str | None:
         tok = data.get("accessToken")
         if isinstance(tok, str) and tok.strip():
             return tok
-        # nested: {"claudeAiOauth": {"accessToken": "..."}}
-        for v in data.values():
+        # nested: {"claudeAiOauth": {"accessToken": "..."}}. claudeAiOauth is
+        # tried FIRST — a real blob holds one accessToken per OAuth integration
+        # (MCP servers, design tools) and any of those as a Bearer 401s. Same
+        # rule as the bash daemon's read_token_for (tests/test_bash_token.sh).
+        for v in (data.get("claudeAiOauth"), *data.values()):
             if isinstance(v, dict):
                 tok = v.get("accessToken")
                 if isinstance(tok, str) and tok.strip():
                     return tok
     m = re.search(r'"accessToken"\s*:\s*"([^"]+)"', blob)
-    if m:
+    if m and m.group(1).strip():
         return m.group(1)
     # Raw token (no JSON wrapper) — must look plausible (sk-ant-... etc.)
     if re.fullmatch(r"[A-Za-z0-9_\-.~+/=]{20,}", blob):

--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -427,7 +427,7 @@ def _extract_access_token(blob: str) -> str | None:
         # direct: {"accessToken": "..."}
         tok = data.get("accessToken")
         if isinstance(tok, str) and tok.strip():
-            return tok
+            return tok.strip()
         # nested: {"claudeAiOauth": {"accessToken": "..."}}. claudeAiOauth is
         # tried FIRST — a real blob holds one accessToken per OAuth integration
         # (MCP servers, design tools) and any of those as a Bearer 401s. Same
@@ -436,10 +436,10 @@ def _extract_access_token(blob: str) -> str | None:
             if isinstance(v, dict):
                 tok = v.get("accessToken")
                 if isinstance(tok, str) and tok.strip():
-                    return tok
+                    return tok.strip()
     m = re.search(r'"accessToken"\s*:\s*"([^"]+)"', blob)
     if m and m.group(1).strip():
-        return m.group(1)
+        return m.group(1).strip()
     # Raw token (no JSON wrapper) — must look plausible (sk-ant-... etc.)
     if re.fullmatch(r"[A-Za-z0-9_\-.~+/=]{20,}", blob):
         return blob

--- a/daemon/tests/test_macos_multidir.py
+++ b/daemon/tests/test_macos_multidir.py
@@ -82,6 +82,14 @@ def test_token_for_unexpired_file_still_wins_over_keychain(tmp_path, monkeypatch
         assert read_token_for(tmp_path) == "TOK_FILE"
 
 
+def test_token_for_unusable_file_falls_back_to_keychain(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(mod.sys, "platform", "darwin")
+    (tmp_path / ".credentials.json").write_text('{"claudeAiOauth":{}}')
+    with patch.object(mod, "_read_token_keychain", return_value="TOK_KEYCHAIN"):
+        assert read_token_for(tmp_path) == "TOK_KEYCHAIN"
+
+
 def test_token_for_expired_file_falls_back_to_keychain(tmp_path, monkeypatch):
     """A stale .credentials.json must not shadow the Keychain token Claude Code refreshes.
 
@@ -136,6 +144,15 @@ def test_extract_empty_token_is_none():
     assert mod._extract_access_token('{"accessToken": ""}') is None
     assert mod._extract_access_token('{"claudeAiOauth":{"accessToken":"  "}}') is None
     assert mod._extract_access_token("{}") is None
+
+
+def test_extract_strips_token_whitespace_for_both_python_daemons():
+    from daemon.claude_usage_daemon_windows import _extract_access_token as win_extract
+
+    for extract in (mod._extract_access_token, win_extract):
+        assert extract('{"accessToken":"  TOK_DIRECT  "}') == "TOK_DIRECT"
+        assert extract('{"claudeAiOauth":{"accessToken":"  TOK_NESTED  "}}') == "TOK_NESTED"
+        assert extract('[{"accessToken":"  TOK_REGEX  "}]') == "TOK_REGEX"
 
 
 def test_oauth_expired_handles_odd_shapes():

--- a/daemon/tests/test_macos_multidir.py
+++ b/daemon/tests/test_macos_multidir.py
@@ -6,6 +6,7 @@ Covers read_config_dirs, read_token_for, PlanSelector, and poll_active_payload.
 Run: python -m pytest daemon/tests/test_macos_multidir.py -x -q
 """
 import asyncio
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -68,6 +69,81 @@ def test_token_for_file_wins_over_keychain(tmp_path, monkeypatch):
     (tmp_path / ".credentials.json").write_text('{"accessToken":"TOK_FILE"}')
     with patch.object(mod, "_read_token_keychain", return_value="TOK_KEYCHAIN"):
         assert read_token_for(tmp_path) == "TOK_FILE"
+
+
+def test_token_for_unexpired_file_still_wins_over_keychain(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(mod.sys, "platform", "darwin")
+    future_ms = int((time.time() + 3600) * 1000)
+    (tmp_path / ".credentials.json").write_text(
+        '{"claudeAiOauth":{"accessToken":"TOK_FILE","expiresAt":%d}}' % future_ms
+    )
+    with patch.object(mod, "_read_token_keychain", return_value="TOK_KEYCHAIN"):
+        assert read_token_for(tmp_path) == "TOK_FILE"
+
+
+def test_token_for_expired_file_falls_back_to_keychain(tmp_path, monkeypatch):
+    """A stale .credentials.json must not shadow the Keychain token Claude Code refreshes.
+
+    Regression guard: returning the expired file token makes every poll 401 with
+    "OAuth access token has expired" and nothing recovers it (no daemon refreshes).
+    """
+    monkeypatch.setattr(mod, "DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(mod.sys, "platform", "darwin")
+    past_ms = int((time.time() - 3600) * 1000)
+    (tmp_path / ".credentials.json").write_text(
+        '{"claudeAiOauth":{"accessToken":"TOK_STALE","expiresAt":%d}}' % past_ms
+    )
+    with patch.object(mod, "_read_token_keychain", return_value="TOK_KEYCHAIN"):
+        assert read_token_for(tmp_path) == "TOK_KEYCHAIN"
+
+
+def test_token_for_expired_file_no_keychain_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod.sys, "platform", "linux")
+    past_ms = int((time.time() - 3600) * 1000)
+    (tmp_path / ".credentials.json").write_text(
+        '{"claudeAiOauth":{"accessToken":"TOK_STALE","expiresAt":%d}}' % past_ms
+    )
+    assert read_token_for(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_access_token — must pick claudeAiOauth, not the first OAuth entry
+# ---------------------------------------------------------------------------
+
+# Real blobs carry one accessToken per OAuth integration. Any non-claudeAiOauth
+# token as a Bearer 401s; the bash daemon already guards this
+# (tests/test_bash_token.sh) — these are the Python ports' equivalent.
+_MULTI_OAUTH = (
+    '{"designOauth":{"accessToken":"sk-ant-oat01-DESIGN-WRONG","refreshToken":"rt2"},'
+    '"mcpOAuth":{"contentful|abc":{"accessToken":"mcp-contentful-TOKEN","expiresAt":0}},'
+    '"claudeAiOauth":{"accessToken":"sk-ant-oat01-CLAUDE-REAL","refreshToken":"rt",'
+    '"expiresAt":1783620177377,"subscriptionType":"max"}}'
+)
+
+
+def test_extract_prefers_claude_ai_oauth():
+    assert mod._extract_access_token(_MULTI_OAUTH) == "sk-ant-oat01-CLAUDE-REAL"
+
+
+def test_extract_prefers_claude_ai_oauth_windows():
+    from daemon.claude_usage_daemon_windows import _extract_access_token as win_extract
+
+    assert win_extract(_MULTI_OAUTH) == "sk-ant-oat01-CLAUDE-REAL"
+
+
+def test_extract_empty_token_is_none():
+    assert mod._extract_access_token('{"accessToken": ""}') is None
+    assert mod._extract_access_token('{"claudeAiOauth":{"accessToken":"  "}}') is None
+    assert mod._extract_access_token("{}") is None
+
+
+def test_oauth_expired_handles_odd_shapes():
+    assert mod._oauth_expired('{"claudeAiOauth":{"expiresAt":1}}') is True
+    assert not mod._oauth_expired('{"claudeAiOauth":{"accessToken":"t"}}')  # no expiry
+    assert not mod._oauth_expired('{"accessToken":"t"}')
+    assert not mod._oauth_expired("[1,2,3]")
+    assert not mod._oauth_expired("not json")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

On macOS the daemon logged this every poll cycle, forever:

```
[07:35:11] API HTTP 401: {"type":"error","error":{"type":"authentication_error",
"message":"OAuth access token has expired. Re-authenticate to continue."},"request_id":null}
[07:35:11] No usable config dir this cycle
```

`read_token_for()` returns the token from `<config_dir>/.credentials.json` whenever that
file exists, and only falls back to the macOS Keychain when it is **absent**:

```python
cred = config_dir / ".credentials.json"
if cred.exists():
    return _extract_access_token(cred.read_text())   # no expiry check
if sys.platform == "darwin" and config_dir == DEFAULT_CONFIG_DIR:
    return _read_token_keychain()                     # unreachable while the file exists
```

Claude Code on macOS keeps the **Keychain** entry (`Claude Code-credentials`) refreshed, but
a leftover `~/.claude/.credentials.json` keeps whatever token it was written with. On my
machine that file was 8 days old (`claudeAiOauth.expiresAt` 183 h in the past) while the
Keychain held a valid token — so the daemon sent a week-expired Bearer every 60 s and the
display never updated.

Nothing recovers from this on its own: none of the three daemons implement the
`refresh_token` flow (by design — Claude Code owns refreshing), so the 401 loop is
permanent until the user notices and deletes the file. `install-mac.sh` doesn't catch it
either: its check only asserts a Keychain entry *exists*, which it did.

## The fix

1. **Skip an expired credentials file** and fall through to the Keychain, logging why.
   Absent or unparseable `expiresAt` still counts as usable — better to try the token and
   read the API's answer than to skip a good one. An unexpired file still wins, so the
   documented file-first behaviour for extra `config_dirs` is unchanged.

2. **Prefer `claudeAiOauth` in `_extract_access_token()`** (both Python daemons). The nested
   scan returned the *first* sub-object carrying an `accessToken`, which on a real blob can
   be an MCP server or design-tool token — any of those as a Bearer 401s. This is the rule
   the bash daemon already has, with a regression test (`daemon/tests/test_bash_token.sh`);
   the Python ports had drifted from it. Blank tokens no longer slip through the regex
   fallback either.

## Tests

Five new cases in `daemon/tests/test_macos_multidir.py` (expired file → Keychain, expired
file + no Keychain → None, unexpired file still wins, `claudeAiOauth` preference for both
Python daemons, `_oauth_expired` on odd shapes).

```
$ pytest daemon/tests/ -q
123 passed
$ bash daemon/tests/test_bash_token.sh
PASS: read_token_for returned the claudeAiOauth token
```

Verified on hardware: after the fix the daemon falls back to the Keychain and resumes
sending payloads (`{"s":5,"sr":190,"w":1,...}`) to a 2.16" AMOLED board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)