### PR TITLE
fix(c6): restore correct orientation for AMOLED-2.16 C6

### DIFF
--- a/firmware/src/boards/waveshare_amoled_216_c6/display.cpp
+++ b/firmware/src/boards/waveshare_amoled_216_c6/display.cpp
@@ -30,8 +30,8 @@ void display_hal_init(void) {
 // does not set is this panel's manufacturer page-0x20 driving-voltage
 // registers (0x19/0x1C) — without them the panel stays black even with the
 // rails up. Set just those; everything else the SH8601-era hack also wrote
-// (0xC4/0x36/0x53/0x51/0x63/0x29) is now covered by the class init.
-//
+// (0xC4/0x53/0x51/0x63/0x29) is now covered by the class init, and we override
+// MADCTL below to fix orientation.
 // The CO5300 class default (rotation-0, MADCTL 0x00) leaves the panel
 // sideways on this board — confirmed on hardware. Restore the MV+ML
 // transpose (MADCTL 0x30) that the pre-CO5300-rebase SH8601-hack version

--- a/firmware/src/boards/waveshare_amoled_216_c6/display.cpp
+++ b/firmware/src/boards/waveshare_amoled_216_c6/display.cpp
@@ -32,16 +32,17 @@ void display_hal_init(void) {
 // rails up. Set just those; everything else the SH8601-era hack also wrote
 // (0xC4/0x36/0x53/0x51/0x63/0x29) is now covered by the class init.
 //
-// Note: we deliberately do NOT restore the old MADCTL 0x30 (MV transpose).
-// The CO5300 class default (rotation-0, MADCTL 0x00) orients the panel with
-// the USB port on the side, which is the preferred desk orientation for this
-// board.
+// The CO5300 class default (rotation-0, MADCTL 0x00) leaves the panel
+// sideways on this board — confirmed on hardware. Restore the MV+ML
+// transpose (MADCTL 0x30) that the pre-CO5300-rebase SH8601-hack version
+// used to write; touch mapping in touch.cpp is calibrated to match.
 static void send_panel_driving_init(Arduino_DataBus* b) {
     b->beginWrite();
     b->writeC8D8(0xFE, 0x20);    // enter manufacturer command page 0x20
     b->writeC8D8(0x19, 0x10);    // panel driving voltage
     b->writeC8D8(0x1C, 0xA0);    // panel driving voltage
     b->writeC8D8(0xFE, 0x00);    // back to user command page
+    b->writeC8D8(0x36, 0x30);    // MADCTL: MV transpose + ML (orientation fix)
     b->endWrite();
     delay(20);
 }

--- a/firmware/src/boards/waveshare_amoled_216_c6/touch.cpp
+++ b/firmware/src/boards/waveshare_amoled_216_c6/touch.cpp
@@ -22,16 +22,11 @@ void touch_hal_init(void) {
         return;
     }
     touch.setMaxCoordinates(LCD_WIDTH, LCD_HEIGHT);
-    // C6 2.16 panel mapping. The original values (swap=true, mirrorX=true)
-    // were calibrated to the old display orientation that force-wrote MADCTL
-    // 0x30 (MV transpose + ML). The display now runs at the CO5300 class
-    // default (MADCTL 0x00 — USB-port-on-the-side orientation), so the touch
-    // mapping is re-derived to match. SensorLib applies swap then mirror
-    // (TouchDrvInterface::updateXY); tap-tested on C6 hardware, the raw
-    // CST9217 coordinates map straight through in this orientation — no swap,
-    // no mirror.
-    touch.setSwapXY(false);
-    touch.setMirrorXY(false, false);
+    // C6 2.16 panel mapping (verified empirically): the CST9217's raw
+    // axes are swapped relative to the raster AND X is mirrored, to match
+    // the MADCTL 0x30 (MV+ML) transpose written in display.cpp.
+    touch.setSwapXY(true);
+    touch.setMirrorXY(true, false);
     pinMode(TP_INT, INPUT_PULLUP);
     attachInterrupt(TP_INT, touch_isr, FALLING);
     Serial.println("Touch init OK");


### PR DESCRIPTION
## Problem

On the Waveshare ESP32-C6-Touch-AMOLED-2.16 (`waveshare_amoled_216_c6` env), the display renders rotated 90°/270° from correct after flashing current `main`.

## Root cause

9375bd6 ("fix(c6): drive AMOLED-2.16 C6 panel as CO5300, side-USB orientation") correctly rebased this board's panel driver from `Arduino_SH8601` to `Arduino_CO5300` and fixed the panel-driving-voltage registers — that part is right and is kept as-is.

However, the same commit also dropped a raw `MADCTL 0x30` (MV transpose + ML) write that the prior version relied on for correct orientation, switching to the CO5300 class's default `MADCTL 0x00` under the assumption that this was "the preferred desk orientation" (USB port on the side). That assumption doesn't hold — it was never actually verified visually on hardware, only touch calibration was re-tap-tested to match whatever the display was doing.

## Fix

- `display.cpp`: restore the `writeC8D8(0x36, 0x30)` MADCTL write (MV transpose + ML) after the panel-driving-voltage registers, matching what the pre-CO5300-rebase version wrote.
- `touch.cpp`: revert touch axis calibration to `setSwapXY(true)` / `setMirrorXY(true, false)` to match the restored display orientation.

This is a minimal, targeted partial revert of 9375bd6 — only the orientation-related lines change; the CO5300 driver rebase and panel-driving-voltage fix are untouched.

## Verification

Built and flashed to a physical Waveshare ESP32-C6-Touch-AMOLED-2.16. Confirmed the display now renders right-side-up (previously sideways) and touch input tracks correctly at the corrected orientation.