### PR TITLE
fix: nest bleak WinRT args so the GATT cache bypass takes effect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,19 @@ pio run -d firmware -e waveshare_amoled_216 -t upload --upload-port /dev/ttyACM0
 # not ESP32-S3") means you picked an S3 env — use a *_c6 env for C6 hardware.
 ```
 
-If `pio` isn't on PATH: try `~/.platformio/penv/bin/pio` (Linux/macOS pio install) or `brew install platformio` on macOS.
+If `pio` isn't on PATH: try `~/.platformio/penv/bin/pio` (Linux/macOS pio install), `~/.platformio/penv/Scripts/pio.exe` on Windows, or `brew install platformio` on macOS.
 
-Device path differs by OS: `/dev/cu.usbmodem*` on macOS, `/dev/ttyACM0` on Linux. Both expose the ESP32-S3 native USB-JTAG (no boot-mode dance needed).
+Device path differs by OS: `/dev/cu.usbmodem*` on macOS, `/dev/ttyACM0` on Linux, `COM<n>` on Windows. All expose the ESP32-S3 native USB-JTAG (no boot-mode dance needed). To find the port on Windows, `py screenshot.py --list` marks the board by USB VID `0x303A` — handy when another COM port (e.g. Intel AMT SOL) is also present.
+
+### Building on Windows
+
+Two hard blockers, both of which look like firmware problems and are not:
+
+1. **`MAX_PATH`.** `esp32-arduino-libs` ships the ESP-Matter/connectedhomeip header tree, whose deepest paths land at *exactly* 260 characters under the default core dir. Extraction dies with `FileNotFoundError` on a header. Fix by shortening the core dir: `PLATFORMIO_CORE_DIR=C:\pio`, which buys ~27 characters. Set it permanently (`[Environment]::SetEnvironmentVariable('PLATFORMIO_CORE_DIR','C:\pio','User')`) or every later invocation reverts. Do **not** put `core_dir` in `platformio.ini` — that would redirect macOS/Linux contributors away from their existing caches for a Windows-only problem.
+
+2. **Do not build from Git Bash / MSYS.** The pioarduino platform runs ESP-IDF's `idf_tools.py`, which hard-refuses with `ERROR: MSys/Mingw is not supported` and then never downloads the compiler. The build proceeds and dies on a *framework* file (`SPI.cpp`) with `'xtensa-esp32s3-elf-g++' is not recognized`, and the toolchain package on disk contains only `package.json`/`tools.json` with an empty `bin/`. Spawning PowerShell from Git Bash is not enough — MSYS environment markers are inherited and the check still fires. Build from a real PowerShell session.
+
+Also beware passing Windows paths through MSYS: `PLATFORMIO_CORE_DIR=C:\pio` gets mangled into a drive-relative `C:pio` and resolves against the project dir, producing a *longer* prefix than the default. Use forward slashes (`C:/pio`) if you must set it from bash.
 
 ## QA your own UI changes — don't ask the user
 
@@ -133,6 +143,8 @@ The boot screen is `SCREEN_SPLASH` and only advances on a physical button press,
 8. **LVGL RGB565A8 is planar.** `w*h` RGB565 pixels followed by `w*h` alpha bytes; `data_size = w*h*3`, `stride = w*2`. Use `init_icon_dsc_rgb565a8()` for icons that overlap non-uniform backgrounds (e.g. battery over splash). Lucide source PNGs are black-on-transparent — converter must tint to white or icons render invisible. See `tools/png_to_lvgl.js`.
 9. **Per-board pre-init is `board_init()`.** Each board's `board_init.cpp` brings up `Wire` and any reset-gating IO expander BEFORE `display_hal_init()`. Skipping the IO expander release on AMOLED-1.8 leaves SH8601 + FT3168 in reset and they silently fail to probe.
 10. **No `#ifdef BOARD_*` in shared code.** The whole point of the refactor — if you're about to add one, you probably want a `BoardCaps` field or a per-board file instead. See `docs/porting/capability-flags.md`.
