### PR TITLE
Enable IMU auto-rotation on ESP32-C6 AMOLED-2.16

### DIFF
--- a/firmware/src/boards/waveshare_amoled_216_c6/board.h
+++ b/firmware/src/boards/waveshare_amoled_216_c6/board.h
@@ -53,7 +53,7 @@
 
 // ---- Capability flags ----
 #define BOARD_HAS_SECONDARY_BUTTON 1
-#define BOARD_HAS_ROTATION         0    // C6 has no PSRAM headroom for the rotation strip
+#define BOARD_HAS_ROTATION         1    // Auto-Rotation: rot_buf liegt im internen RAM (38.4KB); Fallback = unrotiert
 #define BOARD_HAS_IMU              1    // present + initialized for I2C bus health
 #define BOARD_HAS_BATTERY          1
 #define BOARD_HAS_IO_EXPANDER      0    // TCA9554 exists on board but only services audio

--- a/firmware/src/boards/waveshare_amoled_216_c6/display.cpp
+++ b/firmware/src/boards/waveshare_amoled_216_c6/display.cpp
@@ -1,15 +1,19 @@
+// C6-Port der S3-Auto-Rotation: rot_buf im INTERNEN RAM (C6 hat kein PSRAM),
+// LCD ohne Reset-GPIO, plus panel-spezifische Driving-Voltage-Init (Page 0x20).
+// Faellt die rot_buf-Allokation fehl, laeuft das Display unrotiert weiter.
 #include "../../hal/display_hal.h"
+#include "../../hal/imu_hal.h"
+#include "../../brightness.h"
 #include "board.h"
 #include <Arduino.h>
 #include <Arduino_GFX_Library.h>
+#include <esp_heap_caps.h>
+#include <lvgl.h>
 
-// C6 AMOLED-2.16 uses a CO5300 AMOLED panel (per the Waveshare
-// ESP32-C6-Touch-AMOLED-2.16 spec) — the same controller as the S3
-// AMOLED-2.16 sibling, so we drive it with Arduino_CO5300 and reuse that
-// class's vendor-correct init rather than the SH8601 class + a hand-patched
-// sequence. LCD reset is not wired to any MCU GPIO; the panel boots from its
-// internal power-on reset (rst = GFX_NOT_DEFINED). Rotation is disabled (no
-// PSRAM headroom for a rotation strip).
+// Render strip used when rotating in software. Sized to the largest LVGL
+// partial flush we ever do (LCD_WIDTH × BUF_LINES, set in main.cpp).
+#define ROT_BUF_LINES 20   // C6: matcht BUF_LINES 20 aus main.cpp (No-PSRAM-Zweig) -> 19.2KB intern
+static uint16_t* rot_buf = nullptr;
 
 static Arduino_DataBus* bus = nullptr;
 static Arduino_CO5300*  gfx = nullptr;
