### PR TITLE
fix(windows): bound start_notify so a half-open BLE link can't wedge the daemon (#89)

### DIFF
--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -386,8 +386,26 @@ class Session:
         # e.g. a just-power-cycled ESP32 whose server is not yet ready (G-03-01, SC#3).
         # Degrade gracefully instead of crashing the daemon so it stays single-process
         # across a power-cycle reconnect (SC#4, no restart).
+        #
+        # It can also never complete at all. On a half-open link WinRT's CCCD-write
+        # confirmation never arrives, and an unbounded await then wedges the daemon
+        # between "Connected" and the first poll — stale data on the device, nothing
+        # logged, no recovery until a manual restart. An except block cannot help
+        # there: it catches a raised error, never an await that hangs forever. Same
+        # failure shape as the CoreBluetooth hang bounded in claude_usage_daemon.py,
+        # so bound it the same way and proceed on timeout.
+        #
+        # Clause order is load-bearing: on Python 3.11+ asyncio.TimeoutError IS the
+        # builtin TimeoutError, which is a subclass of OSError. With the OSError
+        # clause first it would swallow the timeout and report it as an empty
+        # "Refresh subscription unavailable: ". Keep TimeoutError above it.
         try:
-            await self.client.start_notify(REQ_CHAR_UUID, self._on_refresh)
+            await asyncio.wait_for(
+                self.client.start_notify(REQ_CHAR_UUID, self._on_refresh),
+                timeout=10,
+            )
+        except asyncio.TimeoutError:
+            log("Refresh subscription timed out; polling without it")
         except (BleakError, ValueError, OSError) as e:
             log(f"Refresh subscription unavailable: {e}")
 

--- a/daemon/tests/test_windows_reconnect.py
+++ b/daemon/tests/test_windows_reconnect.py
@@ -608,6 +608,72 @@ def test_start_notify_oserror_does_not_crash_connect_and_run():
 
 
 # ---------------------------------------------------------------------------
+# #89: start_notify() must be BOUNDED — a half-open link can't wedge the daemon
+# ---------------------------------------------------------------------------
+
+def test_start_notify_hang_times_out_and_proceeds(capsys):
+    """#89 regression: on a half-open link WinRT's CCCD-write confirmation never
+    arrives, so start_notify() never returns at all. Unbounded, that await wedges
+    the daemon between "Connected" and the first poll — stale data, nothing
+    logged, no recovery until a manual restart. The except block does not help:
+    it catches a raised error, never an await that hangs forever.
+
+    setup_refresh_subscription() must bound the subscribe and return, since the
+    refresh subscription is optional (the poll loop runs without it).
+
+    The real 10s bound is shortened through the module's asyncio.wait_for so the
+    test is fast while still exercising the genuine timeout path. The real
+    wait_for is captured before patching — calling the patched name from inside
+    the replacement would recurse.
+    """
+    real_wait_for = asyncio.wait_for
+
+    async def never_returns(*_args, **_kwargs):
+        await asyncio.Event().wait()  # never set — the confirmation that never comes
+
+    mock_client = AsyncMock()
+    mock_client.start_notify = AsyncMock(side_effect=never_returns)
+
+    seen_timeouts = []
+
+    async def fast_wait_for(coro, timeout):
+        seen_timeouts.append(timeout)
+        return await real_wait_for(coro, 0.05)
+
+    session = Session(mock_client)
+
+    with patch("daemon.claude_usage_daemon_windows.asyncio.wait_for",
+               side_effect=fast_wait_for):
+        _run(session.setup_refresh_subscription())  # must return, not hang
+
+    # The subscribe really is wrapped, with the intended bound.
+    assert seen_timeouts == [10]
+    assert mock_client.start_notify.call_count == 1
+    assert "Refresh subscription timed out" in capsys.readouterr().out
+
+
+def test_start_notify_bleak_error_still_reports_unavailable(capsys):
+    """The raised-error path must survive the added timeout branch.
+
+    Together with the test above this pins both branches, which is what guards
+    the clause ordering. asyncio.TimeoutError IS the builtin TimeoutError on
+    Python 3.11+, and TimeoutError subclasses OSError, so moving the
+    (BleakError, ValueError, OSError) clause back above the asyncio.TimeoutError
+    one makes the timeout branch dead code — the hang test then fails with an
+    empty "Refresh subscription unavailable: ". This test fails instead if the
+    timeout branch is ever widened enough to capture genuine raised errors.
+    """
+    mock_client = AsyncMock()
+    mock_client.start_notify = AsyncMock(side_effect=BleakError("Unreachable"))
+    session = Session(mock_client)
+
+    _run(session.setup_refresh_subscription())  # must not raise
+
+    assert mock_client.start_notify.call_count == 1
+    assert "Refresh subscription unavailable: Unreachable" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
 # SC#2 field report: write_payload() OSError must not crash the daemon thread
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The problem