+11. **bleak's WinRT options must be nested under `winrt=`.** bleak 3.x moved `use_cached_services` and `address_type` off the top level; the WinRT backend reads them only via `winrt.get(...)`, so a top-level kwarg is swallowed by `**kwargs` and does nothing — no warning, no error. The Windows daemon passed them top-level for a long time, which meant **Windows was serving its cached GATT table**: add a characteristic to the firmware, reflash, and the daemon reports it as "not found" while the binary demonstrably contains it. Symptom looks like a firmware bug; cause is host caching. Guarded by `daemon/tests/test_windows_gatt_cache.py`. Corollary: reviving a long-dead argument is a behaviour change — nesting them also activated `address_type="random"`, which broke connect outright (this board's address is the factory-burned MAC, i.e. public), surfacing as `BleakDeviceNotFoundError`. Leave `address_type` unset.
+12. **A bond mismatch reports as `ERROR_BAD_COMMAND`.** `PermissionError: [WinError -2147024874] The device does not recognize the command` during connect means Windows and the device disagree on their pairing keys. Fix by clearing both sides, device first or Windows re-bonds against the old keys: hold PWR and release between **3–6 s** (`ble_clear_bonds()` drops bonds *and* the owner lock, then re-advertises), then remove the device in Windows Bluetooth settings and re-pair. Unlike the macOS daemon, which has `_is_encryption_error()` / `unpair_macos()`, the Windows path cannot self-heal from this.
 
 ## Icons
 

--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -539,13 +539,26 @@ async def connect_and_run(device, stop_event: asyncio.Event, tray_state=None) ->
     # Rebuild a fresh BleakClient each attempt (locked D-05 recipe).
     client = None
     for attempt in range(CONNECT_RETRIES):
-        # D-05: pass BLEDevice (not address string), address_type="random" (NimBLE
-        # static-random), use_cached_services=False (DIY firmware — WinRT GATT cache
-        # may be stale after firmware reflash).
+        # D-05: pass BLEDevice (not an address string), and disable the WinRT GATT
+        # cache — this is DIY firmware whose attribute table changes between
+        # builds, and a cached table made a freshly flashed board look like it was
+        # missing a newly added characteristic.
+        #
+        # MUST be nested under winrt=. bleak 3.x moved these off the top level and
+        # the WinRT backend reads them only via winrt.get(...), so a top-level
+        # kwarg is swallowed by **kwargs and silently does nothing. Plain dict
+        # rather than WinRTClientArgs, which is a typing-only TypedDict.
+        #
+        # address_type is deliberately NOT set. It used to be passed as
+        # "random" alongside these, but as a dead top-level kwarg it never took
+        # effect — so the working configuration has always been "let the OS
+        # decide". Actually honouring "random" breaks the connect: this board's
+        # address is the factory-burned MAC (the USB serial +1), i.e. PUBLIC, and
+        # forcing random makes WinRT's address lookup return nothing, reported as
+        # BleakDeviceNotFoundError.
         client = BleakClient(
             device,
-            address_type="random",
-            use_cached_services=False,
+            winrt={"use_cached_services": False},
         )
         try:
             await client.connect()

--- a/daemon/requirements-dev.txt
+++ b/daemon/requirements-dev.txt
@@ -3,10 +3,25 @@
 # The runtime manifests (requirements-windows.txt, and the macOS/Linux daemons'
 # own deps) deliberately stay minimal, so the test runner lives here instead.
 #
+# This file provides the RUNNER ONLY. It is not sufficient on its own: the test
+# modules import the daemon modules under test, which import their third-party
+# deps at module scope, so pytest alone fails at collection rather than
+# skipping. The platform gates (e.g. the pytestmark in
+# test_windows_gatt_cache.py) skip test *execution*, but imports still have to
+# resolve for collection to succeed.
+#
+# On Windows, install the runtime manifest too:
+#
+#   python -m pip install -r daemon/requirements-windows.txt
 #   python -m pip install -r daemon/requirements-dev.txt
 #   python -m pytest daemon/tests -q
 #
-# test_hook_listener.py needs nothing but pytest — hook_listener.py is pure
-# stdlib. The other suites mock bleak/httpx, so install the runtime manifest for
-# your platform too if you want the whole suite to run.
+# That covers the whole suite: bleak/httpx for the daemons, plus pystray/Pillow
+# for the tray and icon suites (test_windows_tray.py imports daemon.tray_windows
+# and test_windows_icon.py imports daemon.icon_assets, both at module scope).
+#
+# Only the Windows path above has been exercised. On macOS/Linux the daemons
+# themselves need bleak and httpx; the Windows-only suites import their modules
+# at collection time regardless of platform, so expect to need those deps as
+# well, or to deselect those files.
 pytest

--- a/daemon/requirements-dev.txt
+++ b/daemon/requirements-dev.txt
@@ -1,0 +1,12 @@
+# Test/dev dependencies for the daemon test suite.
+#
+# The runtime manifests (requirements-windows.txt, and the macOS/Linux daemons'
+# own deps) deliberately stay minimal, so the test runner lives here instead.
+#
+#   python -m pip install -r daemon/requirements-dev.txt
+#   python -m pytest daemon/tests -q
+#
+# test_hook_listener.py needs nothing but pytest — hook_listener.py is pure
+# stdlib. The other suites mock bleak/httpx, so install the runtime manifest for
+# your platform too if you want the whole suite to run.
+pytest

