### PR TITLE
sim: build with -std=gnu++17 for macOS

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -476,6 +476,10 @@ build_src_filter =
 
 build_flags =
     -DBOARD_SIM
+    ; macOS: `g++` is Apple clang, which defaults to C++98 without an explicit
+    ; -std and fails on constexpr / brace-init. Linux g++ (real GCC) defaults
+    ; to gnu++17, which is why this only bites on macOS.
+    -std=gnu++17
     ; behave like the PSRAM-equipped S3 targets (big LVGL strips, full
     ; splash canvas, screenshot path compiled) — the heap shim maps every
     ; capability to plain malloc anyway


### PR DESCRIPTION
On macOS `g++` is a wrapper around Apple clang, which defaults to C++98 when invoked under that name (__cplusplus reports 199711L). The sim env never set -std, so the build died on constexpr and brace-init in both ArduinoJson and usage_rate.cpp. Linux `g++` is real GCC and defaults to gnu++17, which is why this only bites on macOS.