### PR TITLE
feat(daemon): Windows multi config-dir polling with active-plan selection (#97)

### DIFF
--- a/daemon/claude_usage_daemon_windows.py
+++ b/daemon/claude_usage_daemon_windows.py
@@ -507,6 +507,142 @@ def _read_expiry() -> str:
     return "expiry unknown"
 
 
+# --- Multi config-dir support (#97, mirrors #95) ---------------------------
+# Claude Code can run against more than one config dir (e.g. ~/.claude for a
+# personal plan and ~/.claude-work for a work plan, selected via
+# CLAUDE_CONFIG_DIR). When the `config_dirs` option is set, the daemon polls
+# each dir's token every cycle and shows whichever plan is "active".
+
+
+def read_config_dirs() -> list[Path]:
+    """Claude config dirs to poll, from the `config_dirs` option (comma list).
+
+    Returns [] when unset/blank so the caller keeps the existing read_token()
+    candidate-list behavior (env overrides + probe list) — zero change for
+    current single-plan setups (#97). Unlike #95's Linux/macOS daemons there
+    is no single default dir to substitute here (the default is a probe LIST),
+    hence [] rather than [~/.claude]. ~ is expanded; blank entries dropped.
+    """
+    raw = ""
+    try:
+        if CONFIG_FILE.exists():
+            for line in CONFIG_FILE.read_text().splitlines():
+                line = line.split("#", 1)[0].strip()
+                if "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                if key.strip().lower() == "config_dirs":
+                    raw = val.strip()
+    except OSError:
+        pass
+    if not raw:
+        return []
+    return [Path(p.strip()).expanduser() for p in raw.split(",") if p.strip()]
+
+
+def read_token_for(config_dir: Path) -> str | None:
+    """Read the OAuth token for one configured dir (<dir>/.credentials.json).
+
+    Mirrors #95's read_token_for. Windows keeps tokens in plain files (no
+    Keychain analogue), so there is no fallback here; the env-override /
+    candidate probing stays in read_token() for the unset-config_dirs path.
+    """
+    try:
+        return _extract_access_token(
+            (config_dir / ".credentials.json").read_text(encoding="utf-8")
+        )
+    except OSError:
+        return None
+
+
+class PlanSelector:
+    """Decide which config dir's plan is "active" across polls.
+
+    "Active" = the plan whose session % rose most recently (recent API activity).
+    A rise stamps a monotonic poll counter, so the choice is sticky and a window
+    reset (a drop to 0) isn't mistaken for use. Before any rise is seen (startup)
+    the highest current session % wins. Mirrors #95's Linux/macOS daemons.
+    """
+
+    def __init__(self) -> None:
+        self.prev_s: dict[Path, int] = {}
+        self.last_active: dict[Path, int] = {}
+        self.seq = 0
+
+    def choose(self, sessions: dict[Path, int]) -> Path:
+        """Update state from this cycle's {dir: session_pct} and return the active dir."""
+        self.seq += 1
+        for d, s in sessions.items():
+            if d in self.prev_s and s > self.prev_s[d]:
+                self.last_active[d] = self.seq
+            self.prev_s[d] = s
+        # Most recent activity wins; ties (and the startup case) break by highest %.
+        return max(sessions, key=lambda d: (self.last_active.get(d, 0), sessions[d]))
+
+
+# Module-level so the active-plan state survives reconnects (#95).
+_SELECTOR = PlanSelector()
+
+
+async def poll_active_payload(selector: PlanSelector = _SELECTOR, tray_state=None) -> dict | None:
+    """Poll the configured config dir(s) and return the active plan's payload.
+
+    With `config_dirs` unset this is EXACTLY the old single-token path —
+    read_token() candidate list, "No token" toast, AuthError toast — so current
+    users see zero change (#97). With it set, every dir is polled and the
+    PlanSelector picks whose payload to send; the "token expired" toast then
+    fires only when NO dir yields a payload, so a working plan is never hidden
+    behind a sibling plan's expired token.
+    """
+    dirs = read_config_dirs()
+    if not dirs:
+        token = read_token()  # D-09: fresh each cycle
+        if not token:
+            log("No token; skipping poll")
+            if tray_state:
+                tray_state.set_error("token expired — run claude login")
+            return None
+        try:
+            return await poll_api(token)
+        except AuthError:
+            # Real 401/403 — token genuinely needs a refresh.
+            if tray_state:
+                tray_state.set_error("token expired — run claude login")
+            return None
+
+    payloads: dict[Path, dict] = {}
+    sessions: dict[Path, int] = {}
+    token_seen = False
+    auth_rejected = False
+    for d in dirs:
+        token = read_token_for(d)  # D-09: fresh each cycle
+        if not token:
+            log(f"No token in {d}; skipping")
+            continue
+        token_seen = True
+        try:
+            payload = await poll_api(token)
+        except AuthError:
+            log(f"Auth rejected for {d}")
+            auth_rejected = True
+            continue
+        if payload is not None:
+            payloads[d] = payload
+            sessions[d] = int(payload.get("s", 0) or 0)
+    if not payloads:
+        log("No usable config dir this cycle")
+        # Toast only for token trouble (missing or rejected everywhere). An
+        # all-TRANSIENT cycle (network/DNS, timeout, 5xx) must NOT fire the
+        # "token expired" toast — same rule as single-dir mode (SC#5).
+        if tray_state and (auth_rejected or not token_seen):
+            tray_state.set_error("token expired — run claude login")
+        return None
+    active = selector.choose(sessions)
+    if len(dirs) > 1:
+        log(f"Active plan: {active} (s={sessions[active]})")
+    return payloads[active]
+
+
 async def _wait_first(*events: asyncio.Event, timeout: float) -> None:
     """Return when any of `events` is set, or after `timeout` seconds.
 
@@ -595,39 +731,30 @@ async def connect_and_run(device, stop_event: asyncio.Event, tray_state=None) ->
             elapsed = now - last_poll
             if session.refresh_requested.is_set() or elapsed >= POLL_INTERVAL:
                 session.refresh_requested.clear()
-                token = read_token()  # D-09: fresh each cycle
-                if not token:
-                    log("No token; skipping poll")
-                    if tray_state:
-                        tray_state.set_error("token expired — run claude login")
-                else:
-                    try:
-                        payload = await poll_api(token)
-                    except AuthError:
-                        # Real 401/403 — token genuinely needs a refresh.
+                # #97: single- and multi-dir polling both route through
+                # poll_active_payload, which owns the tray-toast decision.
+                payload = await poll_active_payload(tray_state=tray_state)
+                if payload is not None:
+                    if await session.write_payload(payload):
+                        last_poll = time.time()
+                        used_successfully = True
+                        consecutive_failures = 0  # D-03: reset on success
                         if tray_state:
-                            tray_state.set_error("token expired — run claude login")
-                        payload = None
-                    if payload is not None:
-                        if await session.write_payload(payload):
-                            last_poll = time.time()
-                            used_successfully = True
-                            consecutive_failures = 0  # D-03: reset on success
-                            if tray_state:
-                                tray_state.set_connected(time.time())
-                        else:
-                            consecutive_failures += 1
-                            if consecutive_failures >= ZOMBIE_BREAK_LIMIT:
-                                log(
-                                    f"Zombie link detected ({consecutive_failures} consecutive"
-                                    f" write failures); abandoning connection"
-                                )
-                                break
-                    # else: payload is None from a TRANSIENT failure (network/DNS,
-                    # timeout, rate-limit, 5xx). poll_api already logged it; do NOT
-                    # toast "token expired" — that mislabeled a boot-time DNS blip
-                    # as an auth problem (SC#5). Leave tray state unchanged; the next
-                    # tick retries and set_connected() recovers it.
+                            tray_state.set_connected(time.time())
+                    else:
+                        consecutive_failures += 1
+                        if consecutive_failures >= ZOMBIE_BREAK_LIMIT:
+                            log(
+                                f"Zombie link detected ({consecutive_failures} consecutive"
+                                f" write failures); abandoning connection"
+                            )
+                            break
+                # else: payload is None — poll_active_payload already logged why
+                # and toasted only for genuine token trouble. A TRANSIENT failure
+                # (network/DNS, timeout, rate-limit, 5xx) must NOT toast "token
+                # expired" — that mislabeled a boot-time DNS blip as an auth
+                # problem (SC#5). Leave tray state unchanged; the next tick
+                # retries and set_connected() recovers it.
 
             # Wake on a refresh request OR a stop, whichever comes first. Waking
             # promptly on stop_event is what lets the finally below run

--- a/daemon/tests/test_windows_multidir.py
+++ b/daemon/tests/test_windows_multidir.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Unit tests for the Windows daemon's multi config-dir active-plan support (#97).
+
+Covers read_config_dirs, read_token_for, PlanSelector, and poll_active_payload,
+mirroring daemon/tests/test_macos_multidir.py from #95 — plus the Windows-only
+tray-toast semantics (SC#5) that the macOS daemon does not have.
+
+Run: python -m pytest daemon/tests/test_windows_multidir.py -x -q
+"""
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import daemon.claude_usage_daemon_windows as mod
+from daemon.claude_usage_daemon_windows import (
+    AuthError,
+    PlanSelector,
+    read_config_dirs,
+    read_token_for,
+)
+
+
+def _run(coro):
+    """Run a coroutine on a fresh private loop (order-independent in the full
+    suite — see test_windows_poll.py for why get_event_loop() is unsafe here)."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# read_config_dirs — unset MUST mean "keep legacy behavior" ([] not a default
+# dir: the Windows default is read_token()'s candidate LIST, #97)
+# ---------------------------------------------------------------------------
+
+def test_config_dirs_empty_when_config_file_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "CONFIG_FILE", tmp_path / "config")  # absent
+    assert read_config_dirs() == []
+
+
+def test_config_dirs_empty_when_key_absent(tmp_path, monkeypatch):
+    cfg = tmp_path / "config"
+    cfg.write_text("clock = auto\nchime = on\n")
+    monkeypatch.setattr(mod, "CONFIG_FILE", cfg)
+    assert read_config_dirs() == []
+
+
+def test_config_dirs_parses_comma_list_and_expands_tilde(tmp_path, monkeypatch):
+    cfg = tmp_path / "config"
+    cfg.write_text("config_dirs = ~/.claude, ~/.claude-work  # two plans\n")
+    monkeypatch.setattr(mod, "CONFIG_FILE", cfg)
+    assert read_config_dirs() == [Path.home() / ".claude", Path.home() / ".claude-work"]
+
+
+def test_config_dirs_blank_value_is_empty(tmp_path, monkeypatch):
+    cfg = tmp_path / "config"
+    cfg.write_text("config_dirs =\n")
+    monkeypatch.setattr(mod, "CONFIG_FILE", cfg)
+    assert read_config_dirs() == []
+
+
+def test_config_dirs_only_commas_is_empty(tmp_path, monkeypatch):
+    """A malformed value of separators only must fall back to legacy behavior."""
+    cfg = tmp_path / "config"
+    cfg.write_text("config_dirs = , ,\n")
+    monkeypatch.setattr(mod, "CONFIG_FILE", cfg)
+    assert read_config_dirs() == []
+
+
+def test_config_dirs_drops_empty_entries(tmp_path, monkeypatch):
+    cfg = tmp_path / "config"
+    cfg.write_text("config_dirs = ~/.claude, , ~/.claude-work,\n")
+    monkeypatch.setattr(mod, "CONFIG_FILE", cfg)
+    assert read_config_dirs() == [Path.home() / ".claude", Path.home() / ".claude-work"]
+
+
+# ---------------------------------------------------------------------------
+# read_token_for
+# ---------------------------------------------------------------------------
+
+def test_token_for_reads_dir_credentials_file(tmp_path):
+    (tmp_path / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": "sk-ant-test-TOK-X"}})
+    )
+    assert read_token_for(tmp_path) == "sk-ant-test-TOK-X"
+
+
+def test_token_for_missing_file_returns_none(tmp_path):
+    assert read_token_for(tmp_path / "nonexistent") is None
+
+
+def test_token_for_empty_token_returns_none(tmp_path):
+    """CR-01 parity: an empty accessToken must not be accepted per-dir either."""
+    (tmp_path / ".credentials.json").write_text('{"accessToken": ""}')
+    assert read_token_for(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# PlanSelector — the "active = recent API activity" rule (#95)
+# ---------------------------------------------------------------------------
+
+A, B = Path("/a"), Path("/b")
+
+
+def test_selector_startup_picks_highest_util():
+    sel = PlanSelector()
+    assert sel.choose({A: 10, B: 30}) == B  # no history yet -> highest %
+
+
+def test_selector_switches_on_rise():
+    sel = PlanSelector()
+    sel.choose({A: 10, B: 30})           # startup -> B
+    assert sel.choose({A: 20, B: 30}) == A  # A rose 10->20 -> A active
+
+
+def test_selector_sticky_when_no_movement():
+    sel = PlanSelector()
+    sel.choose({A: 10, B: 30})
+    sel.choose({A: 20, B: 30})           # A active
+    assert sel.choose({A: 20, B: 30}) == A  # nothing moved -> still A (not higher B)
+
+
+def test_selector_reset_to_zero_is_not_activity():
+    sel = PlanSelector()
+    sel.choose({A: 10, B: 30})
+    sel.choose({A: 20, B: 30})           # A active
+    sel.choose({A: 20, B: 45})           # B rose -> B active
+    assert sel.choose({A: 20, B: 0}) == B   # B window reset (drop) isn't a rise -> stays B
+
+
+def test_selector_larger_rise_wins_same_cycle():
+    sel = PlanSelector()
+    sel.choose({A: 10, B: 10})           # seed
+    assert sel.choose({A: 12, B: 40}) == B  # both rose same cycle -> higher % breaks tie
+
+
+# ---------------------------------------------------------------------------
+# poll_active_payload — unset config_dirs preserves the old single-token path
+# ---------------------------------------------------------------------------
+
+def test_unset_routes_through_legacy_read_token(monkeypatch):
+    """[] from read_config_dirs -> exactly the old read_token()/poll_api path."""
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [])
+    with patch.object(mod, "read_token", return_value="tok") as rt, \
+         patch.object(mod, "poll_api", new=AsyncMock(return_value={"s": 7, "ok": True})):
+        payload = _run(mod.poll_active_payload(PlanSelector()))
+    assert payload == {"s": 7, "ok": True}
+    rt.assert_called_once()
+
+
+def test_unset_no_token_logs_and_toasts(monkeypatch, capsys):
+    """Old behavior kept verbatim: missing token logs and fires the toast."""
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [])
+    tray_state = MagicMock()
+    with patch.object(mod, "read_token", return_value=None):
+        assert _run(mod.poll_active_payload(PlanSelector(), tray_state)) is None
+    assert "No token; skipping poll" in capsys.readouterr().out
+    tray_state.set_error.assert_called_once_with("token expired — run claude login")
+
+
+def test_unset_autherror_toasts(monkeypatch):
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [])
+    tray_state = MagicMock()
+    with patch.object(mod, "read_token", return_value="tok"), \
+         patch.object(mod, "poll_api", new=AsyncMock(side_effect=AuthError(401))):
+        assert _run(mod.poll_active_payload(PlanSelector(), tray_state)) is None
+    tray_state.set_error.assert_called_once_with("token expired — run claude login")
+
+
+def test_unset_transient_failure_does_not_toast(monkeypatch):
+    """SC#5 parity: poll_api None (network blip) must NOT fire the toast."""
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [])
+    tray_state = MagicMock()
+    with patch.object(mod, "read_token", return_value="tok"), \
+         patch.object(mod, "poll_api", new=AsyncMock(return_value=None)):
+        assert _run(mod.poll_active_payload(PlanSelector(), tray_state)) is None
+    tray_state.set_error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# poll_active_payload — multi-dir discovery + active-plan selection
+# ---------------------------------------------------------------------------
+
+def test_poll_active_payload_picks_active_and_skips_tokenless(monkeypatch, capsys):
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: {A: "tA", B: None}[d])  # B has no token
+
+    async def fake_poll(token):
+        return {"s": 25, "ok": True} if token == "tA" else None
+
+    with patch.object(mod, "poll_api", new=AsyncMock(side_effect=fake_poll)):
+        payload = _run(mod.poll_active_payload(PlanSelector()))
+    assert payload == {"s": 25, "ok": True}  # only A had a token
+    assert f"No token in {B}; skipping" in capsys.readouterr().out
+
+
+def test_poll_active_payload_returns_none_when_all_fail(monkeypatch, capsys):
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: None)
+    with patch.object(mod, "poll_api", new=AsyncMock(return_value=None)):
+        assert _run(mod.poll_active_payload(PlanSelector())) is None
+    assert "No usable config dir this cycle" in capsys.readouterr().out
+
+
+def test_poll_active_payload_selects_higher_util_plan(monkeypatch):
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: {A: "tA", B: "tB"}[d])
+
+    async def fake_poll(token):
+        return {"s": 12, "ok": True} if token == "tA" else {"s": 40, "ok": True}
+
+    with patch.object(mod, "poll_api", new=AsyncMock(side_effect=fake_poll)):
+        payload = _run(mod.poll_active_payload(PlanSelector()))
+    assert payload["s"] == 40  # startup -> highest util plan (B)
+
+
+def test_poll_active_payload_sticky_across_cycles(monkeypatch):
+    """The selector state persists across poll cycles: once A shows activity it
+    stays active even though B's utilization is higher."""
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: {A: "tA", B: "tB"}[d])
+    sel = PlanSelector()
+    cycles = iter([
+        ({A: 10, B: 30}),  # startup -> B
+        ({A: 20, B: 30}),  # A rose -> A
+        ({A: 20, B: 30}),  # nothing moved -> still A
+    ])
+
+    def make_poll(s_by_dir):
+        async def fake_poll(token):
+            d = A if token == "tA" else B
+            return {"s": s_by_dir[d], "ok": True}
+        return fake_poll
+
+    for expected_active, s_by_dir in zip([B, A, A], cycles):
+        with patch.object(mod, "poll_api", new=AsyncMock(side_effect=make_poll(s_by_dir))):
+            payload = _run(mod.poll_active_payload(sel))
+        assert payload["s"] == s_by_dir[expected_active]
+
+
+# ---------------------------------------------------------------------------
+# poll_active_payload — Windows tray-toast semantics in multi-dir mode (SC#5)
+# ---------------------------------------------------------------------------
+
+def test_multi_all_transient_does_not_toast(monkeypatch):
+    """All dirs failing TRANSIENTLY (poll_api None) must not fire the toast."""
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: "tok")
+    tray_state = MagicMock()
+    with patch.object(mod, "poll_api", new=AsyncMock(return_value=None)):
+        assert _run(mod.poll_active_payload(PlanSelector(), tray_state)) is None
+    tray_state.set_error.assert_not_called()
+
+
+def test_multi_all_auth_rejected_toasts(monkeypatch):
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: "tok")
+    tray_state = MagicMock()
+    with patch.object(mod, "poll_api", new=AsyncMock(side_effect=AuthError(401))):
+        assert _run(mod.poll_active_payload(PlanSelector(), tray_state)) is None
+    tray_state.set_error.assert_called_once_with("token expired — run claude login")
+
+
+def test_multi_no_tokens_anywhere_toasts(monkeypatch):
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: None)
+    tray_state = MagicMock()
+    assert _run(mod.poll_active_payload(PlanSelector(), tray_state)) is None
+    tray_state.set_error.assert_called_once_with("token expired — run claude login")
+
+
+def test_multi_one_expired_one_working_no_toast(monkeypatch):
+    """A working plan must not be hidden behind a sibling's expired token: the
+    good dir's payload is returned and no 'token expired' toast fires."""
+    monkeypatch.setattr(mod, "read_config_dirs", lambda: [A, B])
+    monkeypatch.setattr(mod, "read_token_for", lambda d: {A: "tA", B: "tB"}[d])
+    tray_state = MagicMock()
+
+    async def fake_poll(token):
+        if token == "tA":
+            raise AuthError(401)
+        return {"s": 33, "ok": True}
+
+    with patch.object(mod, "poll_api", new=AsyncMock(side_effect=fake_poll)):
+        payload = _run(mod.poll_active_payload(PlanSelector(), tray_state))
+    assert payload == {"s": 33, "ok": True}
+    tray_state.set_error.assert_not_called()