--- a/daemon/requirements-windows.txt
+++ b/daemon/requirements-windows.txt
@@ -1,6 +1,11 @@
 # Windows-only dependency manifest for claude_usage_daemon_windows.py
 # The macOS/Linux daemons manage their own dependencies separately.
-bleak
+#
+# bleak>=3: connect_and_run passes its WinRT options nested under `winrt=`,
+# which is the 3.x contract (the backend reads them via winrt.get(...)). Pinning
+# the floor keeps a resolver from selecting a version that predates it and
+# silently re-enabling the GATT cache. Guarded by tests/test_windows_gatt_cache.py.
+bleak>=3
 httpx
 pystray
 Pillow

--- a/daemon/tests/test_windows_gatt_cache.py
+++ b/daemon/tests/test_windows_gatt_cache.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Guard that the WinRT GATT-cache bypass actually reaches bleak -- CACHE-01.
+
+Why this exists: the daemon passed `use_cached_services=False` and
+`address_type="random"` as TOP-LEVEL BleakClient kwargs. That worked on bleak
+0.2x. bleak 3.x moved them under `winrt=`, and its WinRT backend reads them only
+via `winrt.get(...)` -- so the old form was swallowed by `**kwargs` and silently
+did nothing, with no warning and no error.
+
+The visible symptom was nasty and misleading: after flashing firmware that added
+a GATT characteristic, Windows kept serving its cached attribute table and the
+daemon reported the new characteristic as "not found", which reads exactly like a
+firmware bug rather than a host caching bug.
+
+These tests assert the options land on the backend object, so the next bleak
+upgrade that moves them fails here instead of in the field.
+
+Run: python -m pytest daemon/tests/test_windows_gatt_cache.py -x -q
+"""
+import inspect
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="WinRT backend is Windows-only"
+)
+
+
+def _winrt_backend_cls():
+    from bleak.backends.winrt.client import BleakClientWinRT
+    return BleakClientWinRT
+
+
+def test_backend_reads_options_from_the_winrt_dict():
+    """Pins the contract this guard depends on: the backend sources both options
+    from `winrt`, not from top-level kwargs."""
+    src = inspect.getsource(_winrt_backend_cls().__init__)
+    assert 'winrt.get("use_cached_services")' in src
+    assert 'winrt.get("address_type")' in src
+
+
+def test_nested_winrt_args_reach_the_backend():
+    backend = _winrt_backend_cls()(
+        "AA:BB:CC:DD:EE:FF",
+        services=None,
+        winrt={"address_type": "random", "use_cached_services": False},
+        timeout=10.0,          # the backend reads this out of kwargs directly
+    )
+    assert backend._use_cached_services is False
+    assert backend._address_type == "random"
+
+
+def test_top_level_kwargs_are_silently_ignored():
+    """Documents the trap directly: the old call style leaves the cache enabled.
+
+    If a future bleak starts honouring or rejecting top-level kwargs, this test
+    fails and the comment in the daemon can be simplified.
+    """
+    backend = _winrt_backend_cls()(
+        "AA:BB:CC:DD:EE:FF",
+        services=None,
+        winrt={},
+        timeout=10.0,
+        address_type="random",
+        use_cached_services=False,
+    )
+    assert backend._use_cached_services is None, (
+        "bleak now honours top-level kwargs; the daemon's nesting workaround "
+        "and its comment can be revisited"
+    )
+    assert backend._address_type is None
+
+
+def _strip_comments(src: str) -> str:
+    """Drop comment lines so the guard below inspects CODE, not prose.
+
+    Without this, the daemon's own explanatory comment about the dead top-level
+    form trips the negative assertions.
+    """
+    return "\n".join(
+        line for line in src.splitlines() if not line.strip().startswith("#")
+    )
+
+
+def test_daemon_nests_the_cache_bypass():
+    """The actual regression guard: the daemon's own call site must nest it."""
+    from daemon import claude_usage_daemon_windows as d
+
+    code = _strip_comments(inspect.getsource(d.connect_and_run))
+    assert "winrt={" in code, "BleakClient options are no longer nested under winrt="
+    assert '"use_cached_services": False' in code
+    # The dead top-level form must not creep back in.
+    assert "use_cached_services=False" not in code
+
+
+def test_daemon_does_not_force_address_type():
+    """address_type must stay unset.
+
+    It was long passed as "random" but only as a dead top-level kwarg, so the
+    configuration that actually works in the field is "let the OS decide".
+    Honouring "random" broke connect outright: this board's address is the
+    factory-burned MAC (public), and WinRT then finds no device at all.
+    """
+    from daemon import claude_usage_daemon_windows as d
+
+    code = _strip_comments(inspect.getsource(d.connect_and_run))
+    assert "address_type" not in code, (
+        "address_type is set again — if that is deliberate, confirm the board's "
+        "address really is random, because forcing the wrong type surfaces as "
+        "BleakDeviceNotFoundError rather than as a type mismatch"
+    )

