### PR TITLE
daemon(macos): treat blanked-out credentials as absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ The macOS host pieces — Python daemon, LaunchAgent, and flash helper — were 
 ### Flash the firmware
 
 ```bash
-./flash-mac.sh waveshare_amoled_216                       # auto-detects /dev/cu.usbmodem*
-./flash-mac.sh waveshare_amoled_18  /dev/cu.usbmodem1101  # or pass an explicit USB serial port
+./flash-mac.sh waveshare_amoled_216                       # ESP32-S3 2.16" (auto-detects /dev/cu.usbmodem*)
+./flash-mac.sh waveshare_amoled_216_c6                    # ESP32-C6 2.16" variant
+./flash-mac.sh waveshare_amoled_18  /dev/cu.usbmodem1101  # ESP32-S3 1.8" (or pass an explicit USB serial port)
 ```
 
 The board env name is required. Run `./flash-mac.sh` with no args to see the available envs (scraped from `firmware/platformio.ini`).
@@ -87,8 +88,9 @@ launchctl load -w ~/Library/LaunchAgents/com.user.claude-usage-daemon.plist # st
 ### Flash the firmware
 
 ```bash
-./flash.sh waveshare_amoled_216                  # defaults to /dev/ttyACM0
-./flash.sh waveshare_amoled_18  /dev/ttyACM1     # or pass an explicit USB serial port
+./flash.sh waveshare_amoled_216                  # ESP32-S3 2.16" (defaults to /dev/ttyACM0)
+./flash.sh waveshare_amoled_216_c6               # ESP32-C6 2.16" variant
+./flash.sh waveshare_amoled_18  /dev/ttyACM1     # ESP32-S3 1.8" (or pass an explicit USB serial port)
 ```
 
 The board env name is required. Run `./flash.sh` with no args to see the available envs (scraped from `firmware/platformio.ini`).

--- a/daemon/claude_usage_daemon.py
+++ b/daemon/claude_usage_daemon.py
@@ -81,12 +81,15 @@ def _extract_access_token(blob: str) -> str | None:
         data = None
     if isinstance(data, dict):
         # direct: {"accessToken": "..."}
-        if isinstance(data.get("accessToken"), str):
-            return data["accessToken"]
+        tok = data.get("accessToken")
+        if isinstance(tok, str) and tok.strip():
+            return tok
         # nested: {"claudeAiOauth": {"accessToken": "..."}}
         for v in data.values():
-            if isinstance(v, dict) and isinstance(v.get("accessToken"), str):
-                return v["accessToken"]
+            if isinstance(v, dict):
+                tok = v.get("accessToken")
+                if isinstance(tok, str) and tok.strip():
+                    return tok
     m = re.search(r'"accessToken"\s*:\s*"([^"]+)"', blob)
     if m:
         return m.group(1)

--- a/daemon/tests/test_macos_multidir.py
+++ b/daemon/tests/test_macos_multidir.py
@@ -71,6 +71,29 @@ def test_token_for_file_wins_over_keychain(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Blank credentials must read as ABSENT. Logging out of the CLI empties the
+# values in place rather than deleting them; "" is a str, so a type-only check
+# would pass it through and the daemon would poll with an empty Bearer token.
+# ---------------------------------------------------------------------------
+
+def test_blank_token_in_file_reads_as_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod.sys, "platform", "linux")
+    (tmp_path / ".credentials.json").write_text(
+        '{"claudeAiOauth":{"accessToken":"","refreshToken":"","expiresAt":0}}'
+    )
+    assert read_token_for(tmp_path) is None
+
+
+def test_blank_token_in_blob_reads_as_absent():
+    """Same guard on the extraction chokepoint the Keychain path goes through."""
+    assert mod._extract_access_token('{"accessToken":""}') is None
+    assert (
+        mod._extract_access_token('{"claudeAiOauth":{"accessToken":"","expiresAt":0}}')
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
 # PlanSelector — the "active = recent API activity" rule
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Logging out of the Claude Code CLI empties the stored credential values in place rather than deleting them (`accessToken: ""`, `refreshToken: ""`, `expiresAt: 0`). Since `""` is a `str`, the macOS/Linux daemon's `isinstance(..., str)` check passed it through and the daemon polled `/v1/messages` with an empty Bearer token, producing 401s that look like an auth bug but just mean *logged out*.

The Windows daemon already guards against this (`isinstance(tok, str) and tok.strip()` in its `_extract_access_token`); this PR mirrors that exact pattern in `claude_usage_daemon.py` so both daemons behave the same, and adds two regression tests ("blank credentials must read as absent") to `test_macos_multidir.py`.

With the guard, a logged-out store reads as *no token* — under the free-ride design the daemon logs "No token" and skips the dir instead of burning a poll on a dead Bearer.

Also rides along: the README flash examples now label each env with its SoC/panel and list the C6 2.16 variant, so it's discoverable without opening `platformio.ini`.

## Testing

`python -m pytest daemon/tests/test_macos_multidir.py daemon/tests/test_freeride.py` — 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)