`Session.setup_refresh_subscription()` in the Windows daemon awaits
`client.start_notify()` with no bound. On a half-open BLE link WinRT's CCCD-write
confirmation never arrives, so that await never returns. The daemon is a single
process and this call sits between "Connected" and the first poll, so everything
stops there: the device keeps showing stale numbers, nothing is logged, and there
is no recovery short of a manual restart.

The existing `except (BleakError, ValueError, OSError)` does not help. An
exception handler catches a *raised* error; it can do nothing about an await that
hangs forever.

Same bug class as the CoreBluetooth hang #84 fixed on the macOS daemon.

## The fix

Same shape as #84: wrap the subscribe in `asyncio.wait_for(..., timeout=10)` and
log-and-proceed on timeout. The refresh subscription is only an optional
device-initiated nudge — the 60s poll loop works without it — so a subscribe that
never completes should cost a log line, not the daemon.

## Clause order is load-bearing, and only on this daemon

The macOS version catches `(BleakError, ValueError)`. This one also catches
`OSError`, because WinRT surfaces failures as raw `OSError`s; the existing comment
says so. On Python 3.11+:

```
python 3.14.6
asyncio.TimeoutError is builtins.TimeoutError: True
TimeoutError subclass of OSError: True
```

`asyncio.TimeoutError` *is* an `OSError`. Ported naively — keeping macOS's clause
order, where `asyncio.TimeoutError` comes second — the `OSError` handler catches
the timeout first. The new branch becomes dead code and the daemon logs
`Refresh subscription unavailable: ` with an empty message.

So the `asyncio.TimeoutError` clause comes first. That is correct on 3.11+ and
equally correct on 3.10, where the two are still separate classes.

Checked by reordering the clauses locally and re-running the tests:

```
>       assert "Refresh subscription timed out" in capsys.readouterr().out
E       AssertionError: assert 'Refresh subscription timed out' in '[20:27:11] Refresh subscription unavailable: \n'
```

## Tests

Two tests in `daemon/tests/test_windows_reconnect.py`, in the same
`AsyncMock`/`patch` style as the rest of that file:

- `test_start_notify_hang_times_out_and_proceeds` — a `start_notify` that never
  resolves. Asserts the call returns, that it was wrapped with `timeout=10`, and
  that the timeout line is logged. The bound is shortened through the module's
  `asyncio.wait_for` so the test runs in milliseconds. Against the unpatched
  daemon this test hangs forever, which is the bug.
- `test_start_notify_bleak_error_still_reports_unavailable` — a raised
  `BleakError` must still log "unavailable". Together the two pin both branches,
  so a future reshuffle of the clauses fails the suite instead of silently
  collapsing them.

```
$ python -m pytest daemon/tests/ -x -q
118 passed, 2 warnings in 6.23s

$ python -m pytest daemon/tests/test_windows_reconnect.py -v -k start_notify
collected 27 items / 24 deselected / 3 selected
daemon/tests/test_windows_reconnect.py::test_start_notify_oserror_does_not_crash_connect_and_run PASSED [ 33%]
daemon/tests/test_windows_reconnect.py::test_start_notify_hang_times_out_and_proceeds PASSED [ 66%]
daemon/tests/test_windows_reconnect.py::test_start_notify_bleak_error_still_reports_unavailable PASSED [100%]
3 passed, 24 deselected in 0.08s
```

## Verification caveat

> Unit tested on Linux against a mocked bleak client. I don't have a Windows
> machine with the board, so I haven't reproduced the original hang on real
> hardware — the trigger is a half-open WinRT link, which is awkward to force on
> purpose.

Fixes #89