@@ -17,40 +21,32 @@ static Arduino_CO5300*  gfx = nullptr;
 void display_hal_init(void) {
     bus = new Arduino_ESP32QSPI(
         LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
-    // CO5300 constructor: (bus, rst, rotation, w, h, col_off1..2, row_off1..2).
-    // No reset GPIO on this board; the 480-wide panel is full-width so all
-    // offsets are 0 — matches the S3 AMOLED-2.16 instantiation.
+    // CO5300 constructor: (bus, rst, rotation, w, h, col_offset1..2, row_offset1..2)
     gfx = new Arduino_CO5300(
-        bus, GFX_NOT_DEFINED, 0 /* rotation disabled */,
+        bus, GFX_NOT_DEFINED, 0 /* rotation handled in software */,
         LCD_WIDTH, LCD_HEIGHT, 0, 0, 0, 0);
 }
 
-// Arduino_CO5300::begin() already issues SLPOUT, SPI-mode control, pixel
-// format, brightness-control, DISPON and a default MADCTL. The ONLY thing it
-// does not set is this panel's manufacturer page-0x20 driving-voltage
-// registers (0x19/0x1C) — without them the panel stays black even with the
-// rails up. Set just those; everything else the SH8601-era hack also wrote
-// (0xC4/0x36/0x53/0x51/0x63/0x29) is now covered by the class init.
-//
-// Note: we deliberately do NOT restore the old MADCTL 0x30 (MV transpose).
-// The CO5300 class default (rotation-0, MADCTL 0x00) orients the panel with
-// the USB port on the side, which is the preferred desk orientation for this
-// board.
+
+// Panel-spezifische Driving-Voltage-Register (Page 0x20) — ohne die bleibt
+// das C6-Panel schwarz (siehe urspruengliche C6-Implementierung).
 static void send_panel_driving_init(Arduino_DataBus* b) {
     b->beginWrite();
-    b->writeC8D8(0xFE, 0x20);    // enter manufacturer command page 0x20
-    b->writeC8D8(0x19, 0x10);    // panel driving voltage
-    b->writeC8D8(0x1C, 0xA0);    // panel driving voltage
-    b->writeC8D8(0xFE, 0x00);    // back to user command page
+    b->writeC8D8(0xFE, 0x20);
+    b->writeC8D8(0x19, 0x10);
+    b->writeC8D8(0x1C, 0xA0);
+    b->writeC8D8(0xFE, 0x00);
     b->endWrite();
     delay(20);
 }
-
 void display_hal_begin(void) {
     gfx->begin();
-    send_panel_driving_init(bus);   // panel-specific regs the class init omits
+    send_panel_driving_init(bus);
     gfx->fillScreen(0x0000);
     gfx->setBrightness(200);
+
+    // Allocate rotation strip (PSRAM). Sized to match main.cpp's BUF_LINES.
+    rot_buf = (uint16_t*)heap_caps_malloc(LCD_WIDTH * ROT_BUF_LINES * 2, (MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
 }
 
 void display_hal_set_brightness(uint8_t level) {
@@ -61,13 +57,92 @@ void display_hal_fill_screen(uint16_t color) {
     if (gfx) gfx->fillScreen(color);
 }
 
-void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
-                             const uint16_t* pixels) {
-    if (gfx) gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+// Rotate a w×h strip into rot_buf and compute destination coordinates on the
+// 480×480 panel. Src is row-major over the rectangle (sx, sy, w, h).
+static void rotate_strip(const uint16_t* src, int32_t w, int32_t h,
+                         int32_t sx, int32_t sy, uint8_t r,
+                         int32_t* dx, int32_t* dy, int32_t* dw, int32_t* dh) {
+    const int S = LCD_WIDTH;
+
+    switch (r) {
+    case 1: // 90° CW: (x,y) -> (S-1-y, x)
+        *dw = h; *dh = w;
+        *dx = S - sy - h;
+        *dy = sx;
+        for (int32_t y = 0; y < h; y++) {
+            for (int32_t x = 0; x < w; x++) {
+                rot_buf[x * h + (h - 1 - y)] = src[y * w + x];
+            }
+        }
+        break;
+    case 2: // 180°: (x,y) -> (S-1-x, S-1-y)
+        *dw = w; *dh = h;
+        *dx = S - sx - w;
+        *dy = S - sy - h;
+        for (int32_t y = 0; y < h; y++) {
+            for (int32_t x = 0; x < w; x++) {
+                rot_buf[(h - 1 - y) * w + (w - 1 - x)] = src[y * w + x];
+            }
+        }
+        break;
+    case 3: // 270° CW: (x,y) -> (y, S-1-x)
+        *dw = h; *dh = w;
+        *dx = sy;
+        *dy = S - sx - w;
+        for (int32_t y = 0; y < h; y++) {
+            for (int32_t x = 0; x < w; x++) {
+                rot_buf[(w - 1 - x) * h + y] = src[y * w + x];
+            }
+        }
+        break;
+    default:
+        *dx = sx; *dy = sy; *dw = w; *dh = h;
+        break;
+    }
 }
 
+void display_hal_draw_bitmap(int32_t x, int32_t y, int32_t w, int32_t h,
+                             const uint16_t* pixels) {
+    if (!gfx) return;
+    uint8_t r = imu_hal_rotation_quadrant();
+    if (r == 0 || !rot_buf) {
+        gfx->draw16bitRGBBitmap(x, y, (uint16_t*)pixels, w, h);
+        return;
+    }
+    int32_t dx, dy, dw, dh;
+    rotate_strip(pixels, w, h, x, y, r, &dx, &dy, &dw, &dh);
+    gfx->draw16bitRGBBitmap(dx, dy, rot_buf, dw, dh);
+}
+
+// On rotation change, blank the panel, force a full LVGL redraw at the new
+// orientation, then ramp brightness back up over ~125ms so the transition
+// reads as deliberate.
 void display_hal_tick(void) {
-    // No rotation cycle on this board.
+    static uint8_t  last_rotation = 0;
+    static uint8_t  ramp_step = 0;     // 0=idle, 1..4=ramping
+    static uint32_t ramp_last = 0;
+
+    uint8_t rot = imu_hal_rotation_quadrant();
+    if (rot != last_rotation) {
+        display_hal_set_brightness(0);
+        last_rotation = rot;
+        lv_obj_invalidate(lv_screen_active());
+        ramp_step = 1;
+        return;
+    }
+
+    if (ramp_step == 0) return;
+    uint32_t now = millis();
+    if (now - ramp_last < 25) return;
+    ramp_last = now;
+
+    // Ramp back to the user's chosen brightness (not a hardcoded level), so a
+    // physical rotation doesn't reset what they set via PWR-short-press.
+    static const uint8_t pct[] = {30, 60, 85, 100};
+    uint8_t target = brightness_get();
+    display_hal_set_brightness((uint8_t)(((uint16_t)target * pct[ramp_step - 1]) / 100));
+    if (ramp_step >= 4) ramp_step = 0;
+    else                ramp_step++;
 }
 
 // CO5300 requires even-aligned flush regions.

--- a/firmware/src/boards/waveshare_amoled_216_c6/imu.cpp
+++ b/firmware/src/boards/waveshare_amoled_216_c6/imu.cpp
@@ -4,23 +4,63 @@
 #include <Wire.h>
 #include <SensorQMI8658.hpp>
 
-// QMI8658 is populated on the 2.16 carrier PCB but rotation is disabled
-// on the C6 build (BOARD_HAS_ROTATION=0). We still initialize the device
-// so the shared I2C bus stays healthy and so a future build can flip
-// rotation on without changing this file. Always reports quadrant 0.
+// Poll and hysteresis timing
+#define IMU_POLL_MS       100    // ~10 Hz
+#define STABLE_TIME_MS    300    // orientation must hold this long before rotating
+#define TILT_THRESHOLD    0.5f   // ~30° from axis (sin 30° ≈ 0.5)
 
 static SensorQMI8658 imu;
+static uint8_t  current_rotation   = 0;
+static uint8_t  candidate_rotation = 0;
+static uint32_t candidate_since    = 0;
+static uint32_t last_poll_ms       = 0;
+static bool     imu_ok             = false;
+
+static uint8_t accel_to_rotation(float ax, float ay) {
+    float abs_ax = fabsf(ax);
+    float abs_ay = fabsf(ay);
+    if (abs_ax < TILT_THRESHOLD && abs_ay < TILT_THRESHOLD) {
+        return 255;  // ambiguous (face-up/down)
+    }
+    if (abs_ay > abs_ax) return (ay > 0) ? 3 : 1;
+    return (ax > 0) ? 2 : 0;   // C6: IMU-Nullpunkt 180 Grad versetzt zur S3 (empirisch kalibriert)
+}
 
 void imu_hal_init(void) {
     if (!imu.begin(Wire, QMI8658_L_SLAVE_ADDRESS, IIC_SDA, IIC_SCL)) {
         Serial.println("QMI8658 init failed");
         return;
     }
-    Serial.println("QMI8658 init OK (rotation disabled on this board)");
+    Serial.println("QMI8658 init OK");
+    imu.configAccelerometer(
+        SensorQMI8658::ACC_RANGE_4G,
+        SensorQMI8658::ACC_ODR_LOWPOWER_21Hz,
+        SensorQMI8658::LPF_MODE_3);
+    imu.enableAccelerometer();
+    imu_ok = true;
 }
 
 void imu_hal_tick(void) {
-    // No-op — rotation is disabled.
+    if (!imu_ok) return;
+    uint32_t now = millis();
+    if (now - last_poll_ms < IMU_POLL_MS) return;
+    last_poll_ms = now;
+
+    float ax, ay, az;
+    if (!imu.getAccelerometer(ax, ay, az)) return;
+
+    uint8_t target = accel_to_rotation(ax, ay);
+    if (target == 255 || target == current_rotation) {
+        candidate_rotation = current_rotation;
+        return;
+    }
+    if (target != candidate_rotation) {
+        candidate_rotation = target;
+        candidate_since = now;
+    } else if (now - candidate_since >= STABLE_TIME_MS) {
+        current_rotation = target;
+        Serial.printf("Rotation: %d\n", current_rotation);
+    }
 }
 
-uint8_t imu_hal_rotation_quadrant(void) { return 0; }
+uint8_t imu_hal_rotation_quadrant(void) { return current_rotation; }


### PR DESCRIPTION
Port the S3 AMOLED-2.16 rotation path to the C6 board:
- rot_buf in internal RAM (19.2KB, ROT_BUF_LINES=20 matching the C6 no-PSRAM LVGL strip size) instead of PSRAM; falls back to unrotated rendering if allocation fails
- QMI8658 quadrant detection ported from the S3 board; axis mapping calibrated for the C6 IMU orientation (180deg offset)
- keep the C6-specific CO5300 page-0x20 driving-voltage init