### PR TITLE
Add ESP32-S3-Touch-LCD-1.47 port with landscape support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ daemon/.venv/
 # Python bytecode cache
 __pycache__/
 *.pyc
+/.idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,36 +64,15 @@ ESP32-C6 sibling of the S3 1.8: same 368×448 SH8601 panel + FocalTech touch, di
 - Flash: 32 MB. Uses `default_32MB.csv` partition table.
 
 ### LCD-1.47 (landscape strip) — `waveshare_lcd_147`
-Non-AMOLED kit: a 172×320 **JD9853** IPS panel on plain 4-wire SPI, run rotated so
-the UI gets a **320×172 landscape** canvas (the only landscape port). Pin map taken
-from the official schematic, not the wiki — Waveshare's own ESP-IDF BSP header has
-TP_RST/TP_INT swapped relative to the board.
-- Display: JD9853 via SPI (CS=21, SCLK=38, MOSI=39, DC=45, RST=40, BL=46). Driven by
-  Arduino_GFX's `Arduino_ST7789` (the JD9853 shares the ST7789 command set for
-  CASET/RASET/RAMWR/MADCTL) **plus the vendor register sequence** in
-  `jd9853_reg_init()`, pushed after `gfx->begin()`. Without that sequence the panel
-  stays dark. Constructed portrait (172×320) with `col_offset1 = 34` — the visible
-  area starts at column 34 of the controller's 240-wide GRAM — then `setRotation(1)`;
-  `Arduino_TFT::setRotation` maps that offset onto the correct axis. `ips=false`
-  because the vendor sequence issues its own `INVON` (0x21).
+Non-AMOLED kit: a 172×320 **JD9853** IPS panel on plain 4-wire SPI, run rotated so the UI gets a **320×172 landscape** canvas (the only landscape port). Pin map taken from the official schematic, not the wiki — Waveshare's own ESP-IDF BSP header has TP_RST/TP_INT swapped relative to the board.
+- Display: JD9853 via SPI (CS=21, SCLK=38, MOSI=39, DC=45, RST=40, BL=46). Driven by Arduino_GFX's `Arduino_ST7789` (the JD9853 shares the ST7789 command set for CASET/RASET/RAMWR/MADCTL) **plus the vendor register sequence** in `jd9853_reg_init()`, pushed after `gfx->begin()`. Without that sequence the panel stays dark. Constructed portrait (172×320) with `col_offset1 = 34` — the visible area starts at column 34 of the controller's 240-wide GRAM — then `setRotation(1)`; `Arduino_TFT::setRotation` maps that offset onto the correct axis. `ips=false` because the vendor sequence issues its own `INVON` (0x21).
 - Brightness: LEDC PWM on the backlight GPIO (no panel brightness command), like the 1.54.
-- Touch: **AXS5106L** @ I2C 0x63 (SDA=42, SCL=41, INT=48, RST=47), vendored inline
-  reader — 14-byte burst from reg 0x01, finger count in byte 1. Needs a long reset
-  pulse (200 ms low / 300 ms settle). Landscape maps raw portrait coords by swapping
-  axes with no mirroring.
-- Battery: VBAT → 3.0× divider → GPIO12 (**ADC2**_CH1). No PMU, so charging/VBUS state
-  is unknowable and reports false. ADC2 is only contended by Wi-Fi, which this
-  firmware never starts.
-- Buttons: **BOOT (GPIO 0) is the only readable key** and it takes the PWR role
-  (screens / brightness / hold-3s-release pairing) — without it the device could never
-  be paired. So `BoardCaps.button_count == 0` and the HID Space / Shift+Tab paths never
-  fire on this board. Screen switching also works by tapping the touchscreen.
-- **No hold-to-power-off** (unlike the 1.54): there is no power-hold latch to drop, and
-  GPIO 0 is the S3's boot strapping pin — an ext0 LOW-level wake would sample it while
-  still held and drop the chip into USB download mode.
+- Touch: **AXS5106L** @ I2C 0x63 (SDA=42, SCL=41, INT=48, RST=47), vendored inline reader — 14-byte burst from reg 0x01, finger count in byte 1. Needs a long reset pulse (200 ms low / 300 ms settle). Landscape maps raw portrait coords by swapping axes with no mirroring.
+- Battery: VBAT → 3.0× divider → GPIO12 (**ADC2**_CH1). No PMU, so charging/VBUS state is unknowable and reports false. ADC2 is only contended by Wi-Fi, which this firmware never starts.
+- Buttons: **BOOT (GPIO 0) is the only readable key** and it takes the PWR role (screens / brightness / hold-3s-release pairing) — without it the device could never be paired. So `BoardCaps.button_count == 0` and the HID Space / Shift+Tab paths never fire on this board. Screen switching also works by tapping the touchscreen.
+- **No hold-to-power-off** (unlike the 1.54): there is no power-hold latch to drop, and GPIO 0 is the S3's boot strapping pin — an ext0 LOW-level wake would sample it while still held and drop the chip into USB download mode.
 - No IO expander, no IMU, no codec/buzzer. 16 MB flash + 8 MB octal PSRAM (ESP32-S3R8).
-- UI: `compute_layout()` has a dedicated landscape branch (`width > height && height < 200`)
-  that puts the two usage panels **side by side** instead of stacked.
+- UI: `compute_layout()` has a dedicated landscape branch (`width > height && height < 200`) that puts the two usage panels **side by side** instead of stacked.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ selected via PlatformIO's `build_src_filter`. Adding a board means dropping in
 a new folder + a new `[env:...]` block — `main.cpp`, `ui.cpp`, and `splash.cpp`
 never see board-specific code. See [`docs/porting/adding-a-board.md`](docs/porting/adding-a-board.md).
 
-Six ports today (two SoC families, four panel sizes):
+Seven ports today (two SoC families, five panel sizes):
 
 - `boards/waveshare_amoled_216/` — original Waveshare ESP32-S3-Touch-AMOLED-2.16 (CO5300, 480×480 square, CST9220 touch, IMU rotation). Build env: `waveshare_amoled_216`.
 - `boards/waveshare_amoled_18/` — Waveshare ESP32-S3-Touch-AMOLED-1.8 (368×448 portrait, XCA9554 IO expander). Build env: `waveshare_amoled_18`. **Two panel revisions are auto-detected at boot** (`board_rev()` in `board_init.cpp`, enum in `board_rev.h`): original = SH8601 display + FT3168 touch (0x38); later = CO5300 display + CST816 touch (0x15). One binary drives both.
@@ -14,6 +14,7 @@ Six ports today (two SoC families, four panel sizes):
 - `boards/waveshare_amoled_18_c6/` — Waveshare ESP32-C6-Touch-AMOLED-1.8 (368×448 portrait, SH8601, FT3168 touch, TCA9554 expander). Build env: `waveshare_amoled_18_c6`. Same panel as the S3 1.8 but on the C6 SoC. All subsystems (display, touch, BOOT + PWR buttons, battery, BLE) verified on hardware.
 - `boards/waveshare_amoled_206/` — Waveshare ESP32-S3-Touch-AMOLED-2.06 (CO5300, 410×502 watch form factor, FT3168 touch, no IO expander, 32 MB flash, PCF85063 RTC, ES8311 codec). Build env: `waveshare_amoled_206`. Display, touch, battery, IMU init, and BLE verified on hardware; the ES8311 chime path is not wired up (`sound.cpp` no-ops).
 - `boards/waveshare_lcd_154/` — Waveshare ESP32-S3-Touch-LCD-1.54 (ST7789, 240×240 square, CST816T touch @ 0x15). Build env: `waveshare_lcd_154`. **The first non-AMOLED port**: a plain 4-wire SPI TFT, not QSPI, and the panel has no brightness command — backlight is LEDC PWM on `LCD_BL`. **No PMU**: battery is an ADC divider on GPIO1 and `BAT_EN` (GPIO2) is a power-hold line that must be driven HIGH early in `board_init()` or the board browns out on battery. Three buttons (BOOT + GPIO5 + a PWR-role GPIO4); ES8311 chime wired up; QMI8658 populated but unused (fixed orientation, no rotation).
+- `boards/waveshare_lcd_147/` — Waveshare ESP32-S3-Touch-LCD-1.47 (JD9853, 172×320 panel driven as a 320×172 landscape canvas, AXS5106L touch @ 0x63). Build env: `waveshare_lcd_147`. **The first landscape port**: `compute_layout()` puts the two usage panels side by side on screens too short to stack them. A plain 4-wire SPI TFT with no brightness command — backlight is LEDC PWM on `LCD_BL`. **No PMU**: battery is a 3.0× ADC divider on GPIO12 and there is no power-hold latch to assert at boot. The kit ships only BOOT and RESET, so BOOT takes the PWR role — `BoardCaps.button_count` is 0 and the HID Space / Shift+Tab paths never fire. No IMU or audio populated. Display, touch, battery ADC and BLE verified on hardware.
 
 **C6 ports have no PSRAM** — shared code gates on `BOARD_HAS_PSRAM` (absent on C6) to use `MALLOC_CAP_INTERNAL` for LVGL/splash buffers, and the `screenshot` serial command is disabled (`LV_USE_SNAPSHOT=0`), so UI changes on a C6 board must be eyeballed on hardware, not auto-captured.
 
@@ -62,6 +63,38 @@ ESP32-C6 sibling of the S3 1.8: same 368×448 SH8601 panel + FocalTech touch, di
 - Buttons: GPIO 0 (BOOT → Space/voice-mode), AXP PKEY (PWR → cycle screens; hold-to-pair). **No third button**.
 - Flash: 32 MB. Uses `default_32MB.csv` partition table.
 
+### LCD-1.47 (landscape strip) — `waveshare_lcd_147`
+Non-AMOLED kit: a 172×320 **JD9853** IPS panel on plain 4-wire SPI, run rotated so
+the UI gets a **320×172 landscape** canvas (the only landscape port). Pin map taken
+from the official schematic, not the wiki — Waveshare's own ESP-IDF BSP header has
+TP_RST/TP_INT swapped relative to the board.
+- Display: JD9853 via SPI (CS=21, SCLK=38, MOSI=39, DC=45, RST=40, BL=46). Driven by
+  Arduino_GFX's `Arduino_ST7789` (the JD9853 shares the ST7789 command set for
+  CASET/RASET/RAMWR/MADCTL) **plus the vendor register sequence** in
+  `jd9853_reg_init()`, pushed after `gfx->begin()`. Without that sequence the panel
+  stays dark. Constructed portrait (172×320) with `col_offset1 = 34` — the visible
+  area starts at column 34 of the controller's 240-wide GRAM — then `setRotation(1)`;
+  `Arduino_TFT::setRotation` maps that offset onto the correct axis. `ips=false`
+  because the vendor sequence issues its own `INVON` (0x21).
+- Brightness: LEDC PWM on the backlight GPIO (no panel brightness command), like the 1.54.
+- Touch: **AXS5106L** @ I2C 0x63 (SDA=42, SCL=41, INT=48, RST=47), vendored inline
+  reader — 14-byte burst from reg 0x01, finger count in byte 1. Needs a long reset
+  pulse (200 ms low / 300 ms settle). Landscape maps raw portrait coords by swapping
+  axes with no mirroring.
+- Battery: VBAT → 3.0× divider → GPIO12 (**ADC2**_CH1). No PMU, so charging/VBUS state
+  is unknowable and reports false. ADC2 is only contended by Wi-Fi, which this
+  firmware never starts.
+- Buttons: **BOOT (GPIO 0) is the only readable key** and it takes the PWR role
+  (screens / brightness / hold-3s-release pairing) — without it the device could never
+  be paired. So `BoardCaps.button_count == 0` and the HID Space / Shift+Tab paths never
+  fire on this board. Screen switching also works by tapping the touchscreen.
+- **No hold-to-power-off** (unlike the 1.54): there is no power-hold latch to drop, and
+  GPIO 0 is the S3's boot strapping pin — an ext0 LOW-level wake would sample it while
+  still held and drop the chip into USB download mode.
+- No IO expander, no IMU, no codec/buzzer. 16 MB flash + 8 MB octal PSRAM (ESP32-S3R8).
+- UI: `compute_layout()` has a dedicated landscape branch (`width > height && height < 200`)
+  that puts the two usage panels **side by side** instead of stacked.
+
 ## Architecture
 
 ```text
@@ -80,9 +113,10 @@ firmware/src/
     waveshare_amoled_18_c6/ — C6: SH8601 + FT3168 + AXP PKEY + TCA9554 (gates power), no PSRAM
     waveshare_amoled_206/   — CO5300 + FT3168 + AXP PKEY, no IO expander, 32 MB, no rotation
     waveshare_lcd_154/      — ST7789 SPI TFT + CST816T + ADC battery (no PMU), PWM backlight
+    waveshare_lcd_147/      — JD9853 (4-wire SPI, landscape 320x172) + AXS5106L + battery ADC, BOOT-as-PWR
     template/               — copy this to bootstrap a new port
   main.cpp                  — setup() + loop(): HAL calls only, zero #ifdef BOARD_*
-  ui.{h,cpp}                — 3-screen UI (splash, usage, bluetooth). compute_layout() picks fonts/positions from board_caps() (responsive — current breakpoint: H >= 460 → large, else compact)
+  ui.{h,cpp}                — 3-screen UI (splash, usage, bluetooth). compute_layout() picks fonts/positions from board_caps() (responsive — landscape strip (W > H && H < 200) → side-by-side panels; H >= 460 → large; H >= 300 → compact; else small)
   splash.{h,cpp}            — 20×20 pixel-art engine. CELL = min(W,H)/20, centered.
   ble.{h,cpp}               — NimBLE peripheral: custom data service + HID keyboard
   data.h                    — UsageData struct
@@ -108,6 +142,7 @@ pio run -d firmware -e waveshare_amoled_216_c6                                  
 pio run -d firmware -e waveshare_amoled_18_c6                                   # build 1.8 (C6)
 pio run -d firmware -e waveshare_amoled_206                                     # build 2.06 (S3, watch)
 pio run -d firmware -e waveshare_lcd_154                                        # build 1.54 (S3, SPI TFT)
+pio run -d firmware -e waveshare_lcd_147                                        # build 1.47 (S3, landscape SPI TFT)
 pio run -d firmware -e waveshare_amoled_18 -t upload --upload-port /dev/cu.usbmodem101   # flash 1.8 on macOS
 pio run -d firmware -e waveshare_amoled_216 -t upload --upload-port /dev/ttyACM0         # flash 2.16 on Linux
 # C6 boards: same native USB-JTAG flashing; flag a chip mismatch ("This chip is ESP32-C6,

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Boards supported out of the box:
 - [Waveshare ESP32-C6-Touch-AMOLED-1.8](https://www.waveshare.com/esp32-c6-touch-amoled-1.8.htm?&aff_id=149786)
 - [Waveshare ESP32-S3-Touch-AMOLED-2.06](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm?&aff_id=149786)
 - [Waveshare ESP32-S3-Touch-LCD-1.54](https://www.waveshare.com/esp32-s3-lcd-1.54.htm?sku=33869) (240x240 SPI TFT, not AMOLED)
+- [Waveshare ESP32-S3-Touch-LCD-1.47](https://www.waveshare.com/esp32-s3-touch-lcd-1.47.htm) (172x320 SPI TFT run landscape as 320x172, not AMOLED)
 
 > Please check if a pull request exists for your alternative hardware port before opening a new one, providing QA feedback and testing on the same hardware is more valuable than duplicate pull requests.
 

--- a/docs/porting/adding-a-board.md
+++ b/docs/porting/adding-a-board.md
@@ -13,9 +13,13 @@ At minimum:
 - An **ESP32-S3** (other ESP32 family members may work; this is what the
   upstream firmware is tested on). OPI PSRAM is **required** — partial
   flush buffers and the splash canvas are allocated from PSRAM.
-- A QSPI **AMOLED panel** with a driver supported by
-  [GFX Library for Arduino](https://github.com/moononournation/Arduino_GFX)
-  (CO5300, SH8601, NV3041A, etc.). Other interfaces aren't supported yet.
+- A **panel** with a driver supported by
+  [GFX Library for Arduino](https://github.com/moononournation/Arduino_GFX).
+  QSPI AMOLEDs (CO5300, SH8601, NV3041A, …) and plain 4-wire SPI TFTs
+  (JD9853 on the LCD-1.47) are both in tree; the HAL only needs
+  `display_hal_draw_bitmap`, so the bus type never leaks into shared code. Panels that can't rotate in hardware can still be run
+  rotated — the LCD-1.47 port drives its 172×320 panel as a 320×172
+  landscape canvas via `setRotation()`.
 - A **touch controller** over I2C. The HAL just needs init + read; you
   can use any driver you can compile.
 - A **primary button** (typically the BOOT/GPIO 0 push button).
@@ -89,7 +93,9 @@ Optional:
    (see [hal-contract.md](hal-contract.md) for breakpoint details);
    most ports will look acceptable out of the box. If your screen size
    doesn't match an existing breakpoint, you may want to add one to
-   `compute_layout()` in `firmware/src/ui.cpp`.
+   `compute_layout()` in `firmware/src/ui.cpp` — that's where the
+   landscape branch lives too (`usage_panels_row` puts the two usage
+   panels side by side on screens too short to stack them).
 
 ## Common pitfalls
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -121,6 +121,78 @@ lib_deps =
     h2zero/NimBLE-Arduino@^2.1.1
 
 
+[env:waveshare_lcd_147]
+; Waveshare ESP32-S3-Touch-LCD-1.47 — 172x320 JD9853 IPS over plain 4-wire SPI,
+; driven rotated as a 320x172 LANDSCAPE canvas (the first landscape port).
+; AXS5106L touch, battery ADC (no PMU), no IMU, no audio, single BOOT key that
+; serves as the PWR button. Module is ESP32-S3R8: 16 MB quad flash + 8 MB
+; octal PSRAM, hence qio_opi and the 16 MB partition layout.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.arduino.memory_type = qio_opi
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_build.partitions = default_16MB.csv
+upload_speed = 921600
+monitor_speed = 115200
+
+build_src_filter =
+    +<*>
+    -<boards/>
+    +<boards/waveshare_lcd_147/>
+
+build_flags =
+    -DBOARD_LCD_147
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    ; NimBLE config — peripheral, 2 simultaneous connections so the OS can
+    ; hold the HID link while the daemon holds its own connection for the
+    ; custom data service. (This board has no HID button, but the HID
+    ; service is still advertised by the shared BLE code.)
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER=1
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=1
+    -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=0
+    -DCONFIG_BT_NIMBLE_ROLE_OBSERVER=0
+    -DCONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
+    ; Bond slots deliberately exceed MAX_OWNERS (3, in ble.cpp): the firmware
+    ; evicts the stalest owner itself. Sized equal, NimBLE's own round-robin
+    ; would recycle a bond slot first and silently unpair a still-listed owner.
+    -DCONFIG_BT_NIMBLE_MAX_BONDS=5
+    ; Security level 3 = "encrypted, authenticated". Makes the stack itself
+    ; reject a pairing request whose authreq lacks the MITM bit, instead of
+    ; letting it bond unauthenticated and relying purely on the app-level
+    ; isAuthenticated() gate in ble.cpp.
+    -DCONFIG_BT_NIMBLE_SM_LVL=3
+    ; Peripheral Preferred Connection Parameters — see the waveshare_amoled_216
+    ; env for the full rationale (Windows supervision-timeout churn fix).
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MIN_CONN_INTERVAL=12
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_MAX_CONN_INTERVAL=24
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SLAVE_LATENCY=0
+    -DMYNEWT_VAL_BLE_SVC_GAP_PPCP_SUPERVISION_TMO=600
+    ; LVGL config via build flags
+    -DLV_CONF_SKIP
+    -DLV_COLOR_DEPTH=16
+    -DLV_USE_LOG=0
+    -DLV_USE_BAR=1
+    -DLV_USE_LABEL=1
+    -DLV_USE_ARC=1
+    -DLV_USE_BTN=1
+    -DLV_USE_LINE=1
+    -DLV_USE_OBJ=1
+    -DLV_USE_IMG=1
+    -DLV_USE_IMAGE=1
+    -DLV_USE_ANIMIMG=0
+    -DLV_TICK_CUSTOM=1
+    -DLV_USE_SNAPSHOT=1
+
+lib_deps =
+    moononournation/GFX Library for Arduino@^1.6.4
+    lvgl/lvgl@^9.2.0
+    bblanchon/ArduinoJson@^7.0.0
+    h2zero/NimBLE-Arduino@^2.1.1
+
+
 [env:waveshare_amoled_18]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
 board = esp32-s3-devkitc-1

--- a/firmware/src/boards/waveshare_lcd_147/board.h
+++ b/firmware/src/boards/waveshare_lcd_147/board.h
@@ -61,7 +61,7 @@
 // have simply don't exist here; input.cpp reports no buttons and
 // BoardCaps.button_count is 0. Screen switching is also available by tapping
 // the touchscreen.
-#define BTN_PWR_GPIO         0     // BOOT — PWR role; hold 8s = power off (see power.cpp)
+#define BTN_PWR_GPIO         0     // BOOT — PWR role (screens/brightness; hold ~3s + release to pair)
 
 // ---- Capability flags ----
 #define BOARD_HAS_SECONDARY_BUTTON 0

--- a/firmware/src/boards/waveshare_lcd_147/board.h
+++ b/firmware/src/boards/waveshare_lcd_147/board.h
@@ -1,0 +1,72 @@
+#pragma once
+
+// Waveshare ESP32-S3-Touch-LCD-1.47 — 1.47" 172x320 IPS TFT kit, driven here
+// in LANDSCAPE (320x172). JD9853 panel over plain 4-wire SPI (the JD9853 is
+// register-compatible enough with the ST7789 command set that Arduino_GFX's
+// Arduino_ST7789 drives it once the vendor init sequence has been pushed —
+// that's exactly what Waveshare's own Arduino demo does) + AXS5106L capacitive
+// touch + a plain VBAT divider (no PMU, no IO expander, no codec, no IMU).
+//
+// Pin map verified against the official schematic
+// (files.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.47/ESP32-S3-Touch-LCD-1.47-Schematic.pdf):
+//   IO21 LCD_CS   IO38 LCD_SCL  IO39 LCD_SDA  IO40 LCD_RST  IO45 LCD_DC  IO46 LCD_BL
+//   IO41 TP_SCL   IO42 TP_SDA   IO47 TP_RST   IO48 TP_INT   IO12 BAT_ADC
+// (Waveshare's own ESP-IDF BSP header has TP_RST/TP_INT swapped; the schematic
+// and their Arduino demo agree with the values below.)
+
+#define BOARD_NAME           "Waveshare LCD 1.47"
+
+// ---- Display geometry ----
+// Panel is physically 172x320 portrait; the firmware runs it rotated so the
+// UI gets a 320x172 landscape canvas. LCD_WIDTH/HEIGHT are post-rotation
+// (that's what BoardCaps and the UI layout consume).
+#define LCD_WIDTH            320
+#define LCD_HEIGHT           172
+#define LCD_PANEL_W          172   // native, pre-rotation
+#define LCD_PANEL_H          320
+#define LCD_ROTATION         1     // 1 = landscape (USB-C on the left)
+// The 172-wide active area starts at column 34 of the JD9853's 240-wide GRAM.
+// Arduino_TFT::setRotation maps this offset onto the correct axis per rotation.
+#define LCD_COL_OFFSET       34
+
+// ---- SPI display pins (JD9853, 4-wire SPI) ----
+#define LCD_CS               21
+#define LCD_SCLK             38
+#define LCD_MOSI             39
+#define LCD_DC               45
+#define LCD_RST              40
+#define LCD_BL               46    // backlight, LEDC PWM (TFT has no brightness cmd)
+
+// ---- I2C bus (touch only — nothing else is populated on this kit) ----
+#define IIC_SDA              42
+#define IIC_SCL              41
+
+// ---- Touch (AXS5106L, minimal inline I2C reader) ----
+#define TP_INT               48
+#define TP_RST               47
+#define AXS5106L_ADDR        0x63
+
+// ---- Battery (ADC divider, no I2C-readable PMU) ----
+// VBAT → 3.0x divider → GPIO12 (ADC2_CH1). There is NO power-hold latch on
+// this board (unlike the LCD-1.54's BAT_EN), so nothing to assert at boot.
+#define BAT_ADC_PIN          12
+#define BAT_VOLT_DIVIDER     3.0f
+
+// ---- Buttons ----
+// The kit ships exactly two keys: BOOT (GPIO 0) and RESET (tied to EN, not
+// readable). So there is only ONE usable user button, and it is given the
+// PWR role — screens / brightness / the hold-3s-release pairing gesture —
+// because without it the device could never be paired at all. The HID
+// push-to-talk (Space) and mode-toggle (Shift+Tab) buttons the bigger boards
+// have simply don't exist here; input.cpp reports no buttons and
+// BoardCaps.button_count is 0. Screen switching is also available by tapping
+// the touchscreen.
+#define BTN_PWR_GPIO         0     // BOOT — PWR role; hold 8s = power off (see power.cpp)
+
+// ---- Capability flags ----
+#define BOARD_HAS_SECONDARY_BUTTON 0
+#define BOARD_HAS_ROTATION         0    // panel is rotated once at init, not at runtime
+#define BOARD_HAS_IMU              0    // no IMU populated
+#define BOARD_HAS_BATTERY          1
+#define BOARD_HAS_IO_EXPANDER      0
+#define BOARD_HAS_SOUND            0    // no codec, no buzzer

--- a/firmware/src/boards/waveshare_lcd_147/board_init.cpp
+++ b/firmware/src/boards/waveshare_lcd_147/board_init.cpp
@@ -1,0 +1,11 @@
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// Nothing gates the panel on this kit: no IO expander, no power-hold latch,
+// and the LCD reset is a direct GPIO that Arduino_ST7789 pulses itself. So
+// board_init() only has to bring up the I2C bus the touch controller lives on
+// (touch reset is pulsed in touch_hal_init()).
+extern "C" void board_init(void) {
+    Wire.begin(IIC_SDA, IIC_SCL);
+}

--- a/firmware/src/boards/waveshare_lcd_147/caps.cpp
+++ b/firmware/src/boards/waveshare_lcd_147/caps.cpp
@@ -1,0 +1,18 @@
+#include "../../hal/board_caps.h"
+#include "board.h"
+
+static const BoardCaps caps = {
+    .name = BOARD_NAME,
+    .width = LCD_WIDTH,
+    .height = LCD_HEIGHT,
+    // Zero HID buttons: the kit's only usable key (BOOT) is given the PWR
+    // role in power.cpp — see the comment in board.h. Shared code handles a
+    // board with no primary button (the HID Space / Shift+Tab paths simply
+    // never fire).
+    .button_count = 0,
+    .has_rotation = (bool)BOARD_HAS_ROTATION,
+    .has_battery  = (bool)BOARD_HAS_BATTERY,
+    .has_imu      = (bool)BOARD_HAS_IMU,
+};
+
+const BoardCaps& board_caps(void) { return caps; }

--- a/firmware/src/boards/waveshare_lcd_147/display.cpp
+++ b/firmware/src/boards/waveshare_lcd_147/display.cpp
@@ -1,0 +1,165 @@
+#include "../../hal/display_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+// JD9853 172x320 IPS over plain 4-wire SPI, run rotated to a 320x172 landscape
+// canvas.
+//
+// The JD9853 speaks the ST7789's command set for everything the framebuffer
+// path touches (CASET/RASET/RAMWR/MADCTL/INVON), so Arduino_GFX's ST7789
+// driver drives it directly — but only after the vendor power/gamma init
+// sequence below has been pushed. That is exactly the arrangement in
+// Waveshare's own Arduino demo, and jd9853_reg_init() is that demo's
+// sequence verbatim. Without it the panel stays dark or shows a washed-out
+// image, because Arduino_ST7789::begin() only sends the ST7789's own init.
+//
+// The panel has no brightness command, so brightness is an LEDC PWM duty on
+// the backlight GPIO — same approach as the LCD-1.54 port.
+
+static Arduino_DataBus* bus = nullptr;
+static Arduino_ST7789*  gfx = nullptr;
+
+// Vendor init sequence for the JD9853, lifted from Waveshare's
+// ESP32-S3-Touch-LCD-1.47 Arduino demo (lcd_reg_init()). Pushed after
+// gfx->begin() so the ST7789 driver's own init can't clobber it.
+static void jd9853_reg_init(void) {
+    static const uint8_t init_operations[] = {
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, 0x11,  // 2: Out of sleep mode, no args, w/delay
+    END_WRITE,
+    DELAY, 120,
+
+    BEGIN_WRITE,
+    WRITE_C8_D16, 0xDF, 0x98, 0x53,
+    WRITE_C8_D8, 0xB2, 0x23,
+
+    WRITE_COMMAND_8, 0xB7,
+    WRITE_BYTES, 4,
+    0x00, 0x47, 0x00, 0x6F,
+
+    WRITE_COMMAND_8, 0xBB,
+    WRITE_BYTES, 6,
+    0x1C, 0x1A, 0x55, 0x73, 0x63, 0xF0,
+
+    WRITE_C8_D16, 0xC0, 0x44, 0xA4,
+    WRITE_C8_D8, 0xC1, 0x16,
+
+    WRITE_COMMAND_8, 0xC3,
+    WRITE_BYTES, 8,
+    0x7D, 0x07, 0x14, 0x06, 0xCF, 0x71, 0x72, 0x77,
+
+    WRITE_COMMAND_8, 0xC4,
+    WRITE_BYTES, 12,
+    0x00, 0x00, 0xA0, 0x79, 0x0B, 0x0A, 0x16, 0x79, 0x0B, 0x0A, 0x16, 0x82,
+
+    WRITE_COMMAND_8, 0xC8,
+    WRITE_BYTES, 32,
+    0x3F, 0x32, 0x29, 0x29, 0x27, 0x2B, 0x27, 0x28, 0x28, 0x26, 0x25, 0x17, 0x12, 0x0D, 0x04, 0x00, 0x3F, 0x32, 0x29, 0x29, 0x27, 0x2B, 0x27, 0x28, 0x28, 0x26, 0x25, 0x17, 0x12, 0x0D, 0x04, 0x00,
+
+    WRITE_COMMAND_8, 0xD0,
+    WRITE_BYTES, 5,
+    0x04, 0x06, 0x6B, 0x0F, 0x00,
+
+    WRITE_C8_D16, 0xD7, 0x00, 0x30,
+    WRITE_C8_D8, 0xE6, 0x14,
+    WRITE_C8_D8, 0xDE, 0x01,
+
+    WRITE_COMMAND_8, 0xB7,
+    WRITE_BYTES, 5,
+    0x03, 0x13, 0xEF, 0x35, 0x35,
+
+    WRITE_COMMAND_8, 0xC1,
+    WRITE_BYTES, 3,
+    0x14, 0x15, 0xC0,
+
+    WRITE_C8_D16, 0xC2, 0x06, 0x3A,
+    WRITE_C8_D16, 0xC4, 0x72, 0x12,
+    WRITE_C8_D8, 0xBE, 0x00,
+    WRITE_C8_D8, 0xDE, 0x02,
+
+    WRITE_COMMAND_8, 0xE5,
+    WRITE_BYTES, 3,
+    0x00, 0x02, 0x00,
+
+    WRITE_COMMAND_8, 0xE5,
+    WRITE_BYTES, 3,
+    0x01, 0x02, 0x00,
+
+    WRITE_C8_D8, 0xDE, 0x00,
+    WRITE_C8_D8, 0x35, 0x00,
+    WRITE_C8_D8, 0x3A, 0x05,
+
+    WRITE_COMMAND_8, 0x2A,
+    WRITE_BYTES, 4,
+    0x00, 0x22, 0x00, 0xCD,
+
+    WRITE_COMMAND_8, 0x2B,
+    WRITE_BYTES, 4,
+    0x00, 0x00, 0x01, 0x3F,
+
+    WRITE_C8_D8, 0xDE, 0x02,
+
+    WRITE_COMMAND_8, 0xE5,
+    WRITE_BYTES, 3,
+    0x00, 0x02, 0x00,
+
+    WRITE_C8_D8, 0xDE, 0x00,
+    WRITE_C8_D8, 0x36, 0x00,
+    WRITE_COMMAND_8, 0x21,
+    END_WRITE,
+
+    DELAY, 10,
+
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, 0x29,  // 5: Main screen turn on, no args, w/delay
+    END_WRITE
+
+    };
+    bus->batchOperation(init_operations, sizeof(init_operations));
+}
+
+void display_hal_init(void) {
+    bus = new Arduino_ESP32SPI(LCD_DC, LCD_CS, LCD_SCLK, LCD_MOSI,
+                               GFX_NOT_DEFINED /* no MISO */);
+    // Constructed in the panel's native portrait geometry with the GRAM
+    // column offset; setRotation() below swaps the axes (and maps the offset
+    // onto the right one) to give the UI a 320x172 landscape canvas.
+    // ips=false matches the vendor sequence, which turns inversion on itself
+    // (0x21 at the tail of jd9853_reg_init) — passing true here would send a
+    // second INVON and cancel it back out.
+    gfx = new Arduino_ST7789(bus, LCD_RST, 0 /* rotation */, false /* ips */,
+                             LCD_PANEL_W, LCD_PANEL_H,
+                             LCD_COL_OFFSET, 0, LCD_COL_OFFSET, 0);
+}
+
+void display_hal_begin(void) {
+    gfx->begin(40000000);   // 40 MHz write clock
+    jd9853_reg_init();
+    gfx->setRotation(LCD_ROTATION);
+    gfx->fillScreen(0x0000);
+    ledcAttach(LCD_BL, 5000 /* Hz */, 8 /* bits */);
+    ledcWrite(LCD_BL, 200);
+}
+
+void display_hal_set_brightness(uint8_t level) {
+    ledcWrite(LCD_BL, level);
+}
+
+void display_hal_fill_screen(uint16_t color) {
+    if (gfx) gfx->fillScreen(color);
+}
+
+void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
+                             const uint16_t* pixels) {
+    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+}
+
+void display_hal_tick(void) {
+    // No runtime rotation on this board.
+}
+
+// SPI TFTs have no flush-region alignment requirement.
+void display_hal_round_area(int32_t* x1, int32_t* y1, int32_t* x2, int32_t* y2) {
+    (void)x1; (void)y1; (void)x2; (void)y2;
+}

--- a/firmware/src/boards/waveshare_lcd_147/imu.cpp
+++ b/firmware/src/boards/waveshare_lcd_147/imu.cpp
@@ -1,0 +1,8 @@
+#include "../../hal/imu_hal.h"
+
+// No IMU on this kit (the schematic populates none) and the panel orientation
+// is fixed at boot, so rotation is off and these are pure stubs.
+
+void    imu_hal_init(void) {}
+void    imu_hal_tick(void) {}
+uint8_t imu_hal_rotation_quadrant(void) { return 0; }

--- a/firmware/src/boards/waveshare_lcd_147/input.cpp
+++ b/firmware/src/boards/waveshare_lcd_147/input.cpp
@@ -1,0 +1,15 @@
+#include "../../hal/input_hal.h"
+#include "board.h"
+
+// This kit has exactly one readable key (BOOT / GPIO 0) and power.cpp owns it
+// as the PWR button — without it there is no way to open the BLE pairing
+// window, which would make the device unusable. So there is no HID
+// push-to-talk or mode-toggle button here: both report "not held" forever and
+// BoardCaps.button_count is 0.
+
+void input_hal_init(void) {}
+
+bool input_hal_is_held(InputButton btn) {
+    (void)btn;
+    return false;
+}

--- a/firmware/src/boards/waveshare_lcd_147/power.cpp
+++ b/firmware/src/boards/waveshare_lcd_147/power.cpp
@@ -1,0 +1,106 @@
+#include "../../hal/power_hal.h"
+#include "board.h"
+#include <Arduino.h>
+
+// No PMU on this kit — the charger is a standalone part that exposes nothing
+// over I2C. Battery percentage comes from the VBAT divider on BAT_ADC_PIN
+// (GPIO12 = ADC2_CH1; ADC2 is only contended by Wi-Fi, which this firmware
+// never starts, so BLE-only operation reads it fine). Charging / VBUS state is
+// unknowable, so both report false.
+//
+// The PWR-role button is the BOOT key (GPIO 0), a plain active-LOW GPIO — the
+// kit's only readable button, see board.h. Same software edge synthesis as the
+// LCD-1.54 port:
+//   short    — fired on release if the hold was shorter than PWR_LONG_MS
+//   long     — fired once when a hold crosses PWR_LONG_MS
+//   release  — fired on every release edge
+// which keeps the hold-to-pair gesture in main.cpp board-agnostic.
+//
+// Unlike the LCD-1.54 there is deliberately NO hold-to-power-off: this board
+// has no power-hold latch to drop (so "off" could only ever mean deep sleep),
+// and GPIO 0 is the ESP32-S3's boot strapping pin — waking from deep sleep on
+// an ext0 LOW level means the ROM samples GPIO 0 while the button is still
+// held and drops the chip into USB download mode, which looks like a brick to
+// the user. Holding past the pairing window simply does nothing here.
+
+#define BATTERY_POLL_MS  2000
+#define PWR_POLL_MS      50
+#define PWR_LONG_MS      1500
+
+static int      cached_pct        = -1;
+static bool     pwr_pressed_flag  = false;
+static bool     pwr_long_flag     = false;
+static bool     pwr_released_flag = false;
+static bool     last_pwr_state    = false;
+static uint32_t pwr_press_started_ms = 0;
+static bool     pwr_long_fired    = false;
+static uint32_t last_battery_ms   = 0;
+static uint32_t last_pwr_ms       = 0;
+
+static void sample_battery(void) {
+    // Average a few reads — the divider is high-impedance and single ADC
+    // samples on the S3 are noisy.
+    uint32_t mv = 0;
+    for (int i = 0; i < 4; i++) mv += analogReadMilliVolts(BAT_ADC_PIN);
+    float vbat = (mv / 4) * BAT_VOLT_DIVIDER / 1000.0f;
+
+    if (vbat < 3.0f) {          // divider floating — no battery connected
+        cached_pct = -1;
+        return;
+    }
+    // Linear 3.3 V → 0%, 4.2 V → 100%. Crude but serviceable for a
+    // four-state indicator icon.
+    int pct = (int)((vbat - 3.3f) * (100.0f / 0.9f) + 0.5f);
+    cached_pct = pct < 0 ? 0 : pct > 100 ? 100 : pct;
+}
+
+void power_hal_init(void) {
+    pinMode(BTN_PWR_GPIO, INPUT_PULLUP);
+    analogReadResolution(12);
+    sample_battery();
+}
+
+void power_hal_tick(void) {
+    uint32_t now = millis();
+
+    if (now - last_battery_ms >= BATTERY_POLL_MS) {
+        last_battery_ms = now;
+        sample_battery();
+    }
+    if (now - last_pwr_ms >= PWR_POLL_MS) {
+        last_pwr_ms = now;
+        bool pwr_now = (digitalRead(BTN_PWR_GPIO) == LOW);   // active LOW
+        if (pwr_now && !last_pwr_state) {            // press edge — hold begins
+            pwr_press_started_ms = now;
+            pwr_long_fired = false;
+        } else if (pwr_now && last_pwr_state) {      // held
+            if (!pwr_long_fired && (now - pwr_press_started_ms >= PWR_LONG_MS)) {
+                pwr_long_flag  = true;
+                pwr_long_fired = true;
+            }
+        } else if (!pwr_now && last_pwr_state) {     // release edge
+            pwr_released_flag = true;
+            if (!pwr_long_fired) pwr_pressed_flag = true;  // short press
+        }
+        last_pwr_state = pwr_now;
+    }
+}
+
+int  power_hal_battery_pct(void) { return cached_pct; }
+bool power_hal_is_charging(void) { return false; }
+bool power_hal_is_vbus_in(void)  { return false; }
+
+bool power_hal_pwr_pressed(void) {
+    if (pwr_pressed_flag) { pwr_pressed_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_long_pressed(void) {
+    if (pwr_long_flag) { pwr_long_flag = false; return true; }
+    return false;
+}
+
+bool power_hal_pwr_released(void) {
+    if (pwr_released_flag) { pwr_released_flag = false; return true; }
+    return false;
+}

--- a/firmware/src/boards/waveshare_lcd_147/sound.cpp
+++ b/firmware/src/boards/waveshare_lcd_147/sound.cpp
@@ -1,0 +1,10 @@
+#include "../../hal/sound_hal.h"
+
+// LCD-1.47: no codec, no amplifier, no buzzer — the kit has no audio path at
+// all. The session-reset chime is therefore a no-op here (the shared engine
+// lives in ../../chime.cpp and is wired up by the boards that do have a
+// speaker, behind BOARD_HAS_SOUND).
+
+void sound_hal_init(void) {}
+void sound_hal_tick(void) {}
+void sound_hal_play_reset(void) {}

--- a/firmware/src/boards/waveshare_lcd_147/touch.cpp
+++ b/firmware/src/boards/waveshare_lcd_147/touch.cpp
@@ -1,0 +1,110 @@
+#include "../../hal/touch_hal.h"
+#include "board.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+// Minimal AXS5106L reader, vendored (like the FocalTech/CST readers on the
+// other ports) to keep the dependency tree copyleft-free and avoid pulling in
+// Waveshare's esp_lcd_touch_axs5106l shim.
+//
+// Protocol (from Waveshare's driver for this exact kit):
+//   reg 0x01: 14-byte burst — data[1] = finger count, then 6 bytes per finger:
+//             data[2] X high nibble, data[3] X low, data[4] Y high nibble,
+//             data[5] Y low, (+2 bytes we ignore)
+//   reg 0x08: chip id (3 bytes), used only as a presence probe
+// The controller raises INT (falling) once per report while a finger is down.
+//
+// Coordinates come out in the panel's native 172x320 portrait frame. The UI
+// runs landscape (LCD_ROTATION 1), so the axes are swapped with no mirroring
+// — the mapping Waveshare's own driver applies for rotation 1.
+
+#define AXS5106L_ID_REG         0x08
+#define AXS5106L_TOUCH_REG      0x01
+
+static volatile bool     touch_data_ready = false;
+static volatile bool     touch_pressed = false;
+static volatile uint16_t touch_x = 0;
+static volatile uint16_t touch_y = 0;
+
+static void IRAM_ATTR touch_isr(void) {
+    touch_data_ready = true;
+}
+
+static void touch_read_into_shared_state(void) {
+    Wire.beginTransmission(AXS5106L_ADDR);
+    Wire.write(AXS5106L_TOUCH_REG);
+    if (Wire.endTransmission() != 0) { touch_pressed = false; return; }
+
+    uint8_t data[14] = {0};
+    if (Wire.requestFrom((uint8_t)AXS5106L_ADDR, (uint8_t)sizeof(data)) != sizeof(data)) {
+        touch_pressed = false;
+        return;
+    }
+    Wire.readBytes(data, sizeof(data));
+
+    uint8_t fingers = data[1];
+    if (fingers == 0 || fingers > 5) {
+        touch_pressed = false;
+        return;
+    }
+
+    uint16_t raw_x = ((uint16_t)(data[2] & 0x0F) << 8) | data[3];   // 0..171
+    uint16_t raw_y = ((uint16_t)(data[4] & 0x0F) << 8) | data[5];   // 0..319
+
+#if LCD_ROTATION == 1
+    // 90° — swap axes, no mirror.
+    touch_x = raw_y;
+    touch_y = raw_x;
+#elif LCD_ROTATION == 3
+    // 270° — swap axes and mirror both.
+    touch_x = (LCD_PANEL_H - 1) - raw_y;
+    touch_y = (LCD_PANEL_W - 1) - raw_x;
+#else
+    // 0° portrait — mirror X only (the controller's native reading is flipped
+    // against the panel on this kit).
+    touch_x = (LCD_PANEL_W - 1) - raw_x;
+    touch_y = raw_y;
+#endif
+    touch_pressed = true;
+}
+
+void touch_hal_init(void) {
+    // Hardware reset. The AXS5106L needs a long, clean pulse before it
+    // answers on I2C — Waveshare's driver uses 200 ms low / 300 ms settle
+    // and shorter pulses were not reliable.
+    pinMode(TP_RST, OUTPUT);
+    digitalWrite(TP_RST, LOW);
+    delay(200);
+    digitalWrite(TP_RST, HIGH);
+    delay(300);
+
+    uint8_t id[3] = {0};
+    Wire.beginTransmission(AXS5106L_ADDR);
+    Wire.write(AXS5106L_ID_REG);
+    if (Wire.endTransmission() == 0 &&
+        Wire.requestFrom((uint8_t)AXS5106L_ADDR, (uint8_t)3) == 3) {
+        Wire.readBytes(id, 3);
+        Serial.printf("Touch AXS5106L ID=%02X %02X %02X (addr 0x%02X)\n",
+                      id[0], id[1], id[2], AXS5106L_ADDR);
+    } else {
+        Serial.printf("Touch ID read failed (addr 0x%02X)\n", AXS5106L_ADDR);
+    }
+
+    pinMode(TP_INT, INPUT_PULLUP);
+    attachInterrupt(TP_INT, touch_isr, FALLING);
+    Serial.println("Touch attached on INT pin");
+}
+
+void touch_hal_read(uint16_t* x, uint16_t* y, bool* pressed) {
+    if (touch_data_ready) {
+        touch_data_ready = false;
+        touch_read_into_shared_state();
+    } else if (touch_pressed) {
+        // The finger-up report can land between polls; re-read while we still
+        // believe a finger is down so a stuck "pressed" state clears.
+        touch_read_into_shared_state();
+    }
+    *x = touch_x;
+    *y = touch_y;
+    *pressed = touch_pressed;
+}

--- a/firmware/src/ui.cpp
+++ b/firmware/src/ui.cpp
@@ -32,7 +32,9 @@ struct Layout {
 
     // Usage screen
     int16_t usage_panel_h;
-    int16_t usage_panel_gap;
+    int16_t usage_panel_w;      // width of one usage panel
+    bool    usage_panels_row;   // true = panels side by side (landscape strips)
+    int16_t usage_panel_gap;    // between the two panels, on whichever axis
     int16_t usage_bar_y;
     int16_t usage_reset_y;
     int16_t bar_h;
@@ -101,8 +103,50 @@ static void compute_layout(const BoardCaps& c) {
     L.pair_y2 = 120;
     L.pair_y3 = 160;
     L.idle_px = 160;
+    L.usage_panels_row = false;   // stacked; the landscape branch flips this
 
-    if (c.height >= 460) {
+    if (c.width > c.height && c.height < 200) {
+        // Landscape strip — tuned for 320x172 (LCD-1.47). Too short to stack
+        // the two usage panels, so they sit side by side; everything else
+        // follows the small layout's scale.
+        L.margin = 10;
+        L.title_y = 4;
+        L.content_y = 46;
+        L.usage_panels_row = true;
+        L.usage_panel_h = 100;
+        L.usage_panel_gap = 10;
+        L.usage_bar_y = 40;
+        L.usage_reset_y = 54;
+        L.bar_h = 12;
+        L.panel_pad_x = 10;
+        L.panel_pad_y = 6;
+        L.pill_pad_x = 8;
+        L.pill_pad_y = 2;
+        L.title_font   = &font_tiempos_34;
+        L.pct_font     = &font_styrene_24;
+        L.ent_pct_font = &font_tiempos_34;
+        L.pill_font    = &font_styrene_12;
+        L.reset_font   = &font_styrene_12;
+        L.pace_font    = &font_styrene_12;
+        L.anim_font    = &font_mono_18;
+        L.anim_y = -4;
+        L.small_icons = true;
+        L.title_nudge = 8;
+        L.logo_y = 2;
+        L.batt_y = 10;
+        L.batt_w = ICON_BATTERY_SMALL_W;
+        L.pair_y1 = 6;
+        L.pair_y2 = 46;
+        L.pair_y3 = 70;
+        L.idle_px = 80;
+        L.bt_info_panel_h = 80;
+        L.bt_reset_zone_h = 50;
+        L.bt_title_font    = &font_tiempos_34;
+        L.bt_status_font   = &font_styrene_20;
+        L.bt_device_font   = &font_styrene_14;
+        L.bt_credit_1_font = &font_styrene_12;
+        L.bt_credit_2_font = &font_styrene_12;
+    } else if (c.height >= 460) {
         // Large layout — tuned for 480x480 (AMOLED-2.16).
         L.content_y = 100;
         L.usage_panel_h = 150;
@@ -175,6 +219,11 @@ static void compute_layout(const BoardCaps& c) {
     }
 
     L.content_w = L.scr_w - 2 * L.margin;
+    // Side-by-side panels split the content width; stacked ones each take all
+    // of it. Derived here so every branch above only has to set the flag.
+    L.usage_panel_w = L.usage_panels_row
+                        ? (int16_t)((L.content_w - L.usage_panel_gap) / 2)
+                        : L.content_w;
 }
 
 // Anthropic brand palette — design tokens live in theme.h
@@ -387,10 +436,11 @@ static void init_battery_icons(void) {
 
 // ======== Usage Screen ========
 
-static lv_obj_t* make_usage_panel(lv_obj_t* parent, int y, const char* pill_text,
+static lv_obj_t* make_usage_panel(lv_obj_t* parent, int x, int y, int w,
+                                  const char* pill_text,
                                   lv_obj_t** out_pct, lv_obj_t** out_pill,
                                   lv_obj_t** out_bar, lv_obj_t** out_reset) {
-    lv_obj_t* panel = make_panel(parent, L.margin, y, L.content_w, L.usage_panel_h);
+    lv_obj_t* panel = make_panel(parent, x, y, w, L.usage_panel_h);
 
     *out_pct = lv_label_create(panel);
     lv_label_set_text(*out_pct, "---%");
@@ -402,7 +452,7 @@ static lv_obj_t* make_usage_panel(lv_obj_t* parent, int y, const char* pill_text
     lv_obj_align(*out_pill, LV_ALIGN_TOP_RIGHT, 0, 1);
 
     *out_bar = make_bar(panel, 0, L.usage_bar_y,
-                        L.content_w - 2 * L.panel_pad_x, L.bar_h);
+                        w - 2 * L.panel_pad_x, L.bar_h);
 
     *out_reset = lv_label_create(panel);
     lv_label_set_text(*out_reset, "---");
@@ -497,7 +547,8 @@ static void init_usage_screen(lv_obj_t* scr) {
     lv_obj_clear_flag(usage_group, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_flag(usage_group, LV_OBJ_FLAG_EVENT_BUBBLE);
 
-    panel_session = make_usage_panel(usage_group, L.content_y, "Current",
+    panel_session = make_usage_panel(usage_group, L.margin, L.content_y,
+                     L.usage_panel_w, "Current",
                      &lbl_session_pct, &lbl_session_label,
                      &bar_session, &lbl_session_reset);
 
@@ -521,8 +572,16 @@ static void init_usage_screen(lv_obj_t* scr) {
     lv_obj_set_pos(lbl_spending_status, 0, L.usage_reset_y + 20);
     lv_obj_add_flag(lbl_spending_status, LV_OBJ_FLAG_HIDDEN);
 
-    panel_weekly = make_usage_panel(usage_group,
-                     L.content_y + L.usage_panel_h + L.usage_panel_gap, "Weekly",
+    // Second panel goes to the right of the first on landscape strips that are
+    // too short to stack them, below it everywhere else.
+    const int weekly_x = L.usage_panels_row
+                           ? L.margin + L.usage_panel_w + L.usage_panel_gap
+                           : L.margin;
+    const int weekly_y = L.usage_panels_row
+                           ? L.content_y
+                           : L.content_y + L.usage_panel_h + L.usage_panel_gap;
+    panel_weekly = make_usage_panel(usage_group, weekly_x, weekly_y,
+                     L.usage_panel_w, "Weekly",
                      &lbl_weekly_pct, &lbl_weekly_label,
                      &bar_weekly, &lbl_weekly_reset);
     // Recolor enabled so enterprise period box can color pace and reset separately


### PR DESCRIPTION
## Waveshare ESP32-S3-Touch-LCD-1.47 port

  Adds `firmware/src/boards/waveshare_lcd_147/` + `[env:waveshare_lcd_147]`.
  This is the **first landscape port**: the 172×320 JD9853 panel is driven as a
  320×172 landscape canvas, and `compute_layout()` gains a landscape branch
  (`W > H && H < 200`) that places the two usage panels side by side instead of
  stacked.

  ### Hardware notes
  - **Display:** JD9853 on plain 4-wire SPI (not QSPI), driven by Arduino_GFX's
    `Arduino_ST7789` (shared command set) plus the vendor register init sequence
    pushed after `gfx->begin()` — without it the panel stays dark. Constructed
    portrait with `col_offset1 = 34`, then `setRotation(1)`.
  - **Backlight:** the panel has no brightness command — LEDC PWM on `LCD_BL`.
  - **Touch:** AXS5106L @ I2C 0x63, small vendored inline reader (14-byte burst
    from reg 0x01). Needs a long reset pulse (200 ms low / 300 ms settle).
  - **Battery:** no PMU — VBAT via a 3.0× divider on GPIO12 (ADC2; uncontended
    since the firmware never starts Wi-Fi). Charging/VBUS state is unknowable,
    reported as false.
  - **Buttons:** the kit ships only BOOT + RESET, so BOOT takes the PWR role
    (cycle screens / brightness / hold-3s-to-pair) and `BoardCaps.button_count`
    is 0 — the HID Space / Shift+Tab paths never fire. No hold-to-power-off:
    there is no power-hold latch, and GPIO0 is the S3 boot strapping pin.
  - **Pin map taken from the official schematic**, not the wiki — Waveshare's
    own ESP-IDF BSP header has TP_RST/TP_INT swapped relative to the board.
  - No IMU, audio, or IO expander populated.

  **Verified on hardware:** display, touch, battery ADC, BLE pairing + live
  daemon data.