--- a/daemon/tests/test_windows_gatt_cache.py
+++ b/daemon/tests/test_windows_gatt_cache.py
@@ -105,8 +105,15 @@ def test_daemon_does_not_force_address_type():
     from daemon import claude_usage_daemon_windows as d
 
     code = _strip_comments(inspect.getsource(d.connect_and_run))
-    assert "address_type" not in code, (
+    # Assert the forbidden CALL-SITE forms, not a bare substring. _strip_comments
+    # only drops whole-line comments, so it leaves the function's docstring and
+    # any trailing inline comment in place — a bare `"address_type" not in code`
+    # would fail on someone merely *documenting* that it stays unset.
+    why = (
         "address_type is set again — if that is deliberate, confirm the board's "
         "address really is random, because forcing the wrong type surfaces as "
         "BleakDeviceNotFoundError rather than as a type mismatch"
     )
+    assert "address_type=" not in code, why          # top-level kwarg
+    assert '"address_type"' not in code, why         # nested in the winrt dict
+    assert "'address_type'" not in code, why

--- a/daemon/tests/test_windows_reconnect.py
+++ b/daemon/tests/test_windows_reconnect.py
@@ -8,6 +8,7 @@ Covers:
 Run: python -m pytest daemon/tests/test_windows_reconnect.py -x -q
 """
 import asyncio
+import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -555,10 +556,14 @@ def test_requirements_windows_contains_required_deps():
     Phase 3 (reconnect) added no new deps; Phase 4 (tray) adds pystray + Pillow.
     This test asserts the final expected state: bleak, httpx, pystray, Pillow
     must be present; winreg must NOT be listed (it is stdlib — no install needed).
+
+    Compares distribution NAMES, so a pinned entry (`bleak>=3`) satisfies the
+    same assertion as a bare one — the manifest is free to carry version floors.
     """
     req_path = Path(__file__).parent.parent / "requirements-windows.txt"
     content = req_path.read_text()
-    lines = {line.strip().lower() for line in content.splitlines()
+    lines = {re.split(r"[=<>!~;\[]", line.strip(), maxsplit=1)[0].strip().lower()
+             for line in content.splitlines()
              if line.strip() and not line.strip().startswith("#")}
 
     assert "bleak" in lines, "bleak must be in requirements-windows.txt"


### PR DESCRIPTION
## Problem

The Windows daemon passes `use_cached_services=False` and `address_type="random"` as top-level `BleakClient` kwargs. That worked on bleak 0.2x, but bleak 3.x moved them under `winrt=`, and the WinRT backend now reads them only via `winrt.get(...)`:

```python
self._use_cached_services = winrt.get("use_cached_services")
self._address_type = winrt.get("address_type")
```

Top-level kwargs fall through `**kwargs` to `super().__init__()` and are silently discarded — no warning, no error.

So Windows has been serving its **cached** GATT attribute table. Add a characteristic to the firmware, reflash, and the daemon reports it as "not found" while the built binary demonstrably contains it. It presents as a firmware bug; the cause is host caching.

## Fix

Pass `use_cached_services` nested under `winrt=`, and leave `address_type` unset.

Reviving both turned out to be a behaviour change rather than a no-op: actually honouring `address_type="random"` broke connect outright, because the board's address is the factory-burned MAC (i.e. public), so WinRT's lookup returns nothing and raises `BleakDeviceNotFoundError`. Since that argument had been dead for as long as the project has been on bleak 3.x, the configuration that has always worked in the field is "let the OS decide" — so it stays unset, with a test asserting that.

## Tests

`daemon/tests/test_windows_gatt_cache.py` asserts the options reach the backend object, pins bleak's `winrt.get` contract so a future move fails here rather than in the field, and checks the daemon's own call site still nests them.

Also adds `daemon/requirements-dev.txt` — `pytest` wasn't declared anywhere, so the existing suite had no installable runner.

Verified: 119 passed on Windows.

## Note for maintainers

I don't have a macOS or Linux box to hand, so this is Windows-verified only. It touches nothing outside the WinRT path.