### PR TITLE
Add M5Stack FIRE board port (ESP32-classic, ILI9342C, no touch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # Project context
 
-ESP32-S3 / ESP32-C6 firmware for a desk-side Claude Code usage monitor. Each
+ESP32-S3 / ESP32-C6 / ESP32-classic firmware for a desk-side Claude Code usage monitor. Each
 supported board lives in its own `firmware/src/boards/<name>/` folder and is
 selected via PlatformIO's `build_src_filter`. Adding a board means dropping in
 a new folder + a new `[env:...]` block — `main.cpp`, `ui.cpp`, and `splash.cpp`
 never see board-specific code. See [`docs/porting/adding-a-board.md`](docs/porting/adding-a-board.md).
 
-Six ports today (two SoC families, four panel sizes):
+Seven ports today (three SoC families, five panel sizes):
 
 - `boards/waveshare_amoled_216/` — original Waveshare ESP32-S3-Touch-AMOLED-2.16 (CO5300, 480×480 square, CST9220 touch, IMU rotation). Build env: `waveshare_amoled_216`.
 - `boards/waveshare_amoled_18/` — Waveshare ESP32-S3-Touch-AMOLED-1.8 (368×448 portrait, XCA9554 IO expander). Build env: `waveshare_amoled_18`. **Two panel revisions are auto-detected at boot** (`board_rev()` in `board_init.cpp`, enum in `board_rev.h`): original = SH8601 display + FT3168 touch (0x38); later = CO5300 display + CST816 touch (0x15). One binary drives both.
@@ -14,6 +14,7 @@ Six ports today (two SoC families, four panel sizes):
 - `boards/waveshare_amoled_18_c6/` — Waveshare ESP32-C6-Touch-AMOLED-1.8 (368×448 portrait, SH8601, FT3168 touch, TCA9554 expander). Build env: `waveshare_amoled_18_c6`. Same panel as the S3 1.8 but on the C6 SoC. All subsystems (display, touch, BOOT + PWR buttons, battery, BLE) verified on hardware.
 - `boards/waveshare_amoled_206/` — Waveshare ESP32-S3-Touch-AMOLED-2.06 (CO5300, 410×502 watch form factor, FT3168 touch, no IO expander, 32 MB flash, PCF85063 RTC, ES8311 codec). Build env: `waveshare_amoled_206`. Display, touch, battery, IMU init, and BLE verified on hardware; the ES8311 chime path is not wired up (`sound.cpp` no-ops).
 - `boards/waveshare_lcd_154/` — Waveshare ESP32-S3-Touch-LCD-1.54 (ST7789, 240×240 square, CST816T touch @ 0x15). Build env: `waveshare_lcd_154`. **The first non-AMOLED port**: a plain 4-wire SPI TFT, not QSPI, and the panel has no brightness command — backlight is LEDC PWM on `LCD_BL`. **No PMU**: battery is an ADC divider on GPIO1 and `BAT_EN` (GPIO2) is a power-hold line that must be driven HIGH early in `board_init()` or the board browns out on battery. Three buttons (BOOT + GPIO5 + a PWR-role GPIO4); ES8311 chime wired up; QMI8658 populated but unused (fixed orientation, no rotation).
+- `boards/m5stack_fire/` — M5Stack FIRE (ILI9342C, 320×240 landscape SPI TFT, **no touch**, IP5306 PMU, MPU6886 unused). Build env: `m5stack_fire`. **The first ESP32-classic port and the first touch-less board**: navigation is the three front buttons (A=GPIO39 left→Space, C=GPIO37 right→Shift+Tab, B=GPIO38 middle→PWR-role: cycle screens/brightness + hold-to-pair). Battery/charging come from the **IP5306** power-bank IC over I2C (coarse 25/50/75/100 % gauge, feeds the four-state icon); hardware power on/off is the IP5306's own red side button, so no software power-off. Speaker is a DAC path, not the I2S/ES8311 chime engine, so `sound.cpp` no-ops. Classic ESP32 has **no native USB** — Serial (and the `screenshot` command) run over UART0 through the on-board CH9102 bridge, which appears as `/dev/cu.usbserial-*` (macOS) / `/dev/ttyUSB*` (Linux), *not* `usbmodem*`. The `m5stack-fire` board JSON supplies PSRAM (+ the rev1 cache workaround), 16 MB flash and the 16 MB partitions, so the env stays minimal. 240px-tall → lands on the existing "small" (240×240) UI breakpoint; the extra 80px of width is unused headroom a future landscape breakpoint could claim.
 
 **C6 ports have no PSRAM** — shared code gates on `BOARD_HAS_PSRAM` (absent on C6) to use `MALLOC_CAP_INTERNAL` for LVGL/splash buffers, and the `screenshot` serial command is disabled (`LV_USE_SNAPSHOT=0`), so UI changes on a C6 board must be eyeballed on hardware, not auto-captured.
 
@@ -80,6 +81,7 @@ firmware/src/
     waveshare_amoled_18_c6/ — C6: SH8601 + FT3168 + AXP PKEY + TCA9554 (gates power), no PSRAM
     waveshare_amoled_206/   — CO5300 + FT3168 + AXP PKEY, no IO expander, 32 MB, no rotation
     waveshare_lcd_154/      — ST7789 SPI TFT + CST816T + ADC battery (no PMU), PWM backlight
+    m5stack_fire/           — ESP32 classic: ILI9342C SPI TFT, no touch, 3 buttons, IP5306 PMU, PWM backlight
     template/               — copy this to bootstrap a new port
   main.cpp                  — setup() + loop(): HAL calls only, zero #ifdef BOARD_*
   ui.{h,cpp}                — 3-screen UI (splash, usage, bluetooth). compute_layout() picks fonts/positions from board_caps() (responsive — current breakpoint: H >= 460 → large, else compact)
@@ -108,15 +110,21 @@ pio run -d firmware -e waveshare_amoled_216_c6                                  
 pio run -d firmware -e waveshare_amoled_18_c6                                   # build 1.8 (C6)
 pio run -d firmware -e waveshare_amoled_206                                     # build 2.06 (S3, watch)
 pio run -d firmware -e waveshare_lcd_154                                        # build 1.54 (S3, SPI TFT)
+pio run -d firmware -e m5stack_fire                                             # build M5Stack FIRE (ESP32 classic)
 pio run -d firmware -e waveshare_amoled_18 -t upload --upload-port /dev/cu.usbmodem101   # flash 1.8 on macOS
 pio run -d firmware -e waveshare_amoled_216 -t upload --upload-port /dev/ttyACM0         # flash 2.16 on Linux
+pio run -d firmware -e m5stack_fire -t upload --upload-port /dev/cu.usbserial-XXXX        # flash M5Stack (UART bridge)
 # C6 boards: same native USB-JTAG flashing; flag a chip mismatch ("This chip is ESP32-C6,
 # not ESP32-S3") means you picked an S3 env — use a *_c6 env for C6 hardware.
+# M5Stack FIRE is ESP32 classic over a CH9102 UART bridge, so it enumerates as
+# /dev/cu.usbserial-* (macOS) / /dev/ttyUSB* (Linux), NOT usbmodem*/ttyACM*. A
+# chip mismatch ("This chip is ESP32, not ESP32-S3") means an S3 env was aimed at
+# M5Stack hardware — use the m5stack_fire env.
 ```
 
 If `pio` isn't on PATH: try `~/.platformio/penv/bin/pio` (Linux/macOS pio install) or `brew install platformio` on macOS.
 
-Device path differs by OS: `/dev/cu.usbmodem*` on macOS, `/dev/ttyACM0` on Linux. Both expose the ESP32-S3 native USB-JTAG (no boot-mode dance needed).
+Device path differs by OS and SoC: S3/C6 boards expose a native USB-JTAG at `/dev/cu.usbmodem*` (macOS) / `/dev/ttyACM0` (Linux), no boot-mode dance. The M5Stack FIRE (ESP32 classic) has no native USB — it's a CH9102 UART bridge at `/dev/cu.usbserial-*` / `/dev/ttyUSB*`.
 
 ## QA your own UI changes — don't ask the user
 
@@ -127,7 +135,7 @@ The boot screen is `SCREEN_SPLASH` and only advances on a physical button press,
 ## Critical gotchas
 
 1. **CO5300 cannot rotate.** Its MADCTL only supports axis flips, not column/row exchange. Rotation is done by **CPU pixel remapping inside `display_hal_draw_bitmap`** in `boards/waveshare_amoled_216/display.cpp`. We use **PARTIAL render mode with strip rotation** (small 480×40 strips, fast). On rotation change → AMOLED brightness flash → force redraw (handled inside `display_hal_tick`).
-2. **OPI PSRAM** required: `board_build.arduino.memory_type = qio_opi` in platformio.ini. Without this, `MALLOC_CAP_SPIRAM` returns NULL and the screen is black.
+2. **PSRAM must be enabled or the screen is black** (`MALLOC_CAP_SPIRAM` returns NULL). On the S3 boards that means `board_build.arduino.memory_type = qio_opi` in platformio.ini. The M5Stack FIRE (ESP32 classic, WROVER) instead gets PSRAM + the rev1 cache workaround from its `m5stack-fire` board JSON — no memory_type line. C6 boards have no PSRAM at all and gate on `BOARD_HAS_PSRAM` (see #below).
 3. **pioarduino platform required.** GFX Library for Arduino needs Arduino Core 3.x (`esp32-hal-periman.h`), not the 2.x that standard `espressif32` ships. We pin `pioarduino/platform-espressif32` 55.03.38-1.
 4. **LVGL 9 font patching.** `lv_font_conv` outputs LVGL 8 format. Must remove `#if LVGL_VERSION_MAJOR >= 8` guards, drop `.cache` field, add `.release_glyph`, `.kerning`, `.static_bitmap`, `.fallback`, `.user_data`. Without patching, fonts render invisible.
 5. **Touch reading is centralized inside each board's `touch.cpp`.** The HAL `touch_hal_read()` is called once per loop from `my_touch_cb`; the board's implementation owns its latched `touch_pressed/x/y` state. Don't call the underlying controller from anywhere else — CST9220's `getPoint()` etc. do a full I2C transaction and concurrent callers consume each other's data.

--- a/docs/porting/adding-a-board.md
+++ b/docs/porting/adding-a-board.md
@@ -10,14 +10,25 @@ gap in the HAL — open an issue.
 
 At minimum:
 
-- An **ESP32-S3** (other ESP32 family members may work; this is what the
-  upstream firmware is tested on). OPI PSRAM is **required** — partial
-  flush buffers and the splash canvas are allocated from PSRAM.
-- A QSPI **AMOLED panel** with a driver supported by
-  [GFX Library for Arduino](https://github.com/moononournation/Arduino_GFX)
-  (CO5300, SH8601, NV3041A, etc.). Other interfaces aren't supported yet.
-- A **touch controller** over I2C. The HAL just needs init + read; you
-  can use any driver you can compile.
+- An **ESP32**. The upstream firmware runs on the S3 (most ports), the
+  C6 (RISC-V, no PSRAM), and the original ESP32 classic (M5Stack FIRE) —
+  so any family member the pioarduino Arduino 3.x core supports is fair
+  game. **PSRAM strongly recommended**: partial flush buffers and the
+  splash canvas allocate from it by default. Boards without PSRAM must
+  build without `-DBOARD_HAS_PSRAM` (shared code then shrinks the buffers
+  into internal SRAM and disables the `screenshot` command — see the C6
+  envs).
+- A **panel** with a driver in
+  [GFX Library for Arduino](https://github.com/moononournation/Arduino_GFX).
+  QSPI AMOLEDs (CO5300, SH8601, NV3041A) and plain 4-wire SPI TFTs
+  (ST7789 on the LCD-1.54, ILI9342C on the M5Stack FIRE) both work — the
+  bus is abstracted behind the driver, so the display HAL surface is the
+  same either way.
+- **Either** a touch controller over I2C **or** enough physical buttons
+  to navigate. Touch is optional: the M5Stack FIRE has none, and its
+  `touch.cpp` is a permanent no-op (`read` always reports "not pressed")
+  while the three front buttons carry all input. A touch driver, if you
+  have one, just needs init + read.
 - A **primary button** (typically the BOOT/GPIO 0 push button).
 
 Optional:

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -121,6 +121,70 @@ lib_deps =
     h2zero/NimBLE-Arduino@^2.1.1
 
 
+[env:m5stack_fire]
+; M5Stack FIRE — first ESP32 *classic* port and first touch-less board.
+; 320x240 ILI9342C TFT over 4-wire SPI, three front buttons instead of touch,
+; IP5306 PMU for battery, MPU6886 IMU (unused). The m5stack-fire board JSON
+; already sets the classic-ESP32 MCU, BOARD_HAS_PSRAM (+ the rev1 PSRAM cache
+; workaround), 16 MB flash and the default_16MB partitions — so, unlike the S3
+; envs, there is no memory_type/flash_size to repeat here.
+;
+; No ARDUINO_USB_CDC_ON_BOOT: the classic ESP32 has no native USB — Serial is
+; plain UART0 through the on-board CH9102 bridge (shows up as /dev/cu.usbserial-*
+; / /dev/ttyUSB*), which is also what carries the `screenshot` command.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = m5stack-fire
+framework = arduino
+; The CH9102 UART bridge is flaky at 921600 (esptool "chip stopped responding"
+; reading the flash ID); 460800 is the M5Stack board-JSON default and reliable.
+upload_speed = 460800
+monitor_speed = 115200
+
+build_src_filter =
+    +<*>
+    -<boards/>
+    +<boards/m5stack_fire/>
+
+build_flags =
+    -DBOARD_M5STACK_FIRE
+    ; NimBLE config — peripheral, 2 simultaneous connections so the OS can
+    ; hold the HID link (Space key from BOOT button) while the daemon holds
+    ; its own connection for the custom data service.
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    ; Peripheral Preferred Connection Parameters — see the waveshare_amoled_216
+    ; env for the full rationale (Windows supervision-timeout churn fix).
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MIN_CONN_INTERVAL=12
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MAX_CONN_INTERVAL=24
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SLAVE_LATENCY=0
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SUPERVISION_TMO=600
+    ; LVGL config via build flags
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    ; Arduino_ILI9342 (the M5Stack Core/Fire panel) is in mainline GFX 1.6.4+.
+    moononournation/GFX Library for Arduino@^1.6.4
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1
+
+
 [env:waveshare_amoled_18]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
 board = esp32-s3-devkitc-1

--- a/firmware/src/boards/m5stack_fire/board.h
+++ b/firmware/src/boards/m5stack_fire/board.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// M5Stack FIRE — the first ESP32 *classic* port (all other boards are S3/C6)
+// and the first with no touch panel: a 320x240 ILI9342C TFT over 4-wire SPI,
+// three front push-buttons (A/B/C) in place of touch, an IP5306 power-bank PMU
+// for battery reporting, and an MPU6886 IMU (populated, unused). 16 MB flash +
+// PSRAM (WROVER module). USB is a CH9102 UART bridge — there is no native USB,
+// so Serial is plain UART0 and ARDUINO_USB_CDC_ON_BOOT is NOT set in the env.
+//
+// Pin map is the canonical M5Stack Core/Fire wiring (M5GFX / M5Stack Arduino
+// library): TFT on VSPI, buttons on the input-only GPIOs 37/38/39, internal
+// I2C on 21/22 shared by the IP5306 and MPU6886.
+
+#define BOARD_NAME           "M5Stack FIRE"
+
+// ---- Display geometry (ILI9342C is natively 320x240 landscape) ----
+#define LCD_WIDTH            320
+#define LCD_HEIGHT           240
+
+// ---- SPI display pins (ILI9342C, 4-wire SPI on VSPI) ----
+#define LCD_CS               14
+#define LCD_SCLK             18
+#define LCD_MOSI             23
+#define LCD_MISO             19    // wired but unused by the write-only HAL
+#define LCD_DC               27
+#define LCD_RST              33
+#define LCD_BL               32    // backlight, LEDC PWM (TFT has no brightness cmd)
+
+// ---- I2C bus (IP5306 PMU + MPU6886 IMU share the internal bus) ----
+#define IIC_SDA              21
+#define IIC_SCL              22
+
+// ---- Power (IP5306 power-bank IC, I2C — 4-LED battery gauge, no fine %) ----
+// The IP5306 owns hardware power on/off via M5Stack's dedicated red side
+// button (double-tap on, long-hold off) — that path is entirely in silicon,
+// so this port never synthesizes a software power-off (unlike the LCD-1.54).
+#define IP5306_ADDR          0x75
+
+// ---- Buttons (M5Stack front A/B/C, active-LOW, input-only GPIOs) ----
+// GPIO 34..39 have no internal pull-ups; M5Stack fits external 10k pull-ups,
+// so input.cpp uses plain INPUT (not INPUT_PULLUP).
+//   A (left)   → primary,   HID Space (voice-mode PTT)
+//   C (right)  → secondary, HID Shift+Tab (mode toggle)
+//   B (middle) → PWR-role,  cycle screens / brightness / hold-to-pair
+#define BTN_A_GPIO           39    // primary
+#define BTN_B_GPIO           38    // PWR-role (owned by power.cpp)
+#define BTN_C_GPIO           37    // secondary
+
+// ---- Capability flags ----
+#define BOARD_HAS_SECONDARY_BUTTON 1
+#define BOARD_HAS_ROTATION         0    // fixed desk orientation
+#define BOARD_HAS_IMU              0    // MPU6886 populated but unused
+#define BOARD_HAS_BATTERY          1    // via IP5306
+#define BOARD_HAS_TOUCH            0    // no touch panel — PWR button navigates the splash
+#define BOARD_HAS_IO_EXPANDER      0
+#define BOARD_HAS_SOUND            0    // speaker is a DAC path, not the I2S chime engine

--- a/firmware/src/boards/m5stack_fire/board_init.cpp
+++ b/firmware/src/boards/m5stack_fire/board_init.cpp
@@ -1,0 +1,11 @@
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// Bring up the internal I2C bus (IP5306 PMU + MPU6886 IMU). No IO expander and
+// no power-hold latch on this board — the IP5306 keeps the rail up on its own —
+// so board_init just starts Wire. The display reset is a direct GPIO pulsed by
+// the Arduino_GFX driver in display_hal_begin(), so nothing else is needed here.
+extern "C" void board_init(void) {
+    Wire.begin(IIC_SDA, IIC_SCL);
+}

--- a/firmware/src/boards/m5stack_fire/caps.cpp
+++ b/firmware/src/boards/m5stack_fire/caps.cpp
@@ -1,0 +1,17 @@
+#include "../../hal/board_caps.h"
+#include "board.h"
+
+static const BoardCaps caps = {
+    .name = BOARD_NAME,
+    .width = LCD_WIDTH,
+    .height = LCD_HEIGHT,
+    // Front buttons A (primary) + C (secondary). The middle button B is the
+    // PWR-role button, handled in power.cpp and not counted here.
+    .button_count = (uint8_t)(1 + BOARD_HAS_SECONDARY_BUTTON),
+    .has_rotation = (bool)BOARD_HAS_ROTATION,
+    .has_battery  = (bool)BOARD_HAS_BATTERY,
+    .has_imu      = (bool)BOARD_HAS_IMU,
+    .has_touch    = (bool)BOARD_HAS_TOUCH,
+};
+
+const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/m5stack_fire/display.cpp
+++ b/firmware/src/boards/m5stack_fire/display.cpp
@@ -1,0 +1,52 @@
+#include "../../hal/display_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+// ILI9342C over 4-wire SPI (VSPI) — the M5Stack Core/Fire panel. Arduino_GFX
+// ships a dedicated Arduino_ILI9342 driver whose rotation table already applies
+// the panel's BGR order, so the HAL surface is identical to the ST7789 port.
+// Brightness is a LEDC PWM duty on the backlight GPIO (the TFT has no in-panel
+// brightness command), same approach as the LCD-1.54.
+//
+// Rotation 2 gives the native 320x240 landscape upright with the three front
+// buttons along the bottom edge (rotation 0 renders it 180°-flipped — upside
+// down — on this hardware; both are 320x240, just mirrored 180°).
+
+static Arduino_DataBus*  bus = nullptr;
+static Arduino_ILI9342*  gfx = nullptr;
+
+void display_hal_init(void) {
+    bus = new Arduino_ESP32SPI(LCD_DC, LCD_CS, LCD_SCLK, LCD_MOSI, LCD_MISO);
+    // ips=true — the M5Stack panel needs color inversion for correct blacks.
+    gfx = new Arduino_ILI9342(bus, LCD_RST, 2 /* rotation */, true /* ips */);
+}
+
+void display_hal_begin(void) {
+    gfx->begin(40000000);   // 40 MHz — the M5Stack-library default for this panel
+    gfx->fillScreen(0x0000);
+    ledcAttach(LCD_BL, 5000 /* Hz */, 8 /* bits */);
+    ledcWrite(LCD_BL, 200);
+}
+
+void display_hal_set_brightness(uint8_t level) {
+    ledcWrite(LCD_BL, level);
+}
+
+void display_hal_fill_screen(uint16_t color) {
+    if (gfx) gfx->fillScreen(color);
+}
+
+void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
+                             const uint16_t* pixels) {
+    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+}
+
+void display_hal_tick(void) {
+    // No rotation cycle on this board.
+}
+
+// ILI9342C over SPI has no flush-region alignment requirement.
+void display_hal_round_area(int32_t* x1, int32_t* y1, int32_t* x2, int32_t* y2) {
+    (void)x1; (void)y1; (void)x2; (void)y2;
+}

--- a/firmware/src/boards/m5stack_fire/imu.cpp
+++ b/firmware/src/boards/m5stack_fire/imu.cpp
@@ -1,0 +1,9 @@
+#include "../../hal/imu_hal.h"
+
+// An MPU6886 is populated on the M5Stack FIRE (I2C 0x68), but this port runs at
+// a fixed desk orientation, so rotation is off and the IMU stays uninitialized
+// — matching the AMOLED-1.8 / LCD-1.54 posture.
+
+void    imu_hal_init(void) {}
+void    imu_hal_tick(void) {}
+uint8_t imu_hal_rotation_quadrant(void) { return 0; }

--- a/firmware/src/boards/m5stack_fire/input.cpp
+++ b/firmware/src/boards/m5stack_fire/input.cpp
@@ -1,0 +1,29 @@
+#include "../../hal/input_hal.h"
+#include "board.h"
+#include <Arduino.h>
+
+// M5Stack front buttons A (left) and C (right) are the two screen-independent
+// buttons. The middle button B is the PWR-role button and lives in power.cpp.
+// GPIO 37/38/39 are input-only with no internal pull-up; M5Stack provides
+// external 10k pull-ups, so these use plain INPUT and read LOW when pressed.
+
+void input_hal_init(void) {
+    pinMode(BTN_A_GPIO, INPUT);
+#if BOARD_HAS_SECONDARY_BUTTON
+    pinMode(BTN_C_GPIO, INPUT);
+#endif
+}
+
+bool input_hal_is_held(InputButton btn) {
+    switch (btn) {
+    case INPUT_BTN_PRIMARY:
+        return digitalRead(BTN_A_GPIO) == LOW;
+    case INPUT_BTN_SECONDARY:
+#if BOARD_HAS_SECONDARY_BUTTON
+        return digitalRead(BTN_C_GPIO) == LOW;
+#else
+        return false;
+#endif
+    }
+    return false;
+}

--- a/firmware/src/boards/m5stack_fire/power.cpp
+++ b/firmware/src/boards/m5stack_fire/power.cpp
@@ -1,0 +1,118 @@
+#include "../../hal/power_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// Battery + charging come from the IP5306 power-bank IC over I2C. The IP5306
+// only exposes a coarse 4-LED fuel gauge (25/50/75/100 %), which is plenty for
+// the four-state battery icon. Hardware power on/off is handled by the IP5306
+// itself via M5Stack's red side button, so — unlike the LCD-1.54 — this port
+// never synthesizes a software power-off.
+//
+// The PWR-role button is the middle front button (B) on a plain input-only
+// GPIO. Same software edge synthesis as the other button-only ports so the
+// hold-to-pair gesture in main.cpp stays board-agnostic:
+//   short    — fired on release if the hold was shorter than PWR_LONG_MS
+//   long     — fired once when a hold crosses PWR_LONG_MS
+//   release  — fired on every release edge
+
+#define BATTERY_POLL_MS  2000
+#define PWR_POLL_MS      50
+#define PWR_LONG_MS      1500
+
+static int      cached_pct        = -1;
+static bool     cached_charging   = false;
+static bool     pwr_pressed_flag  = false;
+static bool     pwr_long_flag     = false;
+static bool     pwr_released_flag = false;
+static bool     last_pwr_state    = false;
+static uint32_t pwr_press_started_ms = 0;
+static bool     pwr_long_fired    = false;
+static uint32_t last_battery_ms   = 0;
+static uint32_t last_pwr_ms       = 0;
+
+// Read one IP5306 register; returns false (and leaves *out untouched) on a bus
+// error so a hiccup doesn't get misread as 0x00 (which the gauge maps to 100%).
+static bool ip5306_read(uint8_t reg, uint8_t* out) {
+    Wire.beginTransmission(IP5306_ADDR);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return false;
+    if (Wire.requestFrom((uint8_t)IP5306_ADDR, (uint8_t)1) != 1) return false;
+    *out = Wire.read();
+    return true;
+}
+
+static void sample_battery(void) {
+    uint8_t gauge;
+    if (!ip5306_read(0x78, &gauge)) {   // REG_READ4: 4-LED fuel gauge in the high nibble
+        cached_pct = -1;
+        return;
+    }
+    // Thermometer nibble: more high bits set = lower charge.
+    switch (gauge & 0xF0) {
+    case 0x00: cached_pct = 100; break;
+    case 0x80: cached_pct = 75;  break;
+    case 0xC0: cached_pct = 50;  break;
+    case 0xE0: cached_pct = 25;  break;
+    default:   cached_pct = 5;   break;   // 0xF0 — nearly empty
+    }
+
+    // REG_READ0 bit3 = charging in progress; REG_READ1 bit3 = charge-full. Show
+    // the bolt while either is true (i.e. USB is supplying the pack). These bit
+    // meanings are from community IP5306 notes — verify the bolt on hardware and
+    // flip the masks here if it reads inverted.
+    uint8_t r0 = 0, r1 = 0;
+    bool ok0 = ip5306_read(0x70, &r0);
+    bool ok1 = ip5306_read(0x71, &r1);
+    cached_charging = (ok0 && (r0 & 0x08)) || (ok1 && (r1 & 0x08));
+}
+
+void power_hal_init(void) {
+    pinMode(BTN_B_GPIO, INPUT);   // input-only GPIO, external pull-up on M5Stack
+    sample_battery();
+}
+
+void power_hal_tick(void) {
+    uint32_t now = millis();
+
+    if (now - last_battery_ms >= BATTERY_POLL_MS) {
+        last_battery_ms = now;
+        sample_battery();
+    }
+    if (now - last_pwr_ms >= PWR_POLL_MS) {
+        last_pwr_ms = now;
+        bool pwr_now = (digitalRead(BTN_B_GPIO) == LOW);   // active LOW
+        if (pwr_now && !last_pwr_state) {            // press edge — hold begins
+            pwr_press_started_ms = now;
+            pwr_long_fired = false;
+        } else if (pwr_now && last_pwr_state) {      // held
+            if (!pwr_long_fired && (now - pwr_press_started_ms >= PWR_LONG_MS)) {
+                pwr_long_flag  = true;
+                pwr_long_fired = true;
+            }
+        } else if (!pwr_now && last_pwr_state) {     // release edge
+            pwr_released_flag = true;
+            if (!pwr_long_fired) pwr_pressed_flag = true;  // short press
+        }
+        last_pwr_state = pwr_now;
+    }
+}
+
+int  power_hal_battery_pct(void) { return cached_pct; }
+bool power_hal_is_charging(void) { return cached_charging; }
+bool power_hal_is_vbus_in(void)  { return cached_charging; }
+
+bool power_hal_pwr_pressed(void) {
+    if (pwr_pressed_flag) { pwr_pressed_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_long_pressed(void) {
+    if (pwr_long_flag) { pwr_long_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_released(void) {
+    if (pwr_released_flag) { pwr_released_flag = false; return true; }
+    return false;
+}

--- a/firmware/src/boards/m5stack_fire/power.cpp
+++ b/firmware/src/boards/m5stack_fire/power.cpp
@@ -64,7 +64,9 @@ static void sample_battery(void) {
     uint8_t r0 = 0, r1 = 0;
     bool ok0 = ip5306_read(0x70, &r0);
     bool ok1 = ip5306_read(0x71, &r1);
-    cached_charging = (ok0 && (r0 & 0x08)) || (ok1 && (r1 & 0x08));
+    if (ok0 || ok1) {
+        cached_charging = (ok0 && (r0 & 0x08)) || (ok1 && (r1 & 0x08));
+    }
 }
 
 void power_hal_init(void) {

--- a/firmware/src/boards/m5stack_fire/sound.cpp
+++ b/firmware/src/boards/m5stack_fire/sound.cpp
@@ -1,0 +1,11 @@
+#include "../../hal/sound_hal.h"
+
+// M5Stack FIRE has a speaker, but it's driven from the ESP32 DAC on GPIO25 —
+// not the I2S + ES8311 codec the shared chime engine (../../chime.cpp) targets.
+// Rather than add a DAC playback path, sound output is a no-op for now (same
+// posture as the AMOLED-2.06 / C6 ports). A future revision could wire the
+// reset chime to a DAC tone here.
+
+void sound_hal_init(void) {}
+void sound_hal_tick(void) {}
+void sound_hal_play_reset(void) {}

--- a/firmware/src/boards/m5stack_fire/touch.cpp
+++ b/firmware/src/boards/m5stack_fire/touch.cpp
@@ -1,0 +1,14 @@
+#include "../../hal/touch_hal.h"
+
+// The M5Stack FIRE has no touch panel — navigation is the three front buttons
+// (see input.cpp for A/C and power.cpp for the middle button). The touch HAL
+// is a permanent no-op: read always reports "not pressed", so LVGL's pointer
+// indev stays idle and the shared my_touch_cb never registers a press.
+
+void touch_hal_init(void) {}
+
+void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
+    *x = 0;
+    *y = 0;
+    *pressed = false;
+}

--- a/firmware/src/boards/template/caps.cpp
+++ b/firmware/src/boards/template/caps.cpp
@@ -9,6 +9,7 @@ static const BoardCaps caps = {
     .has_rotation = (bool)BOARD_HAS_ROTATION,
     .has_battery  = (bool)BOARD_HAS_BATTERY,
     .has_imu      = (bool)BOARD_HAS_IMU,
+    .has_touch    = true,   // set false if your board has no touch panel (PWR navigates)
 };
 
 const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_amoled_18/caps.cpp
+++ b/firmware/src/boards/waveshare_amoled_18/caps.cpp
@@ -9,6 +9,7 @@ static const BoardCaps caps = {
     .has_rotation = false,
     .has_battery = true,
     .has_imu = true,
+    .has_touch = true,
 };
 
 const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_amoled_18_c6/caps.cpp
+++ b/firmware/src/boards/waveshare_amoled_18_c6/caps.cpp
@@ -9,6 +9,7 @@ static const BoardCaps caps = {
     .has_rotation = false,
     .has_battery = true,
     .has_imu = true,
+    .has_touch = true,
 };
 
 const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_amoled_206/caps.cpp
+++ b/firmware/src/boards/waveshare_amoled_206/caps.cpp
@@ -9,6 +9,7 @@ static const BoardCaps caps = {
     .has_rotation = false,
     .has_battery = true,
     .has_imu = true,
+    .has_touch = true,
 };
 
 const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_amoled_216/caps.cpp
+++ b/firmware/src/boards/waveshare_amoled_216/caps.cpp
@@ -9,6 +9,7 @@ static const BoardCaps caps = {
     .has_rotation = true,
     .has_battery = true,
     .has_imu = true,
+    .has_touch = true,
 };
 
 const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_amoled_216_c6/caps.cpp
+++ b/firmware/src/boards/waveshare_amoled_216_c6/caps.cpp
@@ -11,6 +11,7 @@ static const BoardCaps caps = {
     .has_rotation = (bool)BOARD_HAS_ROTATION,
     .has_battery = (bool)BOARD_HAS_BATTERY,
     .has_imu = (bool)BOARD_HAS_IMU,
+    .has_touch = true,
 };
 
 const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_lcd_154/caps.cpp
+++ b/firmware/src/boards/waveshare_lcd_154/caps.cpp
@@ -11,6 +11,7 @@ static const BoardCaps caps = {
     .has_rotation = (bool)BOARD_HAS_ROTATION,
     .has_battery  = (bool)BOARD_HAS_BATTERY,
     .has_imu      = (bool)BOARD_HAS_IMU,
+    .has_touch    = true,
 };
 
 const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/hal/board_caps.h
+++ b/firmware/src/hal/board_caps.h
@@ -18,6 +18,9 @@ struct BoardCaps {
     bool    has_rotation;    // IMU-driven CPU rotation in the flush callback
     bool    has_battery;     // AXP2101 battery measurement is meaningful
     bool    has_imu;         // QMI8658 (or compatible) is populated
+    bool    has_touch;       // has a touch panel. Touchless boards (M5Stack FIRE)
+                             // can't tap to leave the splash, so shared code
+                             // routes the splash<->usage toggle to the PWR button.
 };
 
 const BoardCaps& board_caps(void);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -341,10 +341,20 @@ void loop() {
 
         if (power_hal_pwr_pressed()) {
             if (!idle_consume_wake_press()) {
-                // On splash: cycle animations. On the usage view: cycle
-                // screen brightness (single non-splash view, no more screens).
-                if (ui_get_current_screen() == SCREEN_SPLASH) splash_next();
-                else                                          brightness_cycle();
+                if (!board_caps().has_touch) {
+                    // Touchless boards (e.g. M5Stack FIRE) have no screen tap to
+                    // leave the splash, so the PWR button is the sole splash<->usage
+                    // toggle. Animations still auto-rotate (~20s) and follow the
+                    // usage-rate group, so manual splash cycling isn't lost here.
+                    ui_toggle_splash();
+                } else if (ui_get_current_screen() == SCREEN_SPLASH) {
+                    // On splash: cycle animations (a screen tap toggles the view).
+                    splash_next();
+                } else {
+                    // On the usage view: cycle screen brightness (single
+                    // non-splash view, no more screens).
+                    brightness_cycle();
+                }
             }
         }
 

--- a/flash-mac.sh
+++ b/flash-mac.sh
@@ -20,11 +20,27 @@ if [ -z "$BOARD" ]; then
 fi
 
 if [ -z "$PORT" ]; then
-    PORT=$(ls /dev/cu.usbmodem* 2>/dev/null | head -1)
-    if [ -z "$PORT" ]; then
-        echo "Error: no /dev/cu.usbmodem* device found. Plug in via USB-C."
-        exit 1
-    fi
+    case "$BOARD" in
+        m5stack_fire)
+            # ESP32-classic over a CH9102 UART bridge → /dev/cu.usbserial-* or
+            # /dev/cu.wchusbserial* (NOT the native-USB usbmodem* the S3/C6 use).
+            PORT=$(ls /dev/cu.usbserial-* /dev/cu.wchusbserial* 2>/dev/null | head -1)
+            if [ -z "$PORT" ]; then
+                echo "Error: no /dev/cu.usbserial-* (CH9102 UART bridge) device found."
+                echo "Plug the M5Stack FIRE in via USB-C. If it still isn't seen, install"
+                echo "the CH34x/CH9102 driver from https://www.wch-ic.com/downloads/CH34XSER_MAC_ZIP.html"
+                exit 1
+            fi
+            ;;
+        *)
+            # S3 / C6 boards expose a native USB-JTAG serial → /dev/cu.usbmodem*
+            PORT=$(ls /dev/cu.usbmodem* 2>/dev/null | head -1)
+            if [ -z "$PORT" ]; then
+                echo "Error: no /dev/cu.usbmodem* device found. Plug in via USB-C."
+                exit 1
+            fi
+            ;;
+    esac
 fi
 
 if ! command -v pio >/dev/null; then


### PR DESCRIPTION
# Add M5Stack FIRE board port (ESP32-classic, ILI9342C, no touch)

## Summary

Adds a seventh board port: the **M5Stack FIRE**. It's the first **ESP32-classic** target (all existing ports are S3 or C6) and the first **touch-less** board, so it exercises two paths the HAL hadn't before.

Verified end-to-end on hardware: display + orientation, IP5306 battery/charging, the BLE data service showing live usage from the daemon (session 6% / weekly 50%), and button navigation. 
<img height="500" alt="IMG_3526" src="https://github.com/user-attachments/assets/56b0dac1-2674-49b4-a55b-e7648dddd187" />


## What's in it

**New board (`firmware/src/boards/m5stack_fire/`)**
- `display.cpp` — `Arduino_ILI9342` (mainline GFX ≥1.6.4) over 4-wire SPI @ 40 MHz, `ips=true`, **rotation 2** (upright with the front buttons along the bottom edge). LEDC-PWM backlight, same as the LCD-1.54.
- `touch.cpp` — permanent no-op; there is no touch panel.
- `input.cpp` — front buttons **A (GPIO39) → HID Space**, **C (GPIO37) → HID Shift+Tab**, on the input-only GPIOs (external pull-ups, plain `INPUT`).
- `power.cpp` — **IP5306** over I2C for battery (coarse 25/50/75/100 % gauge → the four-state icon) and charging; middle button **B (GPIO38)** is the PWR-role button. No software power-off — the IP5306's side button handles hardware power.
- `imu.cpp` / `sound.cpp` — MPU6886 unused (fixed orientation); speaker is a DAC path, not the I2S/ES8311 chime engine, so sound no-ops (same posture as the 2.06 / C6 ports).

**Touch-less navigation (`has_touch` capability)**
- The splash↔usage toggle was **touch-only** (`global_click_cb` on `LV_EVENT_CLICKED`), so a board with no touch panel could never leave the splash — it sat there forever even with data flowing.
- Adds a `has_touch` field to `BoardCaps` and routes the PWR button to `ui_toggle_splash()` (previously dead code) on touch-less boards. Animations still auto-rotate (~20 s) and follow the usage-rate group, so manual cycling isn't lost.
- All existing boards are touch boards and are set `has_touch = true`; **no behavior change on them**.

**Env + docs**
- New `[env:m5stack_fire]` in `platformio.ini`. The `m5stack-fire` board JSON already supplies the classic-ESP32 MCU, PSRAM (+ rev1 cache workaround), 16 MB flash and partitions, so the env stays minimal.
- **No `ARDUINO_USB_CDC_ON_BOOT`**: classic ESP32 has no native USB — Serial (and the `screenshot` command) run over UART0 through the on-board CH9102 bridge, which enumerates as `/dev/cu.usbserial-*` / `/dev/ttyUSB*` (not `usbmodem*`), and upload runs at **460800** (921600 is flaky on that bridge).
- `CLAUDE.md` + `docs/porting/adding-a-board.md` updated: the port disproves the old "S3-only / QSPI-AMOLED-only / touch-required" assumptions.

## Build / flash

```bash
./flash-mac.sh m5stack_fire                       # auto-detects

or

pio run -d firmware -e m5stack_fire
pio run -d firmware -e m5stack_fire -t upload --upload-port /dev/cu.usbserial-XXXX
```

## Notes for reviewers / follow-ups

- The `has_touch` change touches every board's `caps.cpp` (one line each) — that's the intended blast radius of adding a capability field, not scope creep.
- IP5306 charging-bit masks come from community notes and are commented as such in `power.cpp`; the bolt reads correctly on this unit but the masks are worth a second look on other IP5306 revisions.
- The 240 px-tall panel lands on the existing 240×240 "small" UI breakpoint; the extra 80 px of width is unused headroom a future dedicated landscape breakpoint could claim.
- Audio is intentionally deferred (DAC path unwired).

## Commits

1. `feat: add has_touch cap so touchless boards navigate splash via PWR`
2. `feat: add M5Stack FIRE board port`

Each commit builds on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