### PR DESCRIPTION
Implements #97 — mirrors #95's multi config-dir + active-plan selection into the Windows daemon.

**What it does**
- New `config_dirs` key (comma-separated) in `%LOCALAPPDATA%\Clawdmeter\config`, parsed with the same style as the existing `chime`/`clock` readers.
- `PlanSelector` ported verbatim from #95's Python daemon: active = plan whose 5h session % rose most recently (rise stamps a monotonic poll counter, so the choice is sticky; a window reset to 0 is not activity; startup/tie falls back to highest current %). Module-level instance so state survives reconnects, matching #95's `_SELECTOR`.

**Deliberate deviations from #95, called out for review**
1. Unset `config_dirs` returns `[]` and routes through the *untouched* legacy `read_token()` path — the Windows default is a candidate/probe LIST (env overrides + 3 paths), not a single dir, so substituting `[~/.claude]` would change current behavior. Zero change for existing setups; the pre-existing reconnect tests pass unmodified.
2. Toast semantics (no #95 analogue, macOS has no tray): "token expired" toasts only when NO configured dir yields a payload AND the failure is genuinely token-shaped (missing or 401/403 everywhere). All-transient cycles stay silent (preserves the SC#5 fix), and one expired sibling never hides a working plan.
3. No Keychain fallback in `read_token_for` — no Windows analogue.

**Testing**
- 26 new tests in `daemon/tests/test_windows_multidir.py` following the existing mock conventions: config parsing edge cases, selector rules (startup/rise/sticky/reset), legacy-path preservation, multi-dir polling, and all four toast-semantics cases.
- Full daemon suite: **142 passed**.
- Same caveat as #139: unit-tested (Linux/pytest), not run on a physical Windows machine — the poll/selection logic is exercised through the real code paths with mocked BLE/API/filesystem.

Not included: `install-windows.ps1` prompts (#98, tracked separately per the issue notes) and Windows config docs (no existing Windows doc surface documents any config keys yet — happy to add a section to `README-windows.md` in this PR if you want one).

Closes #97