### PR TITLE
Don't feed a {"ok":false} no-data beat to the rate ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,22 @@ JSON payload format (written to RX):
 
 Fields: `s` = session %, `sr` = session reset (minutes), `w` = weekly %, `wr` = weekly reset (minutes), `st` = status, `ok` = success flag.
 
+## Running the daemon tests
+
+The Python daemons have a test suite under `daemon/tests/`. Runtime dependencies
+are installed per platform by the installers, so the test extras live in their
+own manifest:
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r daemon/requirements-dev.txt
+.venv/bin/python -m pytest daemon/tests
+```
+
+Two tests are marked Linux/WSL-only and skip elsewhere: on macOS, spawning the
+Windows daemon initialises CoreBluetooth and trips the Bluetooth privacy gate,
+which aborts the child rather than producing the scan-loop hang they assert on.
+
 ## Recompiling fonts
 
 The `firmware/src/font_*.c` files are pre-compiled LVGL bitmap fonts.

--- a/daemon/requirements-dev.txt
+++ b/daemon/requirements-dev.txt
@@ -1,0 +1,19 @@
+# Dependencies for running the daemon test suite (daemon/tests/).
+#
+#     python3 -m venv .venv
+#     .venv/bin/pip install -r daemon/requirements-dev.txt
+#     .venv/bin/python -m pytest daemon/tests
+#
+# Runtime deps are declared per platform and stay that way: install-mac.sh
+# installs bleak/httpx into daemon/.venv, requirements-windows.txt covers the
+# Windows tray build. The tests import both daemons and the icon renderer
+# whatever the host is, so they need the union of those plus pytest.
+#
+# pystray is deliberately absent. tray_windows.py imports it inside main(), and
+# test_windows_tray.py says so in its own docstring — the tests exercise the
+# handlers without ever importing the top-level module, which would want a GUI
+# toolkit on Linux. Adding it here would make every contributor pay for that.
+pytest
+bleak
+httpx
+Pillow

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -372,20 +372,30 @@ void loop() {
 
     if (ble_has_data()) {
         if (parse_json(ble_get_data(), &usage)) {
-            int g_before = usage_rate_group();
-            bool session_reset = usage_rate_sample(usage.session_pct);
-            int g_after = usage_rate_group();
-            // 5-hour session limit refilled → chime so the user knows they can
-            // use Claude again (no-op on boards without a buzzer). Gated on the
-            // daemon's opt-in `chime` config; the `buzz` serial cmd ignores it.
-            if (session_reset && usage.chime) {
-                Serial.println("session reset detected — chime");
-                sound_hal_play_reset();
-            }
-            if (g_after != g_before) {
-                Serial.printf("usage rate: group %d -> %d (s=%.2f%%)\n",
-                    g_before, g_after, usage.session_pct);
-                if (splash_is_active()) splash_pick_for_current_rate();
+            // A {"ok":false} beat is the daemon saying "no fresh data" — it
+            // writes that key and nothing else, so session_pct arrives as 0.0
+            // from the `| 0.0f` default rather than as a reading. That must not
+            // reach the rate ring: usage_rate_sample() treats a drop of more
+            // than five points as a 5-hour refill, so it would clear the
+            // history and report a reset, and a daemon that has merely lost its
+            // token would ring the chime. ui_update() guards on ok already; the
+            // sampler runs ahead of it and needs its own guard.
+            if (usage.ok) {
+                int g_before = usage_rate_group();
+                bool session_reset = usage_rate_sample(usage.session_pct);
+                int g_after = usage_rate_group();
+                // 5-hour session limit refilled → chime so the user knows they can
+                // use Claude again (no-op on boards without a buzzer). Gated on the
+                // daemon's opt-in `chime` config; the `buzz` serial cmd ignores it.
+                if (session_reset && usage.chime) {
+                    Serial.println("session reset detected — chime");
+                    sound_hal_play_reset();
+                }
+                if (g_after != g_before) {
+                    Serial.printf("usage rate: group %d -> %d (s=%.2f%%)\n",
+                        g_before, g_after, usage.session_pct);
+                    if (splash_is_active()) splash_pick_for_current_rate();
+                }
             }
             ui_update(&usage);
             ble_send_ack();


### PR DESCRIPTION
## The bug

A `{"ok":false}` beat makes the device announce that the 5-hour quota came back, at the moment the daemon stops being able to ask about it.

The chain:

1. `claude_usage_daemon.py` has no usable token, so it writes `{"ok": False}` — that key and nothing else.
2. `parse_json` fills the rest from defaults, so `session_pct` arrives as `0.0f` from `doc["s"] | 0.0f` rather than as a reading.
3. `main.cpp` handed that to `usage_rate_sample()` before anything looked at `ok`.
4. `usage_rate_sample()` treats a drop of more than five points as a session refill — it clears the ring and returns `true`.
5. So after any reading above 5%, one no-data beat throws away the rate history and reports a reset. The device rings the chime.

`ui_update()` already guards on `ok`, with the comment *"fall through to idle, keep last numbers"* — the intent that these beats carry no readings is established. But the sampler runs at line 375 and `ui_update()` at 390, so the guard sat downstream of the damage.

Moving the sampler inside the same condition is the whole fix. No behaviour changes for a beat that has real numbers.

`test_freeride.py::test_freeride_autherror_emits_no_data_beat` already covers the daemon half; the beat is sent exactly as intended. Nothing covered what the firmware did on receipt.

## Also: `daemon/requirements-dev.txt`

Runtime deps are declared per platform and this doesn't touch that — `install-mac.sh` pins `bleak`/`httpx` inline, `requirements-windows.txt` covers the tray build. But the test extras weren't declared anywhere, so running `pytest daemon/tests` means discovering `bleak`, `httpx`, `Pillow` and `pytest` one `ModuleNotFoundError` at a time. That's how I found them.

`pystray` is deliberately excluded. `tray_windows.py` imports it inside `main()`, and `test_windows_tray.py` says in its own docstring that the tests exercise the handlers without importing the top-level module — which would want a GUI toolkit on Linux. Adding it would make every contributor pay for that.

Plus a short README section, since a manifest nobody can find is half a fix.

## Verification

- Builds on `waveshare_amoled_216`.
- A fresh venv installed from the new manifest **alone** runs the suite green: **119 passed, 2 skipped**. The two skips are the Linux/WSL-only pair that can't run on macOS by their own markers.
- **Not exercised on hardware** — reproducing it needs the daemon's no-token path. The chain above is read from the source, and step 4's threshold is `usage_rate.cpp`'s `session_pct + 5.0f < ring[latest].pct`.

Happy to split the manifest out into its own PR if you'd rather keep the fix by itself